### PR TITLE
chore: fix leftover tutorial kind strings

### DIFF
--- a/docs/source/reference/config_inheritance.rst
+++ b/docs/source/reference/config_inheritance.rst
@@ -27,7 +27,7 @@ Example - UPT Configuration
 
 .. code-block:: yaml
 
-   kind: tutorial.model.UPT
+   kind: noether.modeling.models.aerodynamics.AeroUPT
    name: upt
    hidden_dim: 192 
    num_heads: 3 
@@ -75,7 +75,7 @@ You can override inherited values at any level by explicitly specifying them:
 
 .. code-block:: yaml
 
-   kind: tutorial.model.UPT
+   kind: noether.modeling.models.aerodynamics.AeroUPT
    name: upt
    hidden_dim: 192
    num_heads: 3

--- a/docs/source/tutorials/training_first_model_with_code.rst
+++ b/docs/source/tutorials/training_first_model_with_code.rst
@@ -230,7 +230,7 @@ Now we will declare dataset constants and convenience ``build_`` methods (you ca
             kind="noether.data.datasets.cfd.ShapeNetCarDataset",
             root=dataset_root,
             pipeline=AeroCFDPipelineConfig(
-                kind="tutorial.pipeline.AeroMultistagePipeline",
+                kind="recipes.aero_cfd.pipeline.multistage_pipelines.aero_multistage.AeroMultistagePipeline",
                 num_surface_points=3586, # max = 3586
                 num_volume_points=4096,   # max = 28504
                 num_surface_queries=3586,
@@ -274,7 +274,7 @@ Step 5: Trainer config
         save_and_ema_every_n_epochs = 10
 
         return AerodynamicsCfdTrainerConfig(
-            kind="tutorial.trainers.AutomotiveAerodynamicsCFDTrainer",
+            kind="recipes.aero_cfd.trainers.aerodynamics_cfd.AerodynamicsCFDTrainer",
             surface_weight=1.0,
             volume_weight=1.0,
             surface_pressure_weight=1.0,
@@ -306,14 +306,14 @@ Step 5: Trainer config
                 ),
                 # test loss
                 AeroMetricsCallbackConfig(
-                    kind="tutorial.callbacks.AeroMetricsCallback",
+                    kind="recipes.aero_cfd.callbacks.aero_metrics.AeroMetricsCallback",
                     batch_size=1,
                     every_n_epochs=loss_and_log_every_n_epochs,
                     dataset_key="test",
                     forward_properties=model_forward_properties,
                 ),
                 AeroMetricsCallbackConfig(
-                    kind="tutorial.callbacks.AeroMetricsCallback",
+                    kind="recipes.aero_cfd.callbacks.aero_metrics.AeroMetricsCallback",
                     batch_size=1,
                     every_n_epochs=500,
                     dataset_key="test_repeat",

--- a/recipes/aero_cfd/model/composite_transformer.py
+++ b/recipes/aero_cfd/model/composite_transformer.py
@@ -16,7 +16,7 @@ from .composite_components import CompositeTransformerBlock
 
 
 class CompositeTransformerConfig(ModelBaseConfig):
-    kind: str = "tutorial.models.composite_transformer.CompositeTransformer"
+    kind: str = "recipes.aero_cfd.model.composite_transformer.CompositeTransformer"
     name: Literal["composite_transformer"] = "composite_transformer"
     use_rope: bool = True
     low_level_blocks: CompositeTransformerBlockConfig


### PR DESCRIPTION
Some kind strings were still left over from the tutorial and have changed since introducing recipes.