### PR TITLE
docs: SEO enhancements

### DIFF
--- a/docs/source/_static/robots.txt
+++ b/docs/source/_static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://noether-docs.emmi.ai/sitemap.xml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,14 @@ project = "Noether Framework"
 author = "Emmi AI"
 copyright = f"{datetime.now():%Y}, {author}"
 
+# SEO: page titles rendered as "<page> - Noether Framework" and used in the
+# <title> tag. `html_short_title` is used by some themes for the sidebar/nav.
+html_title = "Noether Framework Documentation"
+html_short_title = "Noether"
+
+# SEO: declare document language for crawlers and assistive tech.
+language = "en"
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
@@ -25,6 +33,8 @@ extensions = [
     "sphinx_autodoc_typehints",
     "autoapi.extension",  # <-- use AutoAPI
     "sphinx_copybutton",  # for "copy" buttons on code blocks
+    "sphinx_sitemap",  # SEO: generate sitemap.xml
+    "sphinxext.opengraph",  # SEO: Open Graph + Twitter card meta tags
     # Optional if you want Markdown pages:
     # Optional if you want CLI docs:
     # "sphinx_click",
@@ -214,6 +224,39 @@ html_static_path = ["_static"]
 html_css_files = ["emmi_docs_theme.css"]
 html_js_files = ["force_light_theme.js"]
 html_logo = "_static/Emmi_AI_logo_black.svg"  # this works
+
+# --- SEO -------------------------------------------------------------------
+# Canonical base URL: used by sphinx-sitemap for sitemap.xml and emitted as
+# <link rel="canonical"> on every page to prevent duplicate-content penalties.
+html_baseurl = os.environ.get("DOCS_BASEURL", "https://noether-docs.emmi.ai/")
+
+# Expose robots.txt and sitemap.xml at the site root (served from _static/).
+html_extra_path = ["_static/robots.txt"]
+
+# sphinx-sitemap: one URL per HTML page, no language/version suffixes.
+sitemap_url_scheme = "{link}"
+sitemap_filename = "sitemap.xml"
+
+# sphinxext-opengraph: Open Graph + Twitter card metadata for rich link
+# previews on Google, LinkedIn, X, Slack, etc.
+ogp_site_url = html_baseurl
+ogp_site_name = "Noether Framework Documentation"
+ogp_type = "website"
+ogp_image = html_baseurl.rstrip("/") + "/_static/Emmi_AI_logo_black.svg"
+ogp_image_alt = "Noether: A PyTorch-based Framework for Engineering AI"
+ogp_enable_meta_description = True
+ogp_description_length = 200
+ogp_social_cards = {"enable": False}  # requires matplotlib; keep off by default
+# Only truly global tags here. Per-page `<meta name="description">` /
+# `<meta name="keywords">` belong in each page's `.. meta::` directive so
+# crawlers see a page-specific SERP snippet instead of a duplicated default.
+ogp_custom_meta_tags = [
+    '<meta name="twitter:card" content="summary_large_image" />',
+    '<meta name="twitter:site" content="@emmi_ai" />',
+    '<meta name="robots" content="index, follow" />',
+]
+# ---------------------------------------------------------------------------
+
 # This doesn't work, not sure how to make it light/dark mode agnostic yet:
 # if isinstance(html_theme_options["logo"], dict):
 #     html_theme_options["logo"].update({

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,7 @@
+.. meta::
+   :description: Noether is a PyTorch-based framework for Engineering AI: models, datasets, training recipes, and tooling for physics-based ML research.
+   :keywords: Noether, Emmi AI, Engineering AI, PyTorch, machine learning, scientific ML, neural operators, physics-based ML, surrogate models, simulation, CFD, CAE
+
 Noether Framework Documentation
 ===============================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ docs = [
     "myst-parser",
     "autodoc-pydantic>=2.2.0",
     "sphinx-copybutton>=0.5.2",
+    "sphinx-sitemap>=2.6.0",  # SEO: sitemap.xml generation
+    "sphinxext-opengraph>=0.9.1",  # SEO: Open Graph + Twitter card meta tags
     "roman-numerals-py==4.0.0", # pin because of https://github.com/sphinx-doc/sphinx/issues/14186
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ name = "cuda-bindings"
 version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/04/8a4d45dc154a8a32982658cc55be291e9778d1197834b15d33427e2f65c1/cuda_bindings-12.9.6-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea331bc47d9988cc61f0ecc5fa8df9dd188b4493ae1c6688bb1ee8ce8ba1af4", size = 7050347, upload-time = "2026-03-11T14:47:35.221Z" },
@@ -585,37 +585,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -741,7 +741,8 @@ dependencies = [
     { name = "rtree" },
     { name = "setuptools" },
     { name = "submitit" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform != 'darwin'" },
     { name = "trimesh" },
     { name = "typer" },
@@ -769,6 +770,8 @@ dev = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-multiversion" },
+    { name = "sphinx-sitemap" },
+    { name = "sphinxext-opengraph" },
     { name = "types-docutils" },
     { name = "types-pyyaml" },
     { name = "types-tqdm" },
@@ -785,6 +788,8 @@ docs = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-multiversion" },
+    { name = "sphinx-sitemap" },
+    { name = "sphinxext-opengraph" },
 ]
 
 [package.metadata]
@@ -832,6 +837,8 @@ dev = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design" },
     { name = "sphinx-multiversion" },
+    { name = "sphinx-sitemap", specifier = ">=2.6.0" },
+    { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
     { name = "types-docutils", specifier = "==0.22.0.20250822" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
@@ -848,6 +855,8 @@ docs = [
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design" },
     { name = "sphinx-multiversion" },
+    { name = "sphinx-sitemap", specifier = ">=2.6.0" },
+    { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
 ]
 
 [[package]]
@@ -1981,7 +1990,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
@@ -1993,7 +2002,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -2023,9 +2032,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -2037,7 +2046,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -3100,6 +3109,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-last-updated-by-git"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/fd/de1685b6dab173dff31da24e0d3b29f02873fc24a1cdbb7678721ddc8581/sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761", size = 10785, upload-time = "2024-08-11T07:15:54.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499", size = 8580, upload-time = "2024-08-11T07:15:53.244Z" },
+]
+
+[[package]]
 name = "sphinx-multiversion"
 version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3110,6 +3131,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/9a/10/25231164a97a9016b
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/51/203bb30b3ce76373237288e92cb71fb66f80ee380473f36bfe8a9d299c5d/sphinx_multiversion-0.2.4-py2.py3-none-any.whl", hash = "sha256:5c38d5ce785a335d8c8d768b46509bd66bfb9c6252b93b700ca8c05317f207d6", size = 9597, upload-time = "2024-10-03T21:45:52.754Z" },
     { url = "https://files.pythonhosted.org/packages/05/ad/4989e6be165805694e93d09bc57425aa1368273b7de4fe3083fe4310803a/sphinx_multiversion-0.2.4-py3-none-any.whl", hash = "sha256:dec29f2a5890ad68157a790112edc0eb63140e70f9df0a363743c6258fbeb478", size = 9642, upload-time = "2020-08-12T15:48:19.649Z" },
+]
+
+[[package]]
+name = "sphinx-sitemap"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx-last-updated-by-git" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/17/56fe0f65e3567f829b2b4153a622be1d4b222b781e0d90d7db5a7738f30f/sphinx_sitemap-2.9.0.tar.gz", hash = "sha256:70f97bcdf444e3d68e118355cf82a1f54c4d3c03d651cd17fe87398b26e25e21", size = 6978, upload-time = "2025-10-06T00:24:00.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/94/3c57e8b1985e755c48972e2ecd59526d4bf0b52a1fe805bc52a8e98cb92d/sphinx_sitemap-2.9.0-py3-none-any.whl", hash = "sha256:f1f1d3a9ad012ba17a7ef0b560d303bff2d0db26647567d6e810bcc754466664", size = 6218, upload-time = "2025-10-06T00:23:58.778Z" },
 ]
 
 [[package]]
@@ -3167,6 +3200,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinxext-opengraph"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c0/eb6838e3bae624ce6c8b90b245d17e84252863150e95efdb88f92c8aa3fb/sphinxext_opengraph-0.13.0.tar.gz", hash = "sha256:103335d08567ad8468faf1425f575e3b698e9621f9323949a6c8b96d9793e80b", size = 1026875, upload-time = "2025-08-29T12:20:31.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/a4/66c1fd4f8fab88faf71cee04a945f9806ba0fef753f2cfc8be6353f64508/sphinxext_opengraph-0.13.0-py3-none-any.whl", hash = "sha256:936c07828edc9ad9a7b07908b29596dc84ed0b3ceaa77acdf51282d232d4d80e", size = 1004152, upload-time = "2025-08-29T12:20:29.072Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3219,19 +3264,18 @@ name = "torch"
 version = "2.11.0"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "networkx", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "sympy", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252" },
@@ -3239,6 +3283,23 @@ wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cc3a195701bba2239c313ee311487f80f8aaebe9e89b9073dddbcf2f93b5a0ba" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:072a0d6e4865e8b0dc0dbfe6ebed68fae235124222835ef03e5814d414d8c012" },
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23ec7789017da9d95b6d543d790814785e6f30905c5443efa8257d1490d73f79" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
+    { name = "networkx", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
+    { name = "sympy", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.15' and sys_platform == 'darwin'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds comprehensive SEO (Search Engine Optimization) enhancements to the Noether Framework documentation site, including sitemap generation, Open Graph metadata, Twitter cards, and robots.txt configuration.

## Key Changes
- **Sphinx Extensions**: Added `sphinx-sitemap` and `sphinxext-opengraph` extensions to generate `sitemap.xml` and rich metadata for social media link previews
- **HTML Metadata**: Configured `html_title`, `html_short_title`, and `language` settings for improved search engine crawling and accessibility
- **Canonical URLs**: Set `html_baseurl` (configurable via `DOCS_BASEURL` environment variable) to prevent duplicate content penalties and enable proper sitemap generation
- **Open Graph Tags**: Configured OGP metadata including site name, image, description length, and custom Twitter card tags for rich previews on Google, LinkedIn, X, Slack, etc.
- **robots.txt**: Added site root robots.txt file to declare sitemap location and allow all crawlers
- **Page-Level SEO**: Added meta description and keywords to the documentation index page via Sphinx `.. meta::` directive
- **Dependencies**: Added `sphinx-sitemap>=2.6.0` and `sphinxext-opengraph>=0.9.1` to the docs dependencies in pyproject.toml

## Implementation Details
- The `html_baseurl` is configurable via the `DOCS_BASEURL` environment variable with a sensible default, allowing flexibility across deployment environments
- Per-page metadata (description, keywords) is placed in individual page directives rather than global config to ensure crawlers see page-specific SERP snippets
- Open Graph social card generation is disabled by default (requires matplotlib) but can be enabled if needed
- The sitemap uses a simple URL scheme without language or version suffixes for cleaner URLs

https://claude.ai/code/session_012jSNcmj4bA83zeEHNFB5dL