### PR TITLE
chore: add description to periodic callback progress bar

### DIFF
--- a/src/noether/core/callbacks/periodic.py
+++ b/src/noether/core/callbacks/periodic.py
@@ -681,7 +681,7 @@ class PeriodicDataIteratorCallback(PeriodicCallback, metaclass=ABCMeta):
         data_times = []
         results = []
         pbar_ctor = NoopTqdm if not sys.stdout.isatty() or not is_rank0() else tqdm
-        for _ in pbar_ctor(iterable=range(num_batches)):
+        for _ in pbar_ctor(iterable=range(num_batches), desc=f"{self} on {self.dataset_key}", unit="b"):
             with Stopwatch() as data_sw:
                 batch = next(data_iter)
                 batch = move_items_to_device(self.trainer.device, batch)

--- a/src/noether/core/utils/logging/progress.py
+++ b/src/noether/core/utils/logging/progress.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 class NoopTqdm:
     """A no-operation (noop) version of tqdm that does not display a progress bar."""
 
-    def __init__(self, iterable: Iterable[Any]) -> None:
+    def __init__(self, iterable: Iterable[Any], **kwargs: Any) -> None:
         self.iterable = iterable
 
     def __enter__(self) -> Self:


### PR DESCRIPTION
It helps to know which callback is running at the moment, we can use the `desc` field from tqdm.