### PR TITLE
fix: attempt hf download without HF_TOKEN

### DIFF
--- a/src/noether/io/interfaces/huggingface.py
+++ b/src/noether/io/interfaces/huggingface.py
@@ -17,6 +17,9 @@ HFRepoType = Literal["model", "dataset"]
 def _get_hf_token() -> str | None:
     """Retrieve the HuggingFace token from credentials, or return None if unavailable.
 
+    If credentials cannot be retrieved, the failure is logged at INFO level and
+    None is returned so callers can proceed without authentication.
+
     Returns:
         The HF_TOKEN string, or None if credentials are not configured.
     """

--- a/src/noether/io/interfaces/huggingface.py
+++ b/src/noether/io/interfaces/huggingface.py
@@ -25,7 +25,7 @@ def _get_hf_token() -> str | None:
     """
     try:
         credentials = get_credentials(Provider.HUGGINGFACE)
-        return credentials["HF_TOKEN"]
+        return str(credentials["HF_TOKEN"])
     except Exception as e:
         logger.info("Failed to get HuggingFace credentials, proceeding without authentication: %s", e)
         return None

--- a/src/noether/io/interfaces/huggingface.py
+++ b/src/noether/io/interfaces/huggingface.py
@@ -114,7 +114,12 @@ def fetch_huggingface_file(
     Returns:
         - None
     """
-    credentials = get_credentials(Provider.HUGGINGFACE)
+    token = None
+    try:
+        credentials = get_credentials(Provider.HUGGINGFACE)
+        token = credentials["HF_TOKEN"]
+    except Exception as e:
+        logger.info("Failed to get HuggingFace credentials, proceeding without authentication: %s", e)
     local_dir.mkdir(parents=True, exist_ok=True)
 
     hf_hub_download(
@@ -122,7 +127,7 @@ def fetch_huggingface_file(
         filename=filename,
         repo_type=repo_type,
         revision=revision,
-        token=credentials["HF_TOKEN"],
+        token=token,
         local_dir=str(local_dir),
     )
 
@@ -148,14 +153,19 @@ def fetch_huggingface_by_extension(
     Returns:
         - A list of downloaded files.
     """
-    credentials = get_credentials(Provider.HUGGINGFACE)
+    token = None
+    try:
+        credentials = get_credentials(Provider.HUGGINGFACE)
+        token = credentials["HF_TOKEN"]
+    except Exception as e:
+        logger.info("Failed to get HuggingFace credentials, proceeding without authentication: %s", e)
     local_dir.mkdir(parents=True, exist_ok=True)
 
     api = HfApi()
     files = api.list_repo_files(
         repo_id=repo_id,
         repo_type=repo_type,
-        token=credentials["HF_TOKEN"],
+        token=token,
         revision=revision,
     )
 
@@ -175,7 +185,7 @@ def fetch_huggingface_by_extension(
             filename=fname,
             repo_type=repo_type,
             revision=revision,
-            token=credentials["HF_TOKEN"],
+            token=token,
             local_dir=str(local_dir),
         )
         downloaded_files.append(fname)

--- a/src/noether/io/interfaces/huggingface.py
+++ b/src/noether/io/interfaces/huggingface.py
@@ -14,6 +14,20 @@ from noether.io.providers import Provider
 HFRepoType = Literal["model", "dataset"]
 
 
+def _get_hf_token() -> str | None:
+    """Retrieve the HuggingFace token from credentials, or return None if unavailable.
+
+    Returns:
+        The HF_TOKEN string, or None if credentials are not configured.
+    """
+    try:
+        credentials = get_credentials(Provider.HUGGINGFACE)
+        return credentials["HF_TOKEN"]
+    except Exception as e:
+        logger.info("Failed to get HuggingFace credentials, proceeding without authentication: %s", e)
+        return None
+
+
 def estimate_hf_repo_size(
     repo_id: str,
     repo_type: HFRepoType = "model",
@@ -114,12 +128,7 @@ def fetch_huggingface_file(
     Returns:
         - None
     """
-    token = None
-    try:
-        credentials = get_credentials(Provider.HUGGINGFACE)
-        token = credentials["HF_TOKEN"]
-    except Exception as e:
-        logger.info("Failed to get HuggingFace credentials, proceeding without authentication: %s", e)
+    token = _get_hf_token()
     local_dir.mkdir(parents=True, exist_ok=True)
 
     hf_hub_download(
@@ -153,12 +162,7 @@ def fetch_huggingface_by_extension(
     Returns:
         - A list of downloaded files.
     """
-    token = None
-    try:
-        credentials = get_credentials(Provider.HUGGINGFACE)
-        token = credentials["HF_TOKEN"]
-    except Exception as e:
-        logger.info("Failed to get HuggingFace credentials, proceeding without authentication: %s", e)
+    token = _get_hf_token()
     local_dir.mkdir(parents=True, exist_ok=True)
 
     api = HfApi()


### PR DESCRIPTION
hf_download from hub also works without having a HF_TOKEN set. It will output a warning if it's not set though, we can safely attempt it and rely on HF to warn about it.