### PR TITLE
fix: CI test Github Action permission

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   unit-tests:
+    permissions:
+      pull-requests: write
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
The test action needs pull-request wirte permission to post the comment with coverage information.