### PR TITLE
chore: add type guard to avoid mypy error in OptimizerWrapper

### DIFF
--- a/recipes/development/development_schema.py
+++ b/recipes/development/development_schema.py
@@ -1,10 +1,10 @@
 #  Copyright © 2026 Emmi AI GmbH. All rights reserved.
 
-from pydantic import Field
-
 from development.dataset import DevelopmentDatasetConfig
 from development.model import DevelopmentModelConfig
 from development.trainer import DevelopmentTrainerConfig
+from pydantic import Field
+
 from noether.core.schemas import ConfigSchema
 
 

--- a/src/noether/core/optimizer/optimizer_wrapper.py
+++ b/src/noether/core/optimizer/optimizer_wrapper.py
@@ -275,8 +275,12 @@ class OptimizerWrapper:
             grad_scaler.unscale_(self.torch_optim)
         # clip gradients
         if self.config.clip_grad_value is not None:
+            if self.all_parameters is None:
+                raise RuntimeError("all_parameters was not initialized")
             torch.nn.utils.clip_grad_value_(self.all_parameters, self.config.clip_grad_value)
         if self.config.clip_grad_norm is not None:
+            if self.all_parameters is None:
+                raise RuntimeError("all_parameters was not initialized")
             torch.nn.utils.clip_grad_norm_(self.all_parameters, self.config.clip_grad_norm)
         # torch optim step with grad scaler
         grad_scaler.step(self.torch_optim)


### PR DESCRIPTION
This fixes a mypy error in OptimizerWrapper. 

Somehow this was not caught in the CI. Possibly related to the torch 2.11 upgrade but I am not sure.