### PR TITLE
feat: make geometry encoder optional in AB-UPT

### DIFF
--- a/src/noether/core/schemas/mixins.py
+++ b/src/noether/core/schemas/mixins.py
@@ -1,12 +1,38 @@
 #  Copyright © 2026 Emmi AI GmbH. All rights reserved.
 
-from typing import Any
+import typing
+from typing import Any, Union, get_args, get_origin
 
 from pydantic import BaseModel, model_validator
+from pydantic.fields import FieldInfo
 
 
 class Shared:
     """Marker class to indicate a field should inherit shared values from the parent config."""
+
+
+def _has_marker(field_info: FieldInfo) -> bool:
+    """Extract a BaseModel subclass from an annotation, handling Optional/Union types."""
+    metadata = field_info.metadata
+    # Handle Union types like `X | None` or `Optional[X]`
+    if get_origin(field_info.annotation) is Union:
+        for arg in get_args(field_info.annotation):
+            metadata.extend(getattr(arg, "__metadata__", []))
+    return any(x is Shared for x in metadata)
+
+
+def _extract_base_model(annotation: Any) -> type[BaseModel] | None:
+    """Extract a BaseModel subclass from an annotation, handling Optional/Union types."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    # Handle Union types like `X | None` or `Optional[X]`
+    if get_origin(annotation) is Union:
+        for arg in get_args(annotation):
+            if isinstance(arg, type) and issubclass(arg, BaseModel):
+                return arg
+            if hasattr(arg, "__origin__") and issubclass(arg.__origin__, BaseModel):
+                return typing.cast("type[BaseModel]", arg.__origin__)
+    return None
 
 
 class InjectSharedFieldFromParentMixin(BaseModel):
@@ -40,14 +66,12 @@ class InjectSharedFieldFromParentMixin(BaseModel):
         # Iterate over all fields in the parent model
         for field_name, field_info in parent_model_type.model_fields.items():
             # Check if inheritance of shared fields is requested via Annotated[..., Shared]
-            if not any(x is Shared for x in field_info.metadata):
+            if not _has_marker(field_info):
                 continue
 
             # Check if the field is a Pydantic model (i.e., a sub-config)
-            if isinstance(field_info.annotation, type) and issubclass(field_info.annotation, BaseModel):
-                sub_model_type = field_info.annotation
-            else:
-                # Not a Pydantic model, skip
+            sub_model_type = _extract_base_model(field_info.annotation)
+            if sub_model_type is None:
                 continue
 
             # Get the sub-config data from the parent dictionary
@@ -83,13 +107,12 @@ class InjectSharedFieldFromParentMixin(BaseModel):
         # Iterate over all fields in the current model
         for field_name, field_info in config_model_type.model_fields.items():
             # Check if inheritance of shared fields is requested via Annotated[..., Shared]
-            if not any(x is Shared or isinstance(x, Shared) for x in field_info.metadata):
+            if not _has_marker(field_info):
                 continue
 
             # Check if the field is a Pydantic model (i.e., a sub-config)
-            if isinstance(field_info.annotation, type) and issubclass(field_info.annotation, BaseModel):
-                sub_model_type = field_info.annotation
-            else:
+            sub_model_type = _extract_base_model(field_info.annotation)
+            if sub_model_type is None:
                 continue
 
             # Get the nested sub-config data

--- a/src/noether/core/schemas/models/ab_upt.py
+++ b/src/noether/core/schemas/models/ab_upt.py
@@ -23,7 +23,7 @@ from .base import ModelBaseConfig
 class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin):
     model_config = ConfigDict(extra="forbid")
 
-    supernode_pooling_config: Annotated[SupernodePoolingConfig, Shared]
+    supernode_pooling_config: Annotated[SupernodePoolingConfig, Shared] | None = None
 
     transformer_block_config: Annotated[TransformerBlockConfig, Shared]
 
@@ -134,7 +134,7 @@ class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin)
         Note: transformer_block_config validates hidden_dim % num_heads == 0 in its own validator.
         """
         # SupernodePoolingConfig: hidden_dim equality
-        if self.supernode_pooling_config.hidden_dim != self.hidden_dim:
+        if self.supernode_pooling_config is not None and self.supernode_pooling_config.hidden_dim != self.hidden_dim:
             raise ValueError(
                 f"supernode_pooling_config.hidden_dim ({self.supernode_pooling_config.hidden_dim}) "
                 f"must match model hidden_dim ({self.hidden_dim})."

--- a/src/noether/modeling/models/ab_upt.py
+++ b/src/noether/modeling/models/ab_upt.py
@@ -47,12 +47,6 @@ class AnchoredBranchedUPT(nn.Module):
         self.rope = RopeFrequency(config=config.rope_frequency_config)  # type: ignore[arg-type]
         self.pos_embed = ContinuousSincosEmbed(config=config.pos_embed_config)  # type: ignore[arg-type]
 
-        # geometry
-        self.encoder = SupernodePooling(config=config.supernode_pooling_config)  # type: ignore[arg-type]
-        self.geometry_blocks = nn.ModuleList(
-            [TransformerBlock(config=config.transformer_block_config) for _ in range(config.geometry_depth)],
-        )
-
         # domains (e.g. surface, volume)
         self.domain_names: list[str] = list(config.data_specs.domains.keys())
         self.domain_biases = nn.ModuleDict(
@@ -82,6 +76,13 @@ class AnchoredBranchedUPT(nn.Module):
                 raise NotImplementedError(
                     f"Unknown physics block type: {block}. Supported: self, cross, joint, perceiver."
                 )
+
+        if self.use_geometry_branch and config.supernode_pooling_config is not None:
+            # geometry
+            self.encoder = SupernodePooling(config=config.supernode_pooling_config)  # type: ignore[arg-type]
+            self.geometry_blocks = nn.ModuleList(
+                [TransformerBlock(config=config.transformer_block_config) for _ in range(config.geometry_depth)],
+            )
 
         # per-domain decoder blocks (separate weights per domain)
         self.domain_decoder_blocks = nn.ModuleDict()

--- a/tests/integration/noether/modeling/test_model_outputs.py
+++ b/tests/integration/noether/modeling/test_model_outputs.py
@@ -15,12 +15,15 @@ from noether.modeling.models.transformer import Transformer
 from noether.modeling.models.upt import UPT
 
 
-# Check that the Transformer model produces the same output for the same input across multiple runs, ensuring determinism.
-# If model architecture changes or initialization methods change, this test will fail
-# and expected_sum will need to be updated to the new value.
 def test_transformer_determinism_regression_check(
     transformer_config: TransformerConfig,
 ) -> None:
+    """
+    Checks transformer output against a hardcoded expected sum to ensure that changes to the model are intentional.
+    If the test fails, it indicates a change in the model's output which could be due to changes in architecture,
+    initialization, or other factors affecting determinism.
+    The expected_sum should be updated to the new value if the change is intentional.
+    """
     torch.manual_seed(42)
 
     model = Factory().create(transformer_config)
@@ -44,13 +47,16 @@ def test_transformer_determinism_regression_check(
     assert actual_sum == pytest.approx(expected_sum, abs=1e-5)
 
 
-# Check that the UPT model produces the same output for the same input across multiple runs, ensuring determinism.
-# If model architecture changes or initialization methods change, this test will fail
-# and expected_sum will need to be updated to the new value.
 def test_upt_determinism_regression_check(
     upt_config: UPTConfig,
     upt_input_generator: Callable[[int | None], dict[str, Any]],
 ) -> None:
+    """
+    Checks UPT output against a hardcoded expected sum to ensure that changes to the model are intentional.
+    If the test fails, it indicates a change in the model's output which could be due to changes in architecture,
+    initialization, or other factors affecting determinism.
+    The expected_sum should be updated to the new value if the change is intentional.
+    """
     torch.manual_seed(42)
 
     model = Factory().create(upt_config)
@@ -72,13 +78,16 @@ def test_upt_determinism_regression_check(
     assert actual_sum == pytest.approx(expected_sum, abs=1e-5)
 
 
-# Check that the AB-UPT model produces the same output for the same input across multiple runs, ensuring determinism.
-# If model architecture changes or initialization methods change, this test will fail
-# and expected_sum will need to be updated to the new value.
 def test_ab_upt_determinism_regression_check(
     ab_upt_config: AnchorBranchedUPTConfig,
     ab_upt_input_generator: Callable[[int | None], dict[str, Any]],
 ) -> None:
+    """
+    Checks AB-UPT output against a hardcoded expected sum to ensure that changes to the model are intentional.
+    If the test fails, it indicates a change in the model's output which could be due to changes in architecture,
+    initialization, or other factors affecting determinism.
+    The expected_sum should be updated to the new value if the change is intentional.
+    """
     # 1. Set a random seed
     torch.manual_seed(42)
 
@@ -96,6 +105,6 @@ def test_ab_upt_determinism_regression_check(
     print(f"AnchoredBranchedUPT determinism check: Output Sum = {actual_sum:.6f}")
 
     # Hardcoded expected sum from a previous run to check for regressions in determinism.
-    expected_sum = -0.021468846505740657
+    expected_sum = 0.009243674110621214
     # Check that the actual sum is approximately equal to the expected sum within a small tolerance.
     assert actual_sum == pytest.approx(expected_sum, abs=1e-5)


### PR DESCRIPTION
Not every application will have the equivalent of a geometry; the geometry encoder (supernode pooling and geometry blocks) should be optional.