### PR TITLE
chore: trainer config validation and input validation in transformer

### DIFF
--- a/docs/source/guides/training/implement_a_custom_trainer.rst
+++ b/docs/source/guides/training/implement_a_custom_trainer.rst
@@ -35,7 +35,7 @@ To implement a custom trainer in **Noether**, you need to create a new class tha
 .. testcode::
    :hide:
 
-   _cfg = CustomTrainerConfig(kind="test.CustomTrainer", effective_batch_size=1, callbacks=[])
+   _cfg = CustomTrainerConfig(kind="test.CustomTrainer", effective_batch_size=1, callbacks=[], max_epochs=1)
 
 The default ``train_step`` implementation of the BaseTrainer calls the ``loss_compute`` method to calculate the loss.
 Best practice is to return a dictionary of losses from the ``loss_compute`` method, where each key is a loss name and the value is the corresponding loss tensor.

--- a/src/noether/core/schemas/trainers.py
+++ b/src/noether/core/schemas/trainers.py
@@ -139,6 +139,13 @@ class BaseTrainerConfig[TCallbackConfig: CallBackBaseConfig](_RegistryBase):
 
         return self
 
+    @model_validator(mode="after")
+    def validate_max_training_criteria(self) -> BaseTrainerConfig:
+        """Ensures that exactly one of max_epochs, max_updates, or max_samples is specified."""
+        if sum(criterion is not None for criterion in [self.max_epochs, self.max_updates, self.max_samples]) != 1:
+            raise ValueError("Exactly one of 'max_epochs', 'max_updates', or 'max_samples' must be specified.")
+        return self
+
 
 class WeightedLossTrainerConfig(BaseTrainerConfig):
     """Config for a generic trainer that computes weighted loss per output field.

--- a/src/noether/data/preprocessors/normalizers.py
+++ b/src/noether/data/preprocessors/normalizers.py
@@ -212,6 +212,14 @@ class FieldNormalizer(PreProcessor):
         elif normalizer_config.strategy == "position":
             min_key = stat_keys.get("min", f"{self.normalization_key}_min")
             max_key = stat_keys.get("max", f"{self.normalization_key}_max")
+            if min_key not in statistics:
+                raise ValueError(
+                    f"Missing required statistics for position normalization: '{min_key}' and/or '{max_key}' not found in statistics."
+                )
+            if max_key not in statistics:
+                raise ValueError(
+                    f"Missing required statistics for position normalization: '{min_key}' and/or '{max_key}' not found in statistics."
+                )
             self.normalizer = PositionNormalizer(
                 PositionNormalizerConfig(
                     raw_pos_min=statistics[min_key],

--- a/src/noether/modeling/modules/blocks/transformer.py
+++ b/src/noether/modeling/modules/blocks/transformer.py
@@ -28,6 +28,7 @@ class TransformerBlock(nn.Module):
                 for available options.
         """
         super().__init__()
+        self.config = config
         # modulation
         if config.condition_dim is None:
             self.modulation = None
@@ -106,6 +107,10 @@ class TransformerBlock(nn.Module):
             if condition is None:
                 raise ValueError(
                     "No conditioning vector provided, but the transformer block is configured for conditioning."
+                )
+            if condition.shape[-1] != self.config.condition_dim:
+                raise ValueError(
+                    f"Conditioning vector has incorrect shape. Expected {self.config.condition_dim}, got {condition.shape[-1]}"
                 )
 
             mod = self.modulation(condition)

--- a/tests/unit/noether/core/configs/test_hyperparameters.py
+++ b/tests/unit/noether/core/configs/test_hyperparameters.py
@@ -31,7 +31,7 @@ def mock_params() -> MockHyperparameters:
         output_path="/tmp",
         datasets=dict(),
         model=dict(name="abc", kind="xyz"),
-        trainer=dict(kind="mock", effective_batch_size=32, callbacks=[]),
+        trainer=dict(kind="mock", effective_batch_size=32, callbacks=[], max_epochs=1),
         spec=DimSpec({"def": 1, "abc": 2}),
     )
 


### PR DESCRIPTION
Validation to check that exactly one of max_{epochs,updates,samples} is set. Without this validation we get a fairly cryptic error message in trainer instantiation.

Check the shape for conditioning vectors in transformer block, this gives a friendlier error than the default "matmul shapes don't match"