### PR TITLE
feat: add pre_getitem and post_getitem hooks to Dataset base class

### DIFF
--- a/docs/source/guides/data/how_to_make_a_custom_dataset.rst
+++ b/docs/source/guides/data/how_to_make_a_custom_dataset.rst
@@ -70,6 +70,57 @@ The key provided to the decorator must match the key of the configured normalize
           std: 2.0
 
 
+Using ``pre_getitem`` / ``post_getitem`` Hooks
+-----------------------------------------------
+
+When multiple properties are stored inside a single file (e.g. an HDF5 container), opening the file
+separately in every ``getitem_*`` method is wasteful.  Override
+:py:meth:`~noether.data.Dataset.pre_getitem` to load shared data once, and optionally
+:py:meth:`~noether.data.Dataset.post_getitem` for cleanup.  The dictionary returned by
+``pre_getitem`` is forwarded as keyword arguments to every ``getitem_*`` method that declares
+matching parameters.
+
+.. testcode::
+
+    from noether.data import Dataset
+    from noether.core.schemas.dataset import DatasetBaseConfig
+
+    class HDF5DatasetConfig(DatasetBaseConfig):
+        kind: str = "path.to.HDF5Dataset"
+        file_paths: dict[int, str] = {}
+
+    class HDF5Dataset(Dataset):
+        def __init__(self, config: HDF5DatasetConfig):
+            super().__init__(config)
+            self.file_paths = config.file_paths
+
+        def __len__(self):
+            return len(self.file_paths)
+
+        def pre_getitem(self, idx: int) -> dict:
+            # Open the file once per sample
+            return {"h5file": h5py.File(self.file_paths[idx], "r")}
+
+        def post_getitem(self, idx: int, pre: dict | None) -> None:
+            # Guaranteed to run, even if a getitem_* method raises
+            if pre is not None:
+                pre["h5file"].close()
+
+        def getitem_temperature(self, idx: int, *, h5file=None, **kwargs):
+            return torch.tensor(h5file["temperature"][:])
+
+        def getitem_pressure(self, idx: int, *, h5file=None, **kwargs):
+            return torch.tensor(h5file["pressure"][:])
+
+.. testcode::
+   :hide:
+
+   _cfg = HDF5DatasetConfig(kind="path.to.HDF5Dataset")
+
+``getitem_*`` methods that only accept ``idx`` (like the basic example above) continue to work
+unchanged -- they simply won't receive the extra keyword arguments.
+
+
 Let's say we run a training pipeline with the above dataset configuration and a batch size of 4.
 Then the output will be a list of 4 dictionaries (a batch), where each dictionary has the following structure:
 

--- a/docs/source/noether/understanding_the_data_pipeline.rst
+++ b/docs/source/noether/understanding_the_data_pipeline.rst
@@ -50,10 +50,33 @@ Each dataset implements one ``getitem_<property>`` method per tensor it provides
    # simplified from base/dataset.py
    def __getitem__(self, idx):
        result = {"index": idx}
-       for getitem_name in self.get_all_getitem_names():
-           getitem_fn = getattr(self, getitem_name)
-           result[getitem_name[len("getitem_"):]] = getitem_fn(idx)
+       pre = self.pre_getitem(idx)
+       extra_kwargs = pre if pre is not None else {}
+       try:
+           for getitem_name in self.get_all_getitem_names():
+               getitem_fn = getattr(self, getitem_name)
+               result[getitem_name[len("getitem_"):]] = getitem_fn(idx, **extra_kwargs)
+       finally:
+           self.post_getitem(idx, pre)
        return result
+
+``pre_getitem`` / ``post_getitem`` hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The base class provides two optional lifecycle hooks around the ``getitem_*`` calls:
+
+- :py:meth:`~noether.data.Dataset.pre_getitem` is called **once** before any ``getitem_*`` method.
+  It can return a dictionary whose entries are forwarded as keyword arguments to every ``getitem_*``
+  method that accepts them.  This is useful when multiple properties live in the same file (e.g. an
+  HDF5 container): ``pre_getitem`` opens the file once, and each getter reads its field without
+  re-opening.
+
+- :py:meth:`~noether.data.Dataset.post_getitem` is called **once** after all ``getitem_*`` methods
+  have finished (or if one of them raises).  It receives the value returned by ``pre_getitem`` so
+  that cleanup logic (e.g. closing a file handle) can access the same resources.  The call is
+  wrapped in a ``finally`` block, so cleanup runs even on error.
+
+Both hooks default to no-ops, so existing datasets are unaffected.
 
 By default, every ``__getitem__`` call invokes **all** ``getitem_*`` methods and therefore loads all
 properties from disk. To avoid unnecessary I/O, we provide two ways to restrict which properties are

--- a/src/noether/data/base/dataset.py
+++ b/src/noether/data/base/dataset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import logging
 from collections.abc import Iterator
 from pathlib import Path
@@ -166,6 +167,8 @@ class Dataset(TorchDataset):
                       std: [0.1, 0.2, 0.3]
     """
 
+    _sig_cache: dict[str, bool]  # cache for whether getitem functions accept extra kwargs
+
     def __init__(
         self,
         dataset_config: DatasetBaseConfig,
@@ -177,6 +180,7 @@ class Dataset(TorchDataset):
                 for available options including dataset normalizers.
         """
         super().__init__()
+        self._sig_cache = {}
         self.logger = logging.getLogger(type(self).__name__)
         self._pipeline: Collator | MultiStagePipeline | None = None
         self.config = dataset_config
@@ -236,6 +240,32 @@ class Dataset(TorchDataset):
     def __len__(self) -> int:
         raise NotImplementedError("__len__ method must be implemented")
 
+    def pre_getitem(self, idx: int) -> dict[str, Any] | None:
+        """Optional hook called once before the individual ``getitem_*`` methods.
+
+        Override this to load shared data (e.g. an HDF5 file that contains
+        multiple fields) and return it as a dictionary.  The returned dict is
+        forwarded as keyword arguments to every ``getitem_*`` call for the
+        same sample, so each getter can pull its field without re-opening the
+        file.
+
+        The default implementation returns an empty dict
+        """
+        return dict()
+
+    def post_getitem(self, idx: int, pre: dict[str, Any] | None) -> None:
+        """Optional hook called once after all ``getitem_*`` methods have run.
+
+        Override this to perform per-sample cleanup (e.g. closing a file
+        handle that was opened in :meth:`pre_getitem`).
+
+        The *pre* argument is the value originally returned by
+        :meth:`pre_getitem` so that the cleanup logic can access the same
+        resources.
+
+        The default implementation does nothing.
+        """
+
     def __getitem__(self, idx: int) -> Any:
         """Calls all implemented getitem methods and returns the results
 
@@ -243,11 +273,32 @@ class Dataset(TorchDataset):
             dict[key, Any]: dictionary of all getitem result
         """
         result = dict(index=idx)
-        getitem_names = self.get_all_getitem_names()
-        for getitem_name in getitem_names:
-            getitem_fn = getattr(self, getitem_name)
-            result[getitem_name[len("getitem_") :]] = getitem_fn(idx)
+        pre = self.pre_getitem(idx)
+        if not isinstance(pre, dict):
+            raise TypeError(f"Expected dict from pre_getitem, got {type(pre)}")
+        try:
+            getitem_names = self.get_all_getitem_names()
+            for getitem_name in getitem_names:
+                getitem_fn = getattr(self, getitem_name)
+                # only pass extra kwargs if the getitem_fn accepts more than just idx
+                accepts_kwargs = self._getitem_accepts_kwargs(getitem_name, getitem_fn)
+                if accepts_kwargs:
+                    result[getitem_name[len("getitem_") :]] = getitem_fn(idx, **pre)
+                else:
+                    result[getitem_name[len("getitem_") :]] = getitem_fn(idx)
+        finally:
+            self.post_getitem(idx, pre)
         return result
+
+    def _getitem_accepts_kwargs(self, name: str, fn: Any) -> bool:
+        """Return whether *fn* accepts more than one positional parameter (cached)."""
+        try:
+            return self._sig_cache[name]
+        except KeyError:
+            params = list(inspect.signature(fn).parameters.values())
+            accepts = len(params) > 1
+            self._sig_cache[name] = accepts
+            return accepts
 
     def __iter__(self) -> Iterator[Any]:
         """torch.utils.data.Dataset doesn't define __iter__ which makes 'for sample in dataset' run endlessly.

--- a/tests/unit/noether/data/base/test_base.py
+++ b/tests/unit/noether/data/base/test_base.py
@@ -129,3 +129,132 @@ def test_with_normalizers_decorator_key_error():
     ds = NormalizedDataset()
     with pytest.raises(KeyError, match="Normalizer key 'non_existent_key' not found"):
         _ = ds[0]
+
+
+# --- pre_getitem hook tests ---
+
+
+def test_pre_getitem_default_returns_none(index_dataset: IndexDataset):
+    """Default pre_getitem returns {} and getitem still works normally."""
+    assert index_dataset.pre_getitem(0) == {}
+    sample = index_dataset[0]
+    assert sample == {"index": 0, "x": 0}
+
+
+def test_pre_getitem_forwards_kwargs():
+    """pre_getitem dict is forwarded as kwargs to getitem methods that accept them."""
+
+    class SharedLoadDataset(Dataset):
+        def __init__(self):
+            super().__init__(dataset_config=DatasetBaseConfig(kind="shared"))
+            self.data = {0: {"a": 10, "b": 20}}
+
+        def __len__(self) -> int:
+            return 1
+
+        def pre_getitem(self, idx: int) -> dict:
+            return self.data[idx]
+
+        def getitem_a(self, idx: int, *, a: int = 0, **kwargs) -> int:
+            return a
+
+        def getitem_b(self, idx: int, *, b: int = 0, **kwargs) -> int:
+            return b
+
+    ds = SharedLoadDataset()
+    sample = ds[0]
+    assert sample == {"index": 0, "a": 10, "b": 20}
+
+
+def test_pre_getitem_skips_methods_without_extra_params():
+    """Getitem methods that only take idx are called without extra kwargs."""
+
+    class MixedDataset(Dataset):
+        def __init__(self):
+            super().__init__(dataset_config=DatasetBaseConfig(kind="mixed"))
+
+        def __len__(self) -> int:
+            return 1
+
+        def pre_getitem(self, idx: int) -> dict:
+            return {"shared_value": 42}
+
+        def getitem_plain(self, idx: int) -> str:
+            return "plain"
+
+        def getitem_fancy(self, idx: int, *, shared_value: int = 0, **kwargs) -> int:
+            return shared_value
+
+    ds = MixedDataset()
+    sample = ds[0]
+    assert sample["plain"] == "plain"
+    assert sample["fancy"] == 42
+
+
+def test_post_getitem_called_after_getitem(index_dataset: IndexDataset):
+    """post_getitem is called after all getitem_* methods."""
+    calls = []
+    original_getitem_x = index_dataset.getitem_x
+
+    def tracked_getitem_x(idx):
+        calls.append("getitem_x")
+        return original_getitem_x(idx)
+
+    def tracked_post(idx, pre):
+        calls.append("post_getitem")
+
+    index_dataset.getitem_x = tracked_getitem_x
+    index_dataset.post_getitem = tracked_post
+    index_dataset[0]
+    assert calls == ["getitem_x", "post_getitem"]
+
+
+def test_post_getitem_receives_pre_value():
+    """post_getitem receives the same value that pre_getitem returned."""
+    received_pre = []
+
+    class TrackingDataset(Dataset):
+        def __init__(self):
+            super().__init__(dataset_config=DatasetBaseConfig(kind="tracking"))
+
+        def __len__(self) -> int:
+            return 1
+
+        def pre_getitem(self, idx: int) -> dict:
+            return {"handle": "open_resource"}
+
+        def post_getitem(self, idx: int, pre: dict | None) -> None:
+            received_pre.append(pre)
+
+        def getitem_x(self, idx: int) -> str:
+            return "data"
+
+    ds = TrackingDataset()
+    ds[0]
+    assert received_pre == [{"handle": "open_resource"}]
+
+
+def test_post_getitem_called_on_error():
+    """post_getitem runs even when a getitem_* method raises."""
+    cleanup_called = []
+
+    class FailingDataset(Dataset):
+        def __init__(self):
+            super().__init__(dataset_config=DatasetBaseConfig(kind="failing"))
+
+        def __len__(self) -> int:
+            return 1
+
+        def pre_getitem(self, idx: int) -> dict:
+            return {"fd": 99}
+
+        def post_getitem(self, idx: int, pre: dict | None) -> None:
+            cleanup_called.append(pre)
+
+        def getitem_x(self, idx: int) -> str:
+            raise RuntimeError("broken")
+
+    ds = FailingDataset()
+    with pytest.raises(RuntimeError, match="broken"):
+        ds[0]
+    assert cleanup_called == [{"fd": 99}]

--- a/tests/unit/noether/data/base/wrappers/test_property_subset.py
+++ b/tests/unit/noether/data/base/wrappers/test_property_subset.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from noether.core.schemas.dataset import RepeatWrapperConfig
+from noether.core.schemas.dataset import DatasetBaseConfig, RepeatWrapperConfig
 from noether.data import Dataset
 from noether.data.base.wrappers import PropertySubsetWrapper, RepeatWrapper
 
@@ -220,3 +220,56 @@ def test_double_property_wrapper_2(mock_dataset):
         assert second_wrapper[i] == expected_item
         assert first_wrapper[i]["x"] == f"x_{original_idx}"
         assert first_wrapper[i]["y"] == f"y_{original_idx}"
+
+
+class PreGetItemDataset(Dataset):
+    """Dataset with pre_getitem that provides shared data to getitem methods."""
+
+    def __init__(self, length: int = 10):
+        super().__init__(dataset_config=DatasetBaseConfig(kind="pre"))
+        self._length = length
+        self.pre_getitem_call_count = 0
+
+    def __len__(self) -> int:
+        return self._length
+
+    def pre_getitem(self, idx: int) -> dict:
+        self.pre_getitem_call_count += 1
+        return {"shared": f"shared_{idx}"}
+
+    def getitem_plain(self, idx: int) -> str:
+        return f"plain_{idx}"
+
+    def getitem_fancy(self, idx: int, *, shared: str = "", **kwargs) -> str:
+        return f"fancy_{shared}"
+
+
+def test_property_subset_bypasses_pre_getitem():
+    """PropertySubsetWrapper calls getitem methods directly, skipping pre_getitem."""
+    ds = PreGetItemDataset(length=5)
+    wrapper = PropertySubsetWrapper(dataset=ds, properties={"plain"})
+
+    sample = wrapper[2]
+    assert sample == {"plain": "plain_2"}
+    assert ds.pre_getitem_call_count == 0
+
+
+def test_property_subset_getitem_with_kwargs_uses_defaults():
+    """When PropertySubsetWrapper bypasses pre_getitem, getitem methods fall back to defaults."""
+    ds = PreGetItemDataset(length=5)
+    wrapper = PropertySubsetWrapper(dataset=ds, properties={"fancy"})
+
+    sample = wrapper[3]
+    # fancy gets default shared="" because pre_getitem is not called
+    assert sample == {"fancy": "fancy_"}
+    assert ds.pre_getitem_call_count == 0
+
+
+def test_direct_dataset_calls_pre_getitem():
+    """Contrast: accessing the dataset directly does invoke pre_getitem."""
+    ds = PreGetItemDataset(length=5)
+    sample = ds[2]
+
+    assert sample["plain"] == "plain_2"
+    assert sample["fancy"] == "fancy_shared_2"
+    assert ds.pre_getitem_call_count == 1


### PR DESCRIPTION
Introduce a `pre_getitem` method that loads shared data once per sample and forwards it as keyword arguments to individual `getitem_*` methods, avoiding redundant file opens. And a parallel `post_getitem` method that can be used for cleanup operations.
