### PR TITLE
chore: add release-please tag_name reference to the repo checkout stage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
A potential fix for `release.yml` so future releases publish correctly on the first run