### PR TITLE
fix: default to unlimited job time

### DIFF
--- a/src/noether/core/schemas/slurm.py
+++ b/src/noether/core/schemas/slurm.py
@@ -60,8 +60,8 @@ class SlurmConfig(BaseModel):
     mem_gb: float | None = None
     """Memory per node in gigabytes."""
 
-    timeout_min: int | None = None
-    """Wall-clock limit in minutes."""
+    timeout_min: int = 0
+    """Wall-clock limit in minutes. Use 0 for no time limit"""
 
     stderr_to_stdout: bool | None = None
     """If True, merge stderr into stdout."""

--- a/tests/unit/noether/training/cli/test_submit_job.py
+++ b/tests/unit/noether/training/cli/test_submit_job.py
@@ -313,7 +313,7 @@ class TestSlurmConfigToExecutorKwargs:
     def test_excludes_none_fields(self):
         folder, params = SlurmConfig(name="job", slurm_partition="gpu").to_executor_kwargs()
         assert folder == "submitit_logs"
-        assert params == {"name": "job", "slurm_partition": "gpu"}
+        assert params == {"name": "job", "slurm_partition": "gpu", "timeout_min": 0}
 
     def test_folder_is_returned_separately(self):
         folder, params = SlurmConfig(folder="/tmp/logs").to_executor_kwargs()


### PR DESCRIPTION
I noticed it's better to default to unlimited time, since `None` would be replaced with submitits default of 5 minutes, which is a very bad default.