### PR TITLE
fix: running eval through noether-eval script

### DIFF
--- a/src/noether/inference/cli/__init__.py
+++ b/src/noether/inference/cli/__init__.py
@@ -1,0 +1,1 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.


### PR DESCRIPTION
Hydra throws an error when Primary config module 'noether.inference.cli' not found.

This is because `cli` was not a Python module since it was missing the __init__.py.