### PR TITLE
ci: run coverage commit job on only pull requests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,8 +48,10 @@ jobs:
             --cov=src --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage.xml \
             --junitxml=pytest.xml
+
       - name: Post Coverage Comment
         uses: MishaKav/pytest-coverage-comment@main
+        if: github.event_name == 'pull_request'
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml


### PR DESCRIPTION
fixed unit-test job running on main. 
As we don't need code coverage comment job on main, this can be skipped.

ref: https://github.com/Emmi-AI/noether/actions/runs/21397649035/job/61599941437 