### PR TITLE
fix: downstream linking in ancestor

### DIFF
--- a/src/noether/core/initializers/checkpoint.py
+++ b/src/noether/core/initializers/checkpoint.py
@@ -34,7 +34,7 @@ class CheckpointInitializer(InitializerBase):
         self.load_optim = initializer_config.load_optim
         self.model_info = initializer_config.model_info
         self.pop_ckpt_kwargs_keys = initializer_config.pop_ckpt_kwargs_keys or []
-        self.stage_name = initializer_config.stage_name or self.path_provider.stage_name
+        self.stage_name = initializer_config.stage_name
         self.init_run_path_provider = self.path_provider.with_run(
             run_id=self.run_id,
             stage_name=self.stage_name,

--- a/src/noether/core/providers/path.py
+++ b/src/noether/core/providers/path.py
@@ -36,7 +36,7 @@ class PathProvider:
         return PathProvider(
             output_root_path=self.output_root,
             run_id=run_id if run_id is not None else self.run_id,
-            stage_name=stage_name if stage_name is not None else self.stage_name,
+            stage_name=stage_name,
         )
 
     @property
@@ -116,7 +116,7 @@ class PathProvider:
             link_path.unlink()
         link_path.symlink_to(ancestor.run_output_path)
 
-        if self.stage_name != ancestor.stage_name:
+        if self.run_id != ancestor.run_id or self.stage_name != ancestor.stage_name:
             if self.stage_name is not None:
                 ancestor_link_path = ancestor.output_root / ancestor.run_id / self.stage_name / self.run_id
             else:


### PR DESCRIPTION
The linking code was making the assumption that we only want to link different stages for the same run. However, we might also want to link a new run into an existing run. 

There was also a small bug that PathProvider of the previous run took the current if stage_name was None, however None should be a valid value and we should just take what's configured.