### PR TITLE
fix: Pydantic warning about wrong datatype

### DIFF
--- a/src/noether/data/datasets/cfd/shapenet_car/split.py
+++ b/src/noether/data/datasets/cfd/shapenet_car/split.py
@@ -809,7 +809,7 @@ class ShapeNetCarDefaultSplitIDs(DatasetSplitIDs):
         "param8/cf4c819d9deb6533108499aad0a89b28",
         "param8/cf698011f90ac05f253c03b7df20edd5",
     }  # type: ignore[assignment]
-    val: set[str] = {}  # type: ignore[assignment]
+    val: set[str] = set()  # type: ignore[assignment]
     test: set[str] = {
         "param0/100715345ee54d7ae38b52b4ee9d36a3",
         "param0/10247b51a42b41603ffe0e5069bf1eb5",


### PR DESCRIPTION
```
/Users/markus/Documents/noether/.venv/lib/python3.12/site-packages/pydantic/main.py:464: UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected `set[str]` - serialized value may not be as expected [field_name='val', input_value={}, input_type=dict])
  return self.__pydantic_serializer__.to_python
```

We get this warning when running the shapenet tutorial. This is because we assign a dict literal `{}` to what is annotated as set[str].