### PR TITLE
feat: Untied physics blocks

### DIFF
--- a/src/noether/core/schemas/models/ab_upt.py
+++ b/src/noether/core/schemas/models/ab_upt.py
@@ -21,6 +21,8 @@ from .base import ModelBaseConfig
 
 
 class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin):
+    kind: str | None = "noether.core.schemas.models.AnchorBranchedUPTConfig"
+
     model_config = ConfigDict(extra="forbid")
 
     supernode_pooling_config: Annotated[SupernodePoolingConfig, Shared] | None = None
@@ -33,13 +35,29 @@ class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin)
     hidden_dim: int = Field(..., ge=1)
     """Hidden dimension of the model."""
 
-    physics_blocks: list[Literal["self", "shared", "cross", "joint", "perceiver"]]
+    physics_blocks: list[
+        Literal[
+            "self",
+            "shared",
+            "cross",
+            "joint",
+            "perceiver",
+            "self_untied",
+            "cross_untied",
+            "joint_untied",
+            "perceiver_untied",
+        ]
+    ]
     """Types of physics blocks to use in the model.
-    Options are "self", "cross", "joint", and "perceiver".
-    Self: Self-attention within a branch. Attention weights are shared between all domains.
-    Cross: Cross-attention between domains. Each domain attends to all other domains' anchors.
-    Joint: Joint attention over all domain points. Full self-attention over all points.
-    Perceiver: Perceiver-style cross-attention to geometry encoding.
+
+    self/shared: Self-attention within a branch/domain. Weights are shared between all domains.
+    cross: Cross-attention between domains. Each domain attends to all other domains' anchors, weights are shared.
+    joint: Joint attention over all domain points. Full self-attention over all points, weights are shared.
+    perceiver: Perceiver-style cross-attention to geometry encoding.
+    self_untied: Self-attention within a branch with untied weights for each domain.
+    cross_untied: Cross-attention between domains with untied weights for each domain.
+    joint_untied: Joint attention over all domain points with untied weights for each domain.
+    perceiver_untied: Perceiver cross-attention with geometry encoding and untied weights per domain.
 
     Note: "shared" is a deprecated alias for "self" and will be removed in a future release."""
 

--- a/src/noether/core/schemas/modules/__init__.py
+++ b/src/noether/core/schemas/modules/__init__.py
@@ -23,6 +23,13 @@ from .layers import (
     UnquantizedDropPathConfig,
 )
 from .mlp import MLPConfig, UpActDownMLPConfig
+from .untied import (
+    UntiedLinearConfig,
+    UntiedMixedAttentionConfig,
+    UntiedMLPConfig,
+    UntiedPerceiverBlockConfig,
+    UntiedTransformerBlockConfig,
+)
 
 __all__ = [
     "AttentionConfig",
@@ -35,6 +42,11 @@ __all__ = [
     "PerceiverAttentionConfig",
     "TransolverAttentionConfig",
     "TransolverPlusPlusAttentionConfig",
+    "UntiedLinearConfig",
+    "UntiedMLPConfig",
+    "UntiedMixedAttentionConfig",
+    "UntiedPerceiverBlockConfig",
+    "UntiedTransformerBlockConfig",
     "PerceiverBlockConfig",
     "TransformerBlockConfig",
     "DeepPerceiverDecoderConfig",

--- a/src/noether/core/schemas/modules/attention.py
+++ b/src/noether/core/schemas/modules/attention.py
@@ -4,7 +4,7 @@ import abc
 from collections.abc import Sequence
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
 from noether.core.types import InitWeightsMode
 
@@ -153,6 +153,18 @@ class TokenSpec(BaseModel):
     def to_dict(self) -> dict[str, int | None]:
         """Convert TokenSpec to dictionary."""
         return {self.name: self.size}
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def domain(self) -> str:
+        """Extract token domain from the name (e.g., "surface" from "surface_anchors")."""
+        return self.name.split("_")[0]
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def attn_type(self) -> str:
+        """Extract attention type from the name (e.g., "anchors" from "surface_anchors")."""
+        return self.name.split("_")[-1]
 
 
 class AttentionPattern(BaseModel):

--- a/src/noether/core/schemas/modules/untied.py
+++ b/src/noether/core/schemas/modules/untied.py
@@ -1,0 +1,142 @@
+#  Copyright © 2025 Emmi AI GmbH. All rights reserved.
+
+from pydantic import BaseModel, Field, computed_field
+
+from noether.core.schemas.modules.attention import MixedAttentionConfig
+from noether.core.schemas.modules.blocks import PerceiverBlockConfig, TransformerBlockConfig
+from noether.core.schemas.modules.layers import LinearProjectionConfig
+from noether.core.schemas.modules.mlp import MLPConfig
+
+
+class UntiedLinearConfig(BaseModel):
+    """Configuration for a linear layer with per-type (untied) weight banks.
+
+    Composes a :class:`LinearProjectionConfig` (shared across types) with a
+    ``num_types`` field: each token type gets its own independent weight matrix
+    with the geometry described by the linear projection config.
+    """
+
+    num_types: int = Field(..., ge=1)
+    """Number of distinct token types, each with its own weight bank."""
+
+    linear_projection: LinearProjectionConfig
+    """Shared geometry (input/output dims, bias, init) for every per-type weight bank."""
+
+
+class UntiedMixedAttentionConfig(MixedAttentionConfig):
+    """Configuration for multi-head attention with per-type (untied) QKV and output projections.
+
+    Extends :class:`MixedAttentionConfig` with a ``num_types`` field: the QKV and
+    output projections are :class:`UntiedLinear` layers so each token type gets
+    its own projection weights. Attention itself is still computed across all
+    tokens via :meth:`MixedAttention._process_pattern_batched`.
+    """
+
+    num_types: int = Field(..., ge=1)
+    """Number of distinct token types, each with its own QKV/output weight bank."""
+
+    @computed_field
+    def projection_config(self) -> UntiedLinearConfig:
+        """Configuration for the per-type QKV and output projections."""
+        return UntiedLinearConfig(
+            num_types=self.num_types,
+            linear_projection=LinearProjectionConfig(
+                input_dim=self.hidden_dim,
+                output_dim=self.hidden_dim,
+                bias=self.bias,
+                init_weights=self.init_weights,
+            ),
+        )
+
+
+class UntiedMLPConfig(BaseModel):
+    """Configuration for an MLP with per-type (untied) weights.
+
+    Composes an :class:`MLPConfig` (architecture: dims, activation, init) with a
+    ``num_types`` field. The untied MLP mirrors :class:`MLP`'s topology
+    (``input -> [hidden]*(num_layers+1) -> output`` with activations between layers)
+    but uses :class:`UntiedLinear` for every linear layer.
+    """
+
+    num_types: int = Field(..., ge=1)
+    """Number of distinct token types."""
+
+    mlp: MLPConfig
+    """Underlying MLP architecture (dims, activation, init)."""
+
+
+class UntiedTransformerBlockConfig(BaseModel):
+    """Configuration for a transformer block with per-type (untied) attention and MLP weights.
+
+    Composes a :class:`TransformerBlockConfig` (shared layout: dims, heads, layer
+    scale, drop path, etc.) with a ``num_types`` field. Both sub-layers have
+    per-type weights: :class:`UntiedMultiHeadAttention` for attention and
+    :class:`UntiedMLP` for the feed-forward.
+    """
+
+    num_types: int = Field(..., ge=1)
+    """Number of distinct token types for the untied MLP."""
+
+    transformer_block: TransformerBlockConfig
+    """Shared transformer-block layout (dims, heads, layer scale, drop path, etc.)."""
+
+    @computed_field
+    def attention_config(self) -> UntiedMixedAttentionConfig:
+        """Configuration for the UntiedMultiHeadAttention sub-layer."""
+        block = self.transformer_block
+        return UntiedMixedAttentionConfig(
+            **block.model_dump(), **(block.attention_arguments or {}), num_types=self.num_types
+        )
+
+    @computed_field
+    def untied_mlp_config(self) -> UntiedMLPConfig:
+        """Configuration for the UntiedMLP sub-layer."""
+        block = self.transformer_block
+        # `mlp_hidden_dim` is guaranteed non-None by TransformerBlockConfig's validator.
+        assert block.mlp_hidden_dim is not None
+        return UntiedMLPConfig(
+            num_types=self.num_types,
+            mlp=MLPConfig(
+                input_dim=block.hidden_dim,
+                output_dim=block.hidden_dim,
+                hidden_dim=block.mlp_hidden_dim,
+                num_layers=0,
+                activation="GELU",
+                init_weights=block.init_weights,
+            ),
+        )
+
+
+class UntiedPerceiverBlockConfig(BaseModel):
+    """Configuration for a perceiver block with per-type (untied) Q/output projections and MLP weights.
+
+    Composes a :class:`PerceiverBlockConfig` (shared layout: dims, heads, layer
+    scale, drop path, etc.) with a ``num_types`` field. The Q and output
+    projections in :class:`PerceiverAttention` become per-type via
+    :class:`UntiedLinear`, while the KV projection stays shared (it operates on
+    a single geometry encoding). The MLP is also replaced with
+    :class:`UntiedMLP`.
+    """
+
+    num_types: int = Field(..., ge=1)
+    """Number of distinct token types for the untied projections."""
+
+    perceiver_block_config: PerceiverBlockConfig
+    """Shared perceiver-block layout (dims, heads, kv_dim, layer scale, drop path, etc.)."""
+
+    @computed_field
+    def untied_mlp_config(self) -> UntiedMLPConfig:
+        """Configuration for the UntiedMLP sub-layer."""
+        block = self.perceiver_block_config
+        assert block.mlp_hidden_dim is not None
+        return UntiedMLPConfig(
+            num_types=self.num_types,
+            mlp=MLPConfig(
+                input_dim=block.hidden_dim,
+                output_dim=block.hidden_dim,
+                hidden_dim=block.mlp_hidden_dim,
+                num_layers=0,
+                activation="GELU",
+                init_weights=block.init_weights,
+            ),
+        )

--- a/src/noether/modeling/models/ab_upt.py
+++ b/src/noether/modeling/models/ab_upt.py
@@ -7,6 +7,9 @@ from typing import Any, cast
 import torch
 from torch import Tensor, nn
 
+from noether.core.schemas.modules.untied import UntiedPerceiverBlockConfig, UntiedTransformerBlockConfig
+from noether.modeling.modules.untied import UntiedPerceiverBlock, UntiedTransformerBlock
+
 KVPair = dict[str, Tensor]  # {"k": tensor, "v": tensor}
 LayerCache = dict[str, KVPair]  # {token_name: KVPair}
 ModelKVCache = dict[str, list[LayerCache]]  # {branch_name: [LayerCache, ...]}
@@ -63,18 +66,43 @@ class AnchoredBranchedUPT(nn.Module):
             "cross": CrossAnchorAttention,
             "joint": JointAnchorAttention,
         }
+        num_domains = len(self.domain_names)
         for block in config.physics_blocks:
-            if block == "perceiver":
+            untied = block.endswith("_untied")
+            block_type = block.removesuffix("_untied") if untied else block
+
+            if block_type == "perceiver":
                 self.use_geometry_branch = True
-                self.physics_blocks.append(PerceiverBlock(config=config.perceiver_block_config))  # type: ignore[arg-type]
-            elif block in attention_constructors:
+                if not untied:
+                    self.physics_blocks.append(PerceiverBlock(config=config.perceiver_block_config))  # type: ignore[arg-type]
+                else:
+                    self.physics_blocks.append(
+                        UntiedPerceiverBlock(
+                            config=UntiedPerceiverBlockConfig(
+                                num_types=num_domains,
+                                perceiver_block_config=config.perceiver_block_config,
+                            )
+                        )
+                    )
+            elif block_type in attention_constructors:
                 block_config = copy.deepcopy(config.transformer_block_config)
-                block_config.attention_constructor = attention_constructors[block]  # type: ignore[assignment]
+                block_config.attention_constructor = attention_constructors[block_type]  # type: ignore[assignment]
                 block_config.attention_arguments = {"branches": tuple(self.domain_names)}
-                self.physics_blocks.append(TransformerBlock(config=block_config))  # type: ignore[arg-type]
+                if not untied:
+                    self.physics_blocks.append(TransformerBlock(config=block_config))  # type: ignore[arg-type]
+                else:
+                    self.physics_blocks.append(
+                        UntiedTransformerBlock(
+                            config=UntiedTransformerBlockConfig(
+                                num_types=num_domains,
+                                transformer_block=block_config,
+                            )
+                        )
+                    )
             else:
                 raise NotImplementedError(
-                    f"Unknown physics block type: {block}. Supported: self, cross, joint, perceiver."
+                    f"Unknown physics block type: {block}. "
+                    "Supported: self, cross, joint, perceiver (each optionally with _untied suffix)."
                 )
 
         if self.use_geometry_branch and config.supernode_pooling_config is not None:
@@ -249,7 +277,7 @@ class AnchoredBranchedUPT(nn.Module):
             start = end
         new_physics_cache: list[LayerCache] = []
         for i, block in enumerate(self.physics_blocks):
-            if isinstance(block, TransformerBlock):
+            if isinstance(block, TransformerBlock | UntiedTransformerBlock):
                 x_physics, block_cache = block(
                     x_physics,
                     attn_kwargs=dict(
@@ -262,13 +290,16 @@ class AnchoredBranchedUPT(nn.Module):
                 if block_cache is not None:
                     new_physics_cache.append(block_cache)
             elif isinstance(block, PerceiverBlock):
+                perceiver_attn_kwargs: dict[str, Any] = dict(
+                    kv_cache=physics_cache[i]["geometry_encoding"] if physics_cache else None,
+                    **physics_perceiver_attn_kwargs,
+                )
+                if isinstance(block, UntiedPerceiverBlock):
+                    perceiver_attn_kwargs["token_specs"] = physics_token_specs
                 x_physics, block_cache = block(
                     q=x_physics,
                     kv=geometry_encoding,
-                    attn_kwargs=dict(
-                        kv_cache=physics_cache[i]["geometry_encoding"] if physics_cache else None,
-                        **physics_perceiver_attn_kwargs,
-                    ),
+                    attn_kwargs=perceiver_attn_kwargs,
                     condition=condition,
                 )
                 if block_cache is not None:

--- a/src/noether/modeling/modules/attention/anchor_attention/mixed.py
+++ b/src/noether/modeling/modules/attention/anchor_attention/mixed.py
@@ -94,56 +94,28 @@ class MixedAttention(DotProductAttention):
 
         self._validate_inputs(x, input_specs, attention_patterns, key_padding_mask, freqs, cached_token_names)
 
-        input_sizes = [spec.size for spec in input_specs]
-
-        def to_token_dict(x: torch.Tensor, split_dim: int = 2) -> dict[str, torch.Tensor]:
-            splits = x.split(input_sizes, dim=split_dim)
-            return {spec.name: split for spec, split in zip(input_specs, splits, strict=True)}
-
         if cached_token_names:
-            # Cached path: only compute Q (K/V come from cache)
+            # Cached path: only compute Q (K/V come from cache); shares no helper with the normal
+            # path because Q uses a slice of qkv.weight and K/V are loaded, not computed.
             if not kv_cache:
                 raise ValueError("Cannot use cached tokens: kv_cache is empty.")
             q = einops.rearrange(self.q(x), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
             if self.use_rope and freqs is not None:
                 q = rope(q, freqs=freqs)
 
-            q_dict: dict[str, torch.Tensor] = to_token_dict(q)
+            q_dict = self._split_per_token_spec(q, input_specs, split_dim=2)
             k_dict: dict[str, torch.Tensor] = {}
             v_dict: dict[str, torch.Tensor] = {}
-
             for name in cached_token_names:
                 if name not in kv_cache:
                     raise ValueError(f"Cached token '{name}' not found in kv_cache.")
                 k_dict[name] = kv_cache[name]["k"]
                 v_dict[name] = kv_cache[name]["v"]
 
-            new_cache = None
-        else:
-            # Normal path: compute Q, K, V for all input tokens
-            q = einops.rearrange(self.q(x), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
-            k = einops.rearrange(self.k(x), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
-            v = einops.rearrange(self.v(x), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
-            if self.use_rope and freqs is not None:
-                q, k = rope(q, freqs=freqs), rope(k, freqs=freqs)
-
-            q_dict, k_dict, v_dict = [to_token_dict(x) for x in [q, k, v]]
-
-            # Save anchor K/V for future cached inference
-            new_cache = {}
-            for spec in input_specs:
-                if "_anchor" in spec.name:
-                    new_cache[spec.name] = {"k": k_dict[spec.name], "v": v_dict[spec.name]}
-
-        # Build key_padding_mask dict (if provided)
-        mask_dict: dict[str, torch.Tensor] | None = None
-        if key_padding_mask is not None:
-            if cached_token_names:
+            if key_padding_mask is not None:
                 raise ValueError("key_padding_mask is not supported when using KV cache.")
-            mask_dict = to_token_dict(key_padding_mask, split_dim=1)
 
-        # Filter cached tokens out of pattern query lists (they have no Q, only cached K/V)
-        if cached_token_names:
+            # Filter cached tokens out of pattern query lists (they have no Q, only cached K/V).
             attention_patterns = [
                 AttentionPattern(
                     query_tokens=[name for name in p.query_tokens if name not in cached_token_names],
@@ -152,6 +124,113 @@ class MixedAttention(DotProductAttention):
                 for p in attention_patterns
                 if any(name not in cached_token_names for name in p.query_tokens)
             ]
+            token_outputs = self._process_pattern_batched(
+                attention_patterns=attention_patterns,
+                q_dict=q_dict,
+                k_dict=k_dict,
+                v_dict=v_dict,
+                mask_dict=None,
+            )
+            output = self._assemble_per_token_spec(token_outputs, input_specs)
+            new_cache = None
+        else:
+            # Normal path: compute Q, K, V for all input tokens, then run the shared attention helper.
+            qkv_weight = torch.cat([self.q.weight, self.k.weight, self.v.weight], dim=0)
+            qkv_bias = torch.cat([self.q.bias, self.k.bias, self.v.bias], dim=0) if self.q.bias is not None else None
+            qkv = F.linear(x, qkv_weight, qkv_bias)
+
+            q, k, v = einops.rearrange(
+                qkv, "bs s (three nh hd) -> three bs nh s hd", three=3, nh=self.num_heads
+            ).unbind(0)
+            output, k_dict, v_dict = self._attend(
+                q,
+                k,
+                v,
+                input_specs=input_specs,
+                attention_patterns=attention_patterns,
+                key_padding_mask=key_padding_mask,
+                freqs=freqs,
+            )
+            # Save anchor K/V for future cached inference.
+            new_cache = {
+                spec.name: {"k": k_dict[spec.name], "v": v_dict[spec.name]}
+                for spec in input_specs
+                if "_anchor" in spec.name
+            }
+
+        return self.proj(output), new_cache
+
+    @staticmethod
+    def _split_per_token_spec(
+        x: torch.Tensor,
+        input_specs: Sequence[TokenSpec],
+        split_dim: int,
+    ) -> dict[str, torch.Tensor]:
+        """Split ``x`` along ``split_dim`` according to ``input_specs`` sizes.
+
+        Args:
+            x: Tensor whose ``split_dim`` size equals the sum of input-spec sizes.
+            input_specs: Specs with non-``None`` ``size``.
+            split_dim: Axis along which to split.
+
+        Returns:
+            Dict mapping each ``input_specs`` name to its slice of ``x``.
+        """
+        sizes = [spec.size for spec in input_specs if spec.size is not None]
+        return {spec.name: chunk for spec, chunk in zip(input_specs, x.split(sizes, dim=split_dim), strict=True)}
+
+    @staticmethod
+    def _assemble_per_token_spec(
+        token_outputs: dict[str, torch.Tensor],
+        input_specs: Sequence[TokenSpec],
+    ) -> torch.Tensor:
+        """Concatenate per-name attention outputs in ``input_specs`` order and merge heads.
+
+        Args:
+            token_outputs: Per-name tensors of shape ``(B, num_heads, S_t, head_dim)``.
+            input_specs: Specs defining the assembly order.
+
+        Returns:
+            Tensor of shape ``(B, S, num_heads * head_dim)`` ready for the output projection.
+        """
+        parts = [token_outputs[spec.name] for spec in input_specs]
+        merged = torch.cat(parts, dim=2)
+        return einops.rearrange(merged, "bs nh s hd -> bs s (nh hd)")
+
+    def _attend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        input_specs: Sequence[TokenSpec],
+        attention_patterns: Sequence[AttentionPattern],
+        key_padding_mask: torch.Tensor | None = None,
+        freqs: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+        """Apply RoPE → split per spec → batched pattern attention → reassemble.
+
+        Args:
+            q, k, v: ``(B, num_heads, S, head_dim)`` tensors (already projected).
+            input_specs: Specs whose sizes sum to ``S``.
+            attention_patterns: Patterns to apply (already filtered for cached tokens, if any).
+            key_padding_mask: Optional ``(B, S)`` boolean mask. ``True`` = real token.
+            freqs: RoPE frequencies (used only when ``self.use_rope``).
+
+        Returns:
+            ``(output, k_dict, v_dict)``:
+            - ``output``: ``(B, S, num_heads * head_dim)`` ready for the output projection.
+            - ``k_dict``, ``v_dict``: per-name K/V tensors post-RoPE, useful for building a KV cache.
+        """
+        if self.use_rope and freqs is not None:
+            q, k = rope(q, freqs=freqs), rope(k, freqs=freqs)
+
+        q_dict = self._split_per_token_spec(q, input_specs, split_dim=2)
+        k_dict = self._split_per_token_spec(k, input_specs, split_dim=2)
+        v_dict = self._split_per_token_spec(v, input_specs, split_dim=2)
+
+        mask_dict: dict[str, torch.Tensor] | None = None
+        if key_padding_mask is not None:
+            mask_dict = self._split_per_token_spec(key_padding_mask, input_specs, split_dim=1)
 
         token_outputs = self._process_pattern_batched(
             attention_patterns=attention_patterns,
@@ -160,12 +239,8 @@ class MixedAttention(DotProductAttention):
             v_dict=v_dict,
             mask_dict=mask_dict,
         )
-
-        # Assemble output (only input tokens, in original order)
-        output_parts = [token_outputs[spec.name] for spec in input_specs]
-        output = torch.cat(output_parts, dim=2)
-        output = einops.rearrange(output, "bs nh s hd -> bs s (nh hd)")
-        return self.proj(output), new_cache
+        output = self._assemble_per_token_spec(token_outputs, input_specs)
+        return output, k_dict, v_dict
 
     def _process_pattern_batched(
         self,

--- a/src/noether/modeling/modules/blocks/transformer.py
+++ b/src/noether/modeling/modules/blocks/transformer.py
@@ -102,7 +102,7 @@ class TransformerBlock(nn.Module):
             if isinstance(attn_out, tuple):
                 attn_out, kv_cache = attn_out
             x = x + self.drop_path1(self.ls1(attn_out))
-            x = x + self.drop_path2(self.ls2(self.mlp(self.norm2(x))))
+            x = x + self.drop_path2(self.ls2(self._mlp_forward(self.norm2(x), attn_kwargs=attn_kwargs)))
         else:
             if condition is None:
                 raise ValueError(
@@ -130,8 +130,31 @@ class TransformerBlock(nn.Module):
             )
             x = x + self.drop_path2(
                 modulate_gate(
-                    self.ls2(self.mlp(modulate_scale_shift(self.norm2(x), scale=mlp_scale, shift=mlp_shift))),
+                    self.ls2(
+                        self._mlp_forward(
+                            modulate_scale_shift(self.norm2(x), scale=mlp_scale, shift=mlp_shift),
+                            attn_kwargs=attn_kwargs,
+                        )
+                    ),
                     gate=mlp_gate,
                 ),
             )
         return x, kv_cache
+
+    def _mlp_forward(self, x: torch.Tensor, attn_kwargs: dict[str, Any] | None = None) -> torch.Tensor:
+        """Apply the MLP sub-layer.
+
+        Override in subclasses that need to pass extra arguments to ``self.mlp``
+        (for example, a token-spec-aware MLP that must route tokens to per-type
+        weight banks). The default implementation ignores ``attn_kwargs`` and
+        calls ``self.mlp`` with just the input tensor.
+
+        Args:
+            x: Input to the MLP, shape ``(B, S, hidden_dim)``.
+            attn_kwargs: Same dict passed to :meth:`forward`; subclasses may read
+                extra keys (e.g., ``token_specs``) from it.
+
+        Returns:
+            MLP output, shape ``(B, S, hidden_dim)``.
+        """
+        return self.mlp(x)  # type: ignore[no-any-return]

--- a/src/noether/modeling/modules/untied.py
+++ b/src/noether/modeling/modules/untied.py
@@ -83,19 +83,34 @@ class UntiedLinear(nn.Module):
     3. Padded ``torch.bmm`` (moderate skew)
     4. Split + ``F.linear`` loop (heavy skew or very few groups)
 
+    Per-type weights are stored as independent 2D :class:`nn.Parameter` entries
+    in an :class:`nn.ParameterList` (one matrix per type). The bmm-based fast
+    paths stack them into a 3D tensor on the fly. Storing them as 2D is what
+    lets :class:`torch.optim.Muon` (which rejects non-2D parameters) update each
+    type's weight matrix independently.
+
     Domains must be strictly consecutive in ``token_specs``.
 
     Args:
         config: Number of types and shared linear-projection geometry.
     """
 
+    bias: nn.ParameterList | None
+
     def __init__(self, config: UntiedLinearConfig) -> None:
         super().__init__()
         self.num_types = config.num_types
         proj = config.linear_projection
         self.init_weights = proj.init_weights
-        self.weight = nn.Parameter(torch.empty(config.num_types, proj.output_dim, proj.input_dim))
-        self.bias = nn.Parameter(torch.zeros(config.num_types, proj.output_dim)) if proj.bias else None
+        self.input_dim = proj.input_dim
+        self.output_dim = proj.output_dim
+        self.weight = nn.ParameterList(
+            [nn.Parameter(torch.empty(proj.output_dim, proj.input_dim)) for _ in range(config.num_types)]
+        )
+        if proj.bias:
+            self.bias = nn.ParameterList([nn.Parameter(torch.zeros(proj.output_dim)) for _ in range(config.num_types)])
+        else:
+            self.bias = None
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
@@ -110,18 +125,32 @@ class UntiedLinear(nn.Module):
             for i in range(self.num_types):
                 nn.init.kaiming_uniform_(self.weight[i], a=math.sqrt(5))
                 if self.bias is not None:
-                    bound = 1 / math.sqrt(self.weight.shape[2])
+                    bound = 1 / math.sqrt(self.input_dim)
                     nn.init.uniform_(self.bias[i], -bound, bound)
         elif self.init_weights in ("truncnormal", "truncnormal002"):
-            nn.init.trunc_normal_(self.weight, std=0.02)
+            for i in range(self.num_types):
+                nn.init.trunc_normal_(self.weight[i], std=0.02)
             if self.bias is not None:
-                nn.init.zeros_(self.bias)
+                for i in range(self.num_types):
+                    nn.init.zeros_(self.bias[i])
         elif self.init_weights == "zeros":
-            nn.init.zeros_(self.weight)
+            for i in range(self.num_types):
+                nn.init.zeros_(self.weight[i])
             if self.bias is not None:
-                nn.init.zeros_(self.bias)
+                for i in range(self.num_types):
+                    nn.init.zeros_(self.bias[i])
         else:
             raise NotImplementedError(f"Initialization method {self.init_weights!r} not implemented for UntiedLinear.")
+
+    def _stacked_weight(self) -> torch.Tensor:
+        """Per-type weights stacked into a single ``(num_types, output_dim, input_dim)`` tensor."""
+        return torch.stack(list(self.weight))
+
+    def _stacked_bias(self) -> torch.Tensor | None:
+        """Per-type biases stacked into ``(num_types, output_dim)``, or ``None``."""
+        if self.bias is None:
+            return None
+        return torch.stack(list(self.bias))
 
     # ------------------------------------------------------------------
     # Forward — auto-selects the fastest code path
@@ -140,7 +169,7 @@ class UntiedLinear(nn.Module):
         """
         sizes = _domain_group_sizes(token_specs)
         B, S, D_in = x.shape
-        D_out = self.weight.shape[1]
+        D_out = self.output_dim
         T = len(sizes)
 
         if T == 0:
@@ -183,9 +212,10 @@ class UntiedLinear(nn.Module):
 
         Skips the transpose when ``D_in == D_out`` (square weight matrices).
         """
-        if self.weight.shape[-2] == self.weight.shape[-1]:
-            return self.weight
-        return self.weight.transpose(-2, -1).contiguous()
+        w = self._stacked_weight()
+        if w.shape[-2] == w.shape[-1]:
+            return w
+        return w.transpose(-2, -1).contiguous()
 
     def _equal_size_bmm_forward(
         self, x: torch.Tensor, n: int, B: int, S: int, D_in: int, D_out: int, T: int
@@ -194,8 +224,9 @@ class UntiedLinear(nn.Module):
         x_r = x.view(B, T, n, D_in).transpose(0, 1).contiguous()
         out = torch.bmm(x_r.view(T, B * n, D_in), self._weight_for_bmm())
         out = out.view(T, B, n, D_out).transpose(0, 1).contiguous().view(B, S, D_out)
-        if self.bias is not None:
-            out = out + self.bias.repeat_interleave(n, dim=0).view(1, S, D_out)
+        bias = self._stacked_bias()
+        if bias is not None:
+            out = out + bias.repeat_interleave(n, dim=0).view(1, S, D_out)
         return out
 
     def _padded_bmm_forward(
@@ -215,9 +246,10 @@ class UntiedLinear(nn.Module):
         out = torch.bmm(padded.view(T, B * max_n, D_in), self._weight_for_bmm())
         out = out.view(T, B, max_n, D_out)
         result = torch.cat([out[t, :, : sizes[t]] for t in range(T)], dim=1)
-        if self.bias is not None:
+        bias = self._stacked_bias()
+        if bias is not None:
             type_ids = torch.cat([torch.full((s,), t, dtype=torch.long, device=x.device) for t, s in enumerate(sizes)])
-            result = result + self.bias[type_ids].view(1, S, D_out)
+            result = result + bias[type_ids].view(1, S, D_out)
         return result
 
     def _grouped_mm_forward(
@@ -236,12 +268,13 @@ class UntiedLinear(nn.Module):
                 path only supports ``B=1``).
         """
         w = self._weight_for_bmm()
+        bias = self._stacked_bias()
         if all(s == sizes[0] for s in sizes):
             # Equal-size: use 3D mat_a → no offs, cleanest path.
             n = sizes[0]
             # (B, S, D_in) → (B, T, n, D_in) → (T, B, n, D_in) → (T, B*n, D_in)
             mat_a = x.view(B, T, n, D_in).transpose(0, 1).contiguous().view(T, B * n, D_in)
-            out = F.grouped_mm(mat_a, w, bias=self.bias)  # (T, B*n, D_out)
+            out = F.grouped_mm(mat_a, w, bias=bias)  # (T, B*n, D_out)
             return out.view(T, B, n, D_out).transpose(0, 1).contiguous().view(B, S, D_out)
         else:
             # Unequal-size: 2D mat_a + offs. Requires per-batch flattening
@@ -253,7 +286,7 @@ class UntiedLinear(nn.Module):
                 raise ValueError("grouped_mm with unequal domain sizes requires B=1")
             mat_a = x.view(S, D_in)
             offs = torch.tensor(sizes, dtype=torch.int32, device=x.device).cumsum(0, dtype=torch.int32)
-            out = F.grouped_mm(mat_a, w, offs=offs, bias=self.bias)  # (S, D_out)
+            out = F.grouped_mm(mat_a, w, offs=offs, bias=bias)  # (S, D_out)
             return out.view(1, S, D_out)
 
 

--- a/src/noether/modeling/modules/untied.py
+++ b/src/noether/modeling/modules/untied.py
@@ -1,0 +1,699 @@
+#  Copyright © 2025 Emmi AI GmbH. All rights reserved.
+
+import math
+from collections.abc import Sequence
+from typing import Any, cast
+
+import einops
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from noether.core.schemas.modules.attention import AttentionConfig, AttentionPattern, TokenSpec
+from noether.core.schemas.modules.layers import LinearProjectionConfig
+from noether.core.schemas.modules.untied import (
+    UntiedLinearConfig,
+    UntiedMixedAttentionConfig,
+    UntiedMLPConfig,
+    UntiedPerceiverBlockConfig,
+    UntiedTransformerBlockConfig,
+)
+from noether.modeling.functional.modulation import modulate_gate, modulate_scale_shift
+from noether.modeling.functional.rope import rope
+from noether.modeling.modules.activations import Activation
+from noether.modeling.modules.attention.anchor_attention.mixed import MixedAttention
+from noether.modeling.modules.attention.anchor_attention.multi_branch import MultiBranchAnchorAttention
+from noether.modeling.modules.attention.perceiver import PerceiverAttention
+from noether.modeling.modules.blocks.perceiver import PerceiverBlock
+from noether.modeling.modules.blocks.transformer import TransformerBlock
+
+
+def _domain_group_sizes(token_specs: Sequence[TokenSpec]) -> list[int]:
+    """Sum token sizes per domain, verifying that domains are strictly consecutive.
+
+    Domains are derived from :attr:`TokenSpec.domain` (first ``_``-delimited segment
+    of the name, e.g. ``"surface"`` from ``"surface_anchors"``).  Multiple specs
+    can belong to the same domain (e.g. ``surface_anchors`` and ``surface_queries``);
+    their sizes are summed into a single group.
+
+    Raises:
+        ValueError: If specs of the same domain are not adjacent (e.g.
+            ``[surface_anchors, volume_anchors, surface_queries]`` has
+            ``"surface"`` split across non-adjacent positions).
+
+    Returns:
+        Per-domain sizes in the order the domains first appear.
+    """
+    sizes: list[int] = []
+    seen_domains: set[str] = set()
+    current_domain: str | None = None
+    current_size = 0
+
+    for spec in token_specs:
+        if spec.size is None or spec.size == 0:
+            continue
+        domain = spec.domain
+        if domain != current_domain:
+            if domain in seen_domains:
+                raise ValueError(
+                    f"Domain '{domain}' is not consecutive in token_specs. Specs for the same domain must be adjacent."
+                )
+            if current_domain is not None:
+                sizes.append(current_size)
+                seen_domains.add(current_domain)
+            current_domain = domain
+            current_size = spec.size
+        else:
+            current_size += spec.size
+
+    if current_domain is not None:
+        sizes.append(current_size)
+
+    return sizes
+
+
+class UntiedLinear(nn.Module):
+    """Linear layer with per-domain weight banks.
+
+    Groups token specs by :attr:`TokenSpec.domain` and applies a separate
+    ``F.linear`` per domain. Automatically picks the fastest strategy at runtime:
+
+    1. ``torch._grouped_mm`` (CUDA, equal-size groups)
+    2. Reshape + single ``torch.bmm`` (equal-size groups, any device)
+    3. Padded ``torch.bmm`` (moderate skew)
+    4. Split + ``F.linear`` loop (heavy skew or very few groups)
+
+    Domains must be strictly consecutive in ``token_specs``.
+
+    Args:
+        config: Number of types and shared linear-projection geometry.
+    """
+
+    def __init__(self, config: UntiedLinearConfig) -> None:
+        super().__init__()
+        self.num_types = config.num_types
+        proj = config.linear_projection
+        self.init_weights = proj.init_weights
+        self.weight = nn.Parameter(torch.empty(config.num_types, proj.output_dim, proj.input_dim))
+        self.bias = nn.Parameter(torch.zeros(config.num_types, proj.output_dim)) if proj.bias else None
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Initialize the per-type weight banks following :class:`LinearProjection`'s scheme.
+
+        Supported modes (from ``config.linear_projection.init_weights``):
+        ``"torch"`` (PyTorch ``nn.Linear`` defaults, applied per type),
+        ``"truncnormal"`` / ``"truncnormal002"`` (truncated normal, std=0.02, zero bias),
+        ``"zeros"`` (zero weight and bias).
+        """
+        if self.init_weights == "torch":
+            for i in range(self.num_types):
+                nn.init.kaiming_uniform_(self.weight[i], a=math.sqrt(5))
+                if self.bias is not None:
+                    bound = 1 / math.sqrt(self.weight.shape[2])
+                    nn.init.uniform_(self.bias[i], -bound, bound)
+        elif self.init_weights in ("truncnormal", "truncnormal002"):
+            nn.init.trunc_normal_(self.weight, std=0.02)
+            if self.bias is not None:
+                nn.init.zeros_(self.bias)
+        elif self.init_weights == "zeros":
+            nn.init.zeros_(self.weight)
+            if self.bias is not None:
+                nn.init.zeros_(self.bias)
+        else:
+            raise NotImplementedError(f"Initialization method {self.init_weights!r} not implemented for UntiedLinear.")
+
+    # ------------------------------------------------------------------
+    # Forward — auto-selects the fastest code path
+    # ------------------------------------------------------------------
+
+    def forward(self, x: torch.Tensor, token_specs: Sequence[TokenSpec]) -> torch.Tensor:
+        """Apply per-domain linear projections.
+
+        Args:
+            x: Input tensor ``(B, S, D_in)`` with tokens concatenated in
+                ``token_specs`` order.  Specs for the same domain must be adjacent.
+            token_specs: Token specifications whose sizes sum to ``S``.
+
+        Returns:
+            Output tensor ``(B, S, D_out)`` in the same positional order as ``x``.
+        """
+        sizes = _domain_group_sizes(token_specs)
+        B, S, D_in = x.shape
+        D_out = self.weight.shape[1]
+        T = len(sizes)
+
+        if T == 0:
+            return x.new_empty(B, 0, D_out)
+
+        # 1) Grouped GEMM via F.grouped_mm (when available).
+        # currently only optmized for bfloat16 on CUDA.
+        if x.dtype == torch.bfloat16:
+            try:
+                return self._grouped_mm_forward(x, sizes, B, S, D_in, D_out, T)
+            except (RuntimeError, NotImplementedError, ValueError):
+                pass
+
+        # 2) Equal-size reshape + bmm (fastest for balanced distributions).
+        if all(s == sizes[0] for s in sizes):
+            return self._equal_size_bmm_forward(x, sizes[0], B, S, D_in, D_out, T)
+
+        # 3) Padded bmm when overhead is modest (T * max_n ≤ 1.1 * S).
+        max_n = max(sizes)
+        if max_n * T <= 1.1 * S:
+            return self._padded_bmm_forward(x, sizes, B, S, D_in, D_out, T, max_n)
+
+        # 4) Split + F.linear loop (fallback for heavy skew).
+        return self._split_loop_forward(x, sizes, D_out)
+
+    def _split_loop_forward(self, x: torch.Tensor, sizes: list[int], D_out: int) -> torch.Tensor:
+        """Split along seq-dim and apply :func:`F.linear` per type."""
+        chunks = x.split(sizes, dim=1)
+        out_chunks: list[torch.Tensor] = []
+        for t, chunk in enumerate(chunks):
+            if chunk.shape[1] > 0:
+                bias_t = self.bias[t] if self.bias is not None else None
+                out_chunks.append(F.linear(chunk, self.weight[t], bias_t))
+            else:
+                out_chunks.append(chunk.new_empty(x.shape[0], 0, D_out))
+        return torch.cat(out_chunks, dim=1)
+
+    def _weight_for_bmm(self) -> torch.Tensor:
+        """Return weight shaped ``(T, D_in, D_out)`` for right-multiplication.
+
+        Skips the transpose when ``D_in == D_out`` (square weight matrices).
+        """
+        if self.weight.shape[-2] == self.weight.shape[-1]:
+            return self.weight
+        return self.weight.transpose(-2, -1).contiguous()
+
+    def _equal_size_bmm_forward(
+        self, x: torch.Tensor, n: int, B: int, S: int, D_in: int, D_out: int, T: int
+    ) -> torch.Tensor:
+        """Reshape + bmm when every domain has ``n`` tokens."""
+        x_r = x.view(B, T, n, D_in).transpose(0, 1).contiguous()
+        out = torch.bmm(x_r.view(T, B * n, D_in), self._weight_for_bmm())
+        out = out.view(T, B, n, D_out).transpose(0, 1).contiguous().view(B, S, D_out)
+        if self.bias is not None:
+            out = out + self.bias.repeat_interleave(n, dim=0).view(1, S, D_out)
+        return out
+
+    def _padded_bmm_forward(
+        self,
+        x: torch.Tensor,
+        sizes: list[int],
+        B: int,
+        S: int,
+        D_in: int,
+        D_out: int,
+        T: int,
+        max_n: int,
+    ) -> torch.Tensor:
+        """Pad each chunk to ``max_n``, one bmm, then unpad."""
+        chunks = x.split(sizes, dim=1)
+        padded = torch.stack([F.pad(c, (0, 0, 0, max_n - c.shape[1])) for c in chunks])
+        out = torch.bmm(padded.view(T, B * max_n, D_in), self._weight_for_bmm())
+        out = out.view(T, B, max_n, D_out)
+        result = torch.cat([out[t, :, : sizes[t]] for t in range(T)], dim=1)
+        if self.bias is not None:
+            type_ids = torch.cat([torch.full((s,), t, dtype=torch.long, device=x.device) for t, s in enumerate(sizes)])
+            result = result + self.bias[type_ids].view(1, S, D_out)
+        return result
+
+    def _grouped_mm_forward(
+        self, x: torch.Tensor, sizes: list[int], B: int, S: int, D_in: int, D_out: int, T: int
+    ) -> torch.Tensor:
+        """Apply per-domain projections via :func:`torch.nn.functional.grouped_mm`.
+
+        Uses the 3D path when all domain sizes are equal (no ``offs`` needed),
+        or the 2D+offs path for unequal sizes.
+
+        Raises:
+            RuntimeError: When ``grouped_mm`` is not supported (wrong device,
+                unaligned strides, unsupported dtype, …).
+            NotImplementedError: When ``grouped_mm`` is not available.
+            ValueError: When ``B > 1`` with unequal domain sizes (the 2D+offs
+                path only supports ``B=1``).
+        """
+        w = self._weight_for_bmm()
+        if all(s == sizes[0] for s in sizes):
+            # Equal-size: use 3D mat_a → no offs, cleanest path.
+            n = sizes[0]
+            # (B, S, D_in) → (B, T, n, D_in) → (T, B, n, D_in) → (T, B*n, D_in)
+            mat_a = x.view(B, T, n, D_in).transpose(0, 1).contiguous().view(T, B * n, D_in)
+            out = F.grouped_mm(mat_a, w, bias=self.bias)  # (T, B*n, D_out)
+            return out.view(T, B, n, D_out).transpose(0, 1).contiguous().view(B, S, D_out)
+        else:
+            # Unequal-size: 2D mat_a + offs. Requires per-batch flattening
+            # where all of type-t's tokens are contiguous — achievable by
+            # permuting (B, [n0|n1|...], D) to type-major order within each batch.
+            # For B>1 this would repeat each group's rows B times, so we only
+            # take this path for B=1 to keep it simple.
+            if B != 1:
+                raise ValueError("grouped_mm with unequal domain sizes requires B=1")
+            mat_a = x.view(S, D_in)
+            offs = torch.tensor(sizes, dtype=torch.int32, device=x.device).cumsum(0, dtype=torch.int32)
+            out = F.grouped_mm(mat_a, w, offs=offs, bias=self.bias)  # (S, D_out)
+            return out.view(1, S, D_out)
+
+
+class UntiedMixedAttention(MixedAttention):
+    """Multi-head attention with per-type QKV and output projections.
+
+    Each token type has its own QKV and output projection weights (via
+    :class:`UntiedLinear`). The attention computation is pattern-aware, mirroring
+    :class:`~noether.modeling.modules.attention.anchor_attention.mixed.MixedAttention`:
+
+    - If ``attention_patterns`` is supplied (typically by a wrapping
+      :class:`~noether.modeling.modules.attention.anchor_attention.multi_branch.MultiBranchAnchorAttention`
+      such as ``SelfAnchorAttention``/``CrossAnchorAttention``/``JointAnchorAttention``),
+      those patterns are honored.
+    - If no patterns are supplied (standalone usage), it falls back to a single
+      all-to-all pattern — every token attends to every other token.
+
+    This lets the same module act as either a drop-in pattern-free attention or
+    the inner workhorse of a multi-branch anchor attention, while keeping QKV
+    and output projection weights untied per token type.
+
+    Args:
+        config: Configuration specifying attention dims and ``num_types``.
+    """
+
+    def __init__(self, config: UntiedMixedAttentionConfig) -> None:
+        super().__init__(config=config)
+
+        # Replace the shared nn.Linear projections with per-type untied ones.
+        self.q = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
+        self.k = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
+        self.v = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
+        self.proj = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
+
+    def forward(  # type: ignore[override]
+        self,
+        x: torch.Tensor,
+        token_specs: Sequence[TokenSpec],
+        attention_patterns: Sequence[AttentionPattern],
+        key_padding_mask: torch.Tensor | None = None,
+        freqs: torch.Tensor | None = None,
+        kv_cache: dict[str, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        """Apply attention with per-type QKV/output projections.
+
+        Positional argument order matches :meth:`MixedAttention.forward` so this
+        module is a drop-in replacement for the shared ``MixedAttention`` that
+        :class:`MultiBranchAnchorAttention` owns — a wrapping anchor attention
+        can call ``self.mixed_attention(x, token_specs, patterns, ...)`` unchanged.
+
+        Args:
+            x: Input tensor ``(B, S, D)`` with tokens concatenated in ``token_specs`` order.
+                ``S`` must equal the sum of ``token_specs`` sizes.
+            token_specs: Token specifications defining the input structure.
+            attention_patterns: Optional attention patterns. When ``None``,
+                falls back to a single all-to-all pattern over every name in
+                ``token_specs`` (standalone usage).
+            key_padding_mask: Optional boolean mask ``(B, S)``. ``True`` = real token.
+            freqs: RoPE frequencies for positional encoding.
+            kv_cache: Optional dictionary for caching key/value tensors. Not yet supported.
+
+        Returns:
+            Output tensor ``(B, S, D)``.
+        """
+        if kv_cache is not None:
+            raise NotImplementedError("UntiedMixedAttention does not yet support kv caching.")
+
+        input_specs = [s for s in token_specs if s.size is not None]
+        self._validate_inputs(x, input_specs, attention_patterns, key_padding_mask, freqs)
+
+        q = einops.rearrange(self.q(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
+        k = einops.rearrange(self.k(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
+        v = einops.rearrange(self.v(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
+
+        output, _, _ = self._attend(
+            q,
+            k,
+            v,
+            input_specs=input_specs,
+            attention_patterns=attention_patterns,
+            key_padding_mask=key_padding_mask,
+            freqs=freqs,
+        )
+
+        # Per-type output projection.
+        projected: torch.Tensor = self.proj(output, token_specs)
+        return projected
+
+
+class UntiedPerceiverAttention(PerceiverAttention):
+    """Perceiver cross-attention with per-type Q and output projections.
+
+    The Q and output projections are :class:`UntiedLinear` layers (one weight
+    bank per token type), while the KV projection remains a shared
+    ``nn.Linear`` since it operates on a single source (e.g. geometry encoding).
+
+    Args:
+        config: Attention configuration (``AttentionConfig``-compatible).
+        num_types: Number of distinct token types for per-type projections.
+    """
+
+    def __init__(self, config: AttentionConfig, num_types: int) -> None:
+        super().__init__(config=config)
+        # Replace the shared Q and output projections with per-type versions.
+        hidden_dim = self.num_heads * self.head_dim
+        self.q = UntiedLinear(  # type: ignore[assignment]
+            UntiedLinearConfig(
+                num_types=num_types,
+                linear_projection=LinearProjectionConfig(
+                    input_dim=hidden_dim,
+                    output_dim=hidden_dim,
+                    bias=self.q.bias is not None,
+                    init_weights=self.init_weights,
+                ),
+            )
+        )
+        self.proj = UntiedLinear(  # type: ignore[assignment]
+            UntiedLinearConfig(
+                num_types=num_types,
+                linear_projection=LinearProjectionConfig(
+                    input_dim=hidden_dim,
+                    output_dim=hidden_dim,
+                    bias=self.proj.bias is not None,
+                    init_weights=self.init_weights,
+                ),
+            )
+        )
+
+    def forward(  # type: ignore[override]
+        self,
+        q: torch.Tensor,
+        token_specs: Sequence[TokenSpec],
+        kv: torch.Tensor | None = None,
+        attn_mask: torch.Tensor | None = None,
+        q_freqs: torch.Tensor | None = None,
+        k_freqs: torch.Tensor | None = None,
+        kv_cache: dict[str, torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor] | None]:
+        """Forward pass with per-type Q and output projections.
+
+        Args:
+            q: Query tensor ``(B, S, hidden_dim)`` with tokens concatenated
+                in ``token_specs`` order.
+            token_specs: Token specifications defining the per-type structure.
+            kv: Key/value tensor from a single source (e.g. geometry).
+                Can be ``None`` when ``kv_cache`` is provided.
+            attn_mask: Optional attention mask.
+            q_freqs: RoPE frequencies for queries.
+            k_freqs: RoPE frequencies for keys.
+            kv_cache: Cached K/V tensors from a previous forward pass.
+
+        Returns:
+            Tuple of (output, new_kv_cache).
+        """
+        # Per-type Q projection.
+        q = self.q(q, token_specs)
+        q = einops.rearrange(
+            q,
+            "bs seqlen_q (num_heads head_dim) -> bs num_heads seqlen_q head_dim",
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+        )
+
+        if kv_cache is not None:
+            k = kv_cache["k"]
+            v = kv_cache["v"]
+            new_cache = None
+        else:
+            if kv is None:
+                raise ValueError("Either kv or kv_cache must be provided.")
+            kv_weight = torch.cat([self.k.weight, self.v.weight], dim=0)
+            kv_bias = torch.cat([self.k.bias, self.v.bias], dim=0) if self.k.bias is not None else None
+            kv_proj = F.linear(kv, kv_weight, kv_bias)
+
+            k, v = einops.rearrange(
+                kv_proj,
+                "bs seqlen_kv (two num_heads head_dim) -> two bs num_heads seqlen_kv head_dim",
+                two=2,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+            ).unbind(0)
+
+            if self.use_rope:
+                assert k_freqs is not None
+                k = rope(k, freqs=k_freqs)
+
+            new_cache = {"k": k, "v": v}
+
+        if self.use_rope:
+            assert q_freqs is not None
+            q = rope(q, freqs=q_freqs)
+
+        x = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_mask, dropout_p=self.dropout if self.training else 0.0
+        )
+        x = einops.rearrange(x, "bs num_heads seqlen head_dim -> bs seqlen (num_heads head_dim)")
+
+        # Per-type output projection.
+        return self.proj_dropout(self.proj(x, token_specs)), new_cache
+
+
+class UntiedMLP(nn.Module):
+    """Multi-layer perceptron with per-type weights.
+
+    Mirrors the topology of :class:`MLP` (input -> [hidden]*(num_layers+1) -> output,
+    with activations between layers), but uses :class:`UntiedLinear` for every
+    linear layer so each token type learns independent weights.
+
+    Args:
+        config: Configuration for the untied MLP.
+    """
+
+    def __init__(self, config: UntiedMLPConfig) -> None:
+        super().__init__()
+        mlp = config.mlp
+        # Layer dims mirror MLP: input -> hidden (x num_layers+1) -> output.
+        dims = [mlp.input_dim] + [mlp.hidden_dim] * (mlp.num_layers + 1) + [mlp.output_dim]
+        self.layers = nn.ModuleList(
+            [
+                UntiedLinear(
+                    UntiedLinearConfig(
+                        num_types=config.num_types,
+                        linear_projection=LinearProjectionConfig(
+                            input_dim=in_d,
+                            output_dim=out_d,
+                            init_weights=mlp.init_weights,
+                        ),
+                    )
+                )
+                for in_d, out_d in zip(dims[:-1], dims[1:], strict=True)
+            ]
+        )
+        self.activation = Activation[mlp.activation].build()
+
+    def forward(self, x: torch.Tensor, token_specs: Sequence[TokenSpec]) -> torch.Tensor:
+        """Apply the untied MLP.
+
+        Args:
+            x: Input tensor ``(B, S, mlp_config.input_dim)``.
+            token_specs: Token specifications defining the input structure.
+
+        Returns:
+            Output tensor ``(B, S, mlp_config.output_dim)``.
+        """
+        last = len(self.layers) - 1
+        for i, layer in enumerate(self.layers):
+            x = layer(x, token_specs)
+            if i < last:
+                x = self.activation(x)
+        return x
+
+
+class UntiedTransformerBlock(TransformerBlock):
+    """Pre-norm transformer block with per-type (untied) attention and MLP weights.
+
+    Same architecture and control flow as :class:`TransformerBlock`; only the
+    attention and MLP sub-modules differ. The parent's ``__init__`` builds all
+    the shared plumbing (norms, modulation, layer scale, drop path, and the
+    full forward pass) — including whichever attention module the configured
+    ``attention_constructor`` selects. This subclass then:
+
+    1. Replaces ``self.mlp`` with :class:`UntiedMLP`.
+    2. Injects per-type QKV/output projections into the attention sub-layer
+       **without disturbing its attention pattern**:
+
+       - When the parent built a
+         :class:`~noether.modeling.modules.attention.anchor_attention.multi_branch.MultiBranchAnchorAttention`
+         (``SelfAnchorAttention`` / ``CrossAnchorAttention`` / ``JointAnchorAttention``),
+         only its inner ``mixed_attention`` is swapped for
+         :class:`UntiedMixedAttention`. The outer wrapper keeps emitting the
+         correct per-branch attention patterns — so ``self_untied`` behaves
+         like ``self`` with untied weights (not like a joint attention).
+       - Otherwise (default ``dot_product`` attention, or any other non-multi-branch
+         constructor) ``self.attention_block`` is replaced outright with
+         :class:`UntiedMixedAttention`, which falls back to a single all-to-all
+         pattern.
+
+    3. Overrides :meth:`_mlp_forward` to route ``token_specs`` from
+       ``attn_kwargs`` into :class:`UntiedMLP`.
+
+    Attention receives ``token_specs`` automatically because the parent's
+    forward passes ``**attn_kwargs`` to ``self.attention_block``, which in turn
+    forwards them on to the inner :class:`UntiedMixedAttention`.
+
+    Args:
+        config: Configuration for the untied transformer block.
+    """
+
+    def __init__(self, config: UntiedTransformerBlockConfig) -> None:
+        super().__init__(config=config.transformer_block)
+        self.num_types = config.num_types
+        # Replace the shared MLP with per-type weights.
+        self.mlp = UntiedMLP(config=config.untied_mlp_config)  # type: ignore[arg-type,assignment]
+        # Inject per-type QKV/output projections into the attention sub-layer.
+        # For a MultiBranchAnchorAttention wrapper we swap only the inner
+        # mixed_attention so that its pattern-emission logic is preserved.
+        untied_attention = UntiedMixedAttention(config=config.attention_config)  # type: ignore[arg-type]
+        if isinstance(self.attention_block, MultiBranchAnchorAttention):
+            self.attention_block.mixed_attention = untied_attention
+        else:
+            self.attention_block = untied_attention  # type: ignore[assignment]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        condition: torch.Tensor | None = None,
+        attn_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, dict[str, torch.Tensor]] | None]:
+        """Validate ``token_specs`` upfront, then delegate to :meth:`TransformerBlock.forward`.
+
+        The untied weight banks are indexed by name-order in ``token_specs``, so
+        duplicates would silently merge types and missing types would index out
+        of range. We check here (before attention runs) to surface a clear error.
+        """
+        if attn_kwargs is None or attn_kwargs.get("token_specs") is None:
+            raise ValueError("attn_kwargs must be provided with 'token_specs' key for UntiedTransformerBlock.")
+        token_specs = cast("Sequence[TokenSpec]", attn_kwargs["token_specs"])
+        # _domain_group_sizes asserts that domains are strictly consecutive and
+        # returns one size per domain. We further check that the number of
+        # domains matches the weight bank count.
+        domain_sizes = _domain_group_sizes(token_specs)
+        assert len(domain_sizes) == self.num_types, (
+            f"Number of domains in token_specs ({len(domain_sizes)}) must match num_types ({self.num_types})."
+        )
+        return super().forward(x, condition=condition, attn_kwargs=attn_kwargs)
+
+    def _mlp_forward(self, x: torch.Tensor, attn_kwargs: dict[str, Any] | None = None) -> torch.Tensor:
+        """Call :class:`UntiedMLP` with ``token_specs`` routed from ``attn_kwargs``.
+
+        ``token_specs`` is guaranteed non-None here because :meth:`forward`
+        validates upfront before delegating.
+        """
+        assert attn_kwargs is not None  # forward() has already validated this
+        token_specs = cast("Sequence[TokenSpec]", attn_kwargs["token_specs"])
+        out: torch.Tensor = self.mlp(x, token_specs)
+        return out
+
+
+class UntiedPerceiverBlock(PerceiverBlock):
+    """Perceiver block with per-type (untied) Q/output projections and MLP weights.
+
+    Same architecture and control flow as :class:`PerceiverBlock`; the Q and
+    output projections in the attention module become per-type via
+    :class:`UntiedPerceiverAttention`, and the feed-forward MLP becomes
+    :class:`UntiedMLP`. The KV projection remains shared since it operates on
+    a single source (e.g. geometry encoding).
+
+    ``token_specs`` must be provided via ``attn_kwargs["token_specs"]``.
+
+    Args:
+        config: Configuration for the untied perceiver block.
+    """
+
+    def __init__(self, config: UntiedPerceiverBlockConfig) -> None:
+        super().__init__(config=config.perceiver_block_config)
+        self.num_types = config.num_types
+        block = config.perceiver_block_config
+        # Replace shared attention with per-type Q/output projections.
+        self.attn = UntiedPerceiverAttention(  # type: ignore[assignment]
+            config=block.perceiver_attention_config,  # type: ignore[arg-type]
+            num_types=config.num_types,
+        )
+        # Replace shared MLP with per-type MLP.
+        self.mlp = UntiedMLP(config=config.untied_mlp_config)  # type: ignore
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor | None = None,
+        condition: torch.Tensor | None = None,
+        attn_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor] | None]:
+        """Forward pass with per-type Q/output projections and MLP.
+
+        Validates ``token_specs`` upfront, then runs the same perceiver block
+        logic as the parent with ``token_specs`` routed to the untied sub-modules.
+
+        Args:
+            q: Query tensor ``(B, S, hidden_dim)`` with tokens from all domains
+                concatenated in ``token_specs`` order.
+            kv: Key/value tensor from a single source (e.g. geometry encoding).
+                Can be ``None`` when ``kv_cache`` is provided in ``attn_kwargs``.
+            condition: Optional conditioning vector for modulation.
+            attn_kwargs: Must contain ``"token_specs"`` key. Other entries
+                (``kv_cache``, RoPE frequencies, masks) are forwarded to attention.
+
+        Returns:
+            Tuple of (output, kv_cache).
+        """
+        if attn_kwargs is None or attn_kwargs.get("token_specs") is None:
+            raise ValueError("attn_kwargs must be provided with 'token_specs' key for UntiedPerceiverBlock.")
+        token_specs = cast("Sequence[TokenSpec]", attn_kwargs["token_specs"])
+        domain_sizes = _domain_group_sizes(token_specs)
+        assert len(domain_sizes) == self.num_types, (
+            f"Number of domains in token_specs ({len(domain_sizes)}) must match num_types ({self.num_types})."
+        )
+
+        # Separate token_specs from kwargs forwarded to attention.
+        fwd_kwargs = {k: v for k, v in attn_kwargs.items() if k != "token_specs"}
+        use_cached_kv = fwd_kwargs.get("kv_cache") is not None
+
+        if self.modulation is None:
+            if condition is not None:
+                raise ValueError("Conditioning vector provided, but modulation is not configured.")
+            attn_out, kv_cache_out = self.attn(
+                q=self.norm1q(q), token_specs=token_specs, kv=self.norm1kv(kv) if kv is not None else None, **fwd_kwargs
+            )
+            q = q + self.drop_path1(self.ls1(attn_out))
+            q = q + self.drop_path2(self.ls2(self.mlp(self.norm2(q), token_specs)))
+        else:
+            if condition is None:
+                raise ValueError("No conditioning vector provided, but modulation is configured.")
+            mod = self.modulation(condition)
+            hd = self.norm1q.normalized_shape[0]
+            kd = self._kv_dim
+            q_scale, q_shift, kv_scale, kv_shift, attn_gate, mlp_scale, mlp_shift, mlp_gate = mod.split(
+                [hd, hd, kd, kd, hd, hd, hd, hd], dim=-1
+            )
+            if use_cached_kv:
+                normed_kv = None
+            else:
+                assert kv is not None, "kv must be provided when not using kv_cache"
+                normed_kv = modulate_scale_shift(self.norm1kv(kv), scale=kv_scale, shift=kv_shift)
+
+            attn_out, kv_cache_out = self.attn(
+                q=modulate_scale_shift(self.norm1q(q), scale=q_scale, shift=q_shift),
+                token_specs=token_specs,
+                kv=normed_kv,
+                **fwd_kwargs,
+            )
+            q = q + self.drop_path1(modulate_gate(self.ls1(attn_out), gate=attn_gate))
+            q = q + self.drop_path2(
+                modulate_gate(
+                    self.ls2(
+                        self.mlp(
+                            modulate_scale_shift(self.norm2(q), scale=mlp_scale, shift=mlp_shift),
+                            token_specs,
+                        ),
+                    ),
+                    gate=mlp_gate,
+                ),
+            )
+        return q, kv_cache_out

--- a/tests/unit/noether/modeling/models/test_ab_upt.py
+++ b/tests/unit/noether/modeling/models/test_ab_upt.py
@@ -617,7 +617,7 @@ class TestAnchoredBranchedUPTUntied:
         for cfg in constructor_configs:
             assert cfg.num_types == num_domains
             # The nested TransformerBlockConfig should be carried through intact.
-            assert cfg.transformer_block_config.hidden_dim == untied_config.hidden_dim
+            assert cfg.transformer_block.hidden_dim == untied_config.hidden_dim
 
     def test_untied_blocks_have_independent_parameters(self, untied_config):
         """Each ``UntiedTransformerBlock`` contributes its own distinct parameters.
@@ -636,7 +636,7 @@ class TestAnchoredBranchedUPTUntied:
         ):
             model = AnchoredBranchedUPT(config=untied_config)
 
-        # Each untied block's q/k/v weight banks have shape (num_types, H, H);
+        # Each untied block's q/k/v weight banks hold one 2D Parameter per type;
         # disjoint parameter tensors across blocks means no accidental sharing.
         # For AB-UPT, ``attention_block`` is a MultiBranchAnchorAttention wrapper
         # (Self/Cross/JointAnchorAttention); its inner ``mixed_attention`` is the
@@ -648,7 +648,7 @@ class TestAnchoredBranchedUPTUntied:
             proj_ids = {id(getattr(b.attention_block.mixed_attention, proj_name).weight) for b in untied_blocks}
             assert len(proj_ids) == 3, f"each UntiedTransformerBlock must hold its own {proj_name} weight tensor"
             for b in untied_blocks:
-                assert getattr(b.attention_block.mixed_attention, proj_name).weight.shape[0] == num_types
+                assert len(getattr(b.attention_block.mixed_attention, proj_name).weight) == num_types
 
     def test_untied_block_uses_configured_attention_constructor(self, untied_config):
         """``*_untied`` blocks must honor the configured ``attention_constructor``.

--- a/tests/unit/noether/modeling/models/test_ab_upt.py
+++ b/tests/unit/noether/modeling/models/test_ab_upt.py
@@ -33,6 +33,16 @@ class FakeTransformerBlock(nn.Module):
         return x, None
 
 
+class FakeUntiedTransformerBlock(nn.Module):
+    """Fake drop-in for UntiedTransformerBlock. Matches (x, kv_cache) return shape."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, x, *args, **kwargs):
+        return x, None
+
+
 class FakeGenericModule(nn.Module):
     """Generic replacement for other modules."""
 
@@ -382,3 +392,336 @@ class TestThreeDomainABUPT:
         assert "query_wake_turbulence" in predictions
         assert predictions["query_wake_turbulence"].shape == (batch_size, 5, 2)
         assert "query_surface_pressure" not in predictions
+
+
+@pytest.fixture
+def untied_config():
+    """Two-domain config using the three ``*_untied`` physics block variants."""
+    data_specs = ModelDataSpecs(
+        position_dim=3,
+        conditioning_dims=FieldDimSpec({"mach_number": 1, "alpha": 1}),
+        domains={
+            "surface": DomainDataSpec(
+                output_dims=FieldDimSpec({"pressure": 1, "shear_stress": 3}),
+                feature_dim=FieldDimSpec({"area": 1}),
+            ),
+            "volume": DomainDataSpec(
+                output_dims=FieldDimSpec({"velocity": 3, "pressure": 1}),
+                feature_dim=FieldDimSpec({"sdf": 1}),
+            ),
+        },
+    )
+
+    tf_config = TransformerBlockConfig(
+        hidden_dim=64,
+        num_heads=4,
+        mlp_expansion_factor=4.0,
+        use_bias=True,
+        use_rope=True,
+        dropout=0.0,
+    )
+
+    pool_config = SupernodePoolingConfig(
+        hidden_dim=64,
+        input_dim=3,
+        radius=0.1,
+        k=None,
+    )
+
+    return AnchorBranchedUPTConfig(
+        kind="AnchoredBranchedUPT",
+        name="ab_upt_untied_test",
+        hidden_dim=64,
+        geometry_depth=1,
+        physics_blocks=["perceiver", "self_untied", "cross_untied", "joint_untied"],
+        num_domain_decoder_blocks={"surface": 1, "volume": 1},
+        transformer_block_config=tf_config,
+        supernode_pooling_config=pool_config,
+        init_weights="truncnormal002",
+        data_specs=data_specs,
+    )
+
+
+@pytest.fixture
+def untied_model(untied_config):
+    """Model with every real block (including ``UntiedTransformerBlock``) replaced by a fake."""
+    with (
+        patch(_MODULE_PATH + ".RopeFrequency", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".SupernodePooling", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".TransformerBlock", new=FakeTransformerBlock),
+        patch(_MODULE_PATH + ".UntiedTransformerBlock", new=FakeUntiedTransformerBlock),
+        patch(_MODULE_PATH + ".ContinuousSincosEmbed", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".MLP", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".PerceiverBlock", new=FakePerceiverBlock),
+        patch(_MODULE_PATH + ".LinearProjection", new=FakeGenericModule),
+    ):
+        model = AnchoredBranchedUPT(config=untied_config)
+        model.domain_decoder_projections["surface"] = nn.Linear(
+            64, untied_config.data_specs.domains["surface"].output_dims.total_dim
+        )
+        model.domain_decoder_projections["volume"] = nn.Linear(
+            64, untied_config.data_specs.domains["volume"].output_dims.total_dim
+        )
+        yield model
+
+
+@pytest.fixture
+def untied_mixed_config():
+    """Config with a mix of shared (``self``) and untied (``cross_untied``) physics blocks."""
+    data_specs = ModelDataSpecs(
+        position_dim=3,
+        domains={
+            "surface": DomainDataSpec(output_dims=FieldDimSpec({"pressure": 1})),
+            "volume": DomainDataSpec(output_dims=FieldDimSpec({"velocity": 3})),
+        },
+    )
+    tf_config = TransformerBlockConfig(
+        hidden_dim=32,
+        num_heads=4,
+        mlp_expansion_factor=2.0,
+        use_bias=True,
+        use_rope=True,
+        dropout=0.0,
+    )
+    pool_config = SupernodePoolingConfig(hidden_dim=32, input_dim=3, radius=0.1, k=None)
+
+    return AnchorBranchedUPTConfig(
+        kind="AnchoredBranchedUPT",
+        name="ab_upt_mixed_untied",
+        hidden_dim=32,
+        geometry_depth=1,
+        physics_blocks=["perceiver", "self", "cross_untied"],
+        num_domain_decoder_blocks={"surface": 1, "volume": 1},
+        transformer_block_config=tf_config,
+        supernode_pooling_config=pool_config,
+        init_weights="truncnormal002",
+        data_specs=data_specs,
+    )
+
+
+@pytest.fixture
+def untied_mixed_model(untied_mixed_config):
+    with (
+        patch(_MODULE_PATH + ".RopeFrequency", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".SupernodePooling", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".TransformerBlock", new=FakeTransformerBlock),
+        patch(_MODULE_PATH + ".UntiedTransformerBlock", new=FakeUntiedTransformerBlock),
+        patch(_MODULE_PATH + ".ContinuousSincosEmbed", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".MLP", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".PerceiverBlock", new=FakePerceiverBlock),
+        patch(_MODULE_PATH + ".LinearProjection", new=FakeGenericModule),
+    ):
+        model = AnchoredBranchedUPT(config=untied_mixed_config)
+        for name in model.domain_names:
+            model.domain_decoder_projections[name] = nn.Linear(
+                32, untied_mixed_config.data_specs.domains[name].output_dims.total_dim
+            )
+        yield model
+
+
+class TestAnchoredBranchedUPTUntied:
+    """Tests exercising the ``*_untied`` physics block variants.
+
+    ``FakeUntiedTransformerBlock`` stands in for the real module so these tests
+    focus on the model's wiring (suffix parsing, block dispatch, forward shapes)
+    rather than the untied block's internal mechanics.
+    """
+
+    def test_init_dispatches_to_untied_blocks(self, untied_model):
+        """``*_untied`` suffix builds ``UntiedTransformerBlock`` for every attention variant."""
+        # perceiver is unaffected; the three untied entries each produce an untied block.
+        assert len(untied_model.physics_blocks) == 4
+        assert isinstance(untied_model.physics_blocks[0], FakePerceiverBlock)
+        assert all(isinstance(b, FakeUntiedTransformerBlock) for b in untied_model.physics_blocks[1:]), (
+            "self_untied / cross_untied / joint_untied should all instantiate UntiedTransformerBlock"
+        )
+        # No shared TransformerBlock should be constructed for the untied physics entries.
+        physics_tf = [b for b in untied_model.physics_blocks if isinstance(b, FakeTransformerBlock)]
+        assert physics_tf == []
+
+    def test_forward_shape_with_untied_blocks(self, untied_model, untied_config):
+        """Forward pass through untied physics blocks produces the same prediction keys/shapes."""
+        batch_size = 2
+        num_surface, num_volume = 20, 15
+
+        untied_model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 128, 64)
+        untied_model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 64)
+        untied_model.rope.forward = lambda *a, **k: torch.randn(batch_size, 2000, 16)
+
+        predictions, _ = untied_model(
+            geometry_position=torch.randn(50, 3),
+            geometry_supernode_idx=torch.zeros(50, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(50, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, num_surface, 3),
+                "volume": torch.randn(batch_size, num_volume, 3),
+            },
+        )
+
+        expected_keys = set()
+        for name, spec in untied_config.data_specs.domains.items():
+            expected_keys.update(f"{name}_{field}" for field in spec.output_dims.keys())
+        assert expected_keys.issubset(predictions.keys())
+
+        assert predictions["surface_pressure"].shape == (batch_size, num_surface, 1)
+        assert predictions["volume_velocity"].shape == (batch_size, num_volume, 3)
+
+    def test_forward_with_queries_untied(self, untied_model):
+        """Queries route through untied physics blocks and emerge under ``query_*`` keys."""
+        batch_size = 1
+
+        untied_model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 64, 64)
+        untied_model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 64)
+        untied_model.rope.forward = lambda *a, **k: torch.randn(batch_size, 2000, 16)
+
+        predictions, _ = untied_model(
+            geometry_position=torch.randn(10, 3),
+            geometry_supernode_idx=torch.zeros(10, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(10, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, 10, 3),
+                "volume": torch.randn(batch_size, 10, 3),
+            },
+            domain_query_positions={"surface": torch.randn(batch_size, 5, 3)},
+        )
+
+        assert predictions["query_surface_pressure"].shape == (batch_size, 5, 1)
+        # Volume has no queries → no query key for volume.
+        assert "query_volume_velocity" not in predictions
+
+    def test_untied_block_receives_correct_num_types(self, untied_config):
+        """``num_types`` passed into ``UntiedTransformerBlockConfig`` equals the number of domains."""
+        # Capture the configs that each UntiedTransformerBlock is constructed with.
+        constructor_configs: list = []
+
+        class RecordingFakeUntied(FakeUntiedTransformerBlock):
+            def __init__(self, *args, **kwargs):
+                super().__init__()
+                constructor_configs.append(kwargs.get("config"))
+
+        with (
+            patch(_MODULE_PATH + ".RopeFrequency", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".SupernodePooling", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".TransformerBlock", new=FakeTransformerBlock),
+            patch(_MODULE_PATH + ".UntiedTransformerBlock", new=RecordingFakeUntied),
+            patch(_MODULE_PATH + ".ContinuousSincosEmbed", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".MLP", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".PerceiverBlock", new=FakePerceiverBlock),
+            patch(_MODULE_PATH + ".LinearProjection", new=FakeGenericModule),
+        ):
+            AnchoredBranchedUPT(config=untied_config)
+
+        # 3 physics entries are *_untied → 3 UntiedTransformerBlock instantiations
+        assert len(constructor_configs) == 3
+        num_domains = len(untied_config.data_specs.domains)  # surface + volume → 2
+        for cfg in constructor_configs:
+            assert cfg.num_types == num_domains
+            # The nested TransformerBlockConfig should be carried through intact.
+            assert cfg.transformer_block_config.hidden_dim == untied_config.hidden_dim
+
+    def test_untied_blocks_have_independent_parameters(self, untied_config):
+        """Each ``UntiedTransformerBlock`` contributes its own distinct parameters.
+
+        Uses the *real* UntiedTransformerBlock (via patches only on the non-attention
+        periphery) so that parameter counting is meaningful.
+        """
+        # Patch peripheral modules only; leave TransformerBlock / UntiedTransformerBlock real.
+        with (
+            patch(_MODULE_PATH + ".RopeFrequency", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".SupernodePooling", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".ContinuousSincosEmbed", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".MLP", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".PerceiverBlock", new=FakePerceiverBlock),
+            patch(_MODULE_PATH + ".LinearProjection", new=FakeGenericModule),
+        ):
+            model = AnchoredBranchedUPT(config=untied_config)
+
+        # Each untied block's q/k/v weight banks have shape (num_types, H, H);
+        # disjoint parameter tensors across blocks means no accidental sharing.
+        # For AB-UPT, ``attention_block`` is a MultiBranchAnchorAttention wrapper
+        # (Self/Cross/JointAnchorAttention); its inner ``mixed_attention`` is the
+        # UntiedMixedAttention that owns the per-type q/k/v weights.
+        untied_blocks = [b for b in model.physics_blocks if b.__class__.__name__ == "UntiedTransformerBlock"]
+        assert len(untied_blocks) == 3
+        num_types = len(untied_config.data_specs.domains)
+        for proj_name in ("q", "k", "v"):
+            proj_ids = {id(getattr(b.attention_block.mixed_attention, proj_name).weight) for b in untied_blocks}
+            assert len(proj_ids) == 3, f"each UntiedTransformerBlock must hold its own {proj_name} weight tensor"
+            for b in untied_blocks:
+                assert getattr(b.attention_block.mixed_attention, proj_name).weight.shape[0] == num_types
+
+    def test_untied_block_uses_configured_attention_constructor(self, untied_config):
+        """``*_untied`` blocks must honor the configured ``attention_constructor``.
+
+        Pins the fix for a bug where ``UntiedTransformerBlock`` previously
+        replaced ``self.attention_block`` wholesale with ``UntiedMixedAttention``,
+        silently discarding the per-branch attention pattern (``self`` / ``cross``
+        / ``joint``). Post-fix, ``attention_block`` is the configured
+        ``MultiBranchAnchorAttention`` subclass and only its inner
+        ``mixed_attention`` is the untied workhorse — so ``self_untied`` really
+        emits per-branch self-attention patterns, not joint attention.
+        """
+        from noether.modeling.modules.attention.anchor_attention import (
+            CrossAnchorAttention,
+            JointAnchorAttention,
+            SelfAnchorAttention,
+        )
+        from noether.modeling.modules.untied import UntiedMixedAttention
+
+        with (
+            patch(_MODULE_PATH + ".RopeFrequency", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".SupernodePooling", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".ContinuousSincosEmbed", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".MLP", new=FakeGenericModule),
+            patch(_MODULE_PATH + ".PerceiverBlock", new=FakePerceiverBlock),
+            patch(_MODULE_PATH + ".LinearProjection", new=FakeGenericModule),
+        ):
+            model = AnchoredBranchedUPT(config=untied_config)
+
+        expected = {
+            "self_untied": SelfAnchorAttention,
+            "cross_untied": CrossAnchorAttention,
+            "joint_untied": JointAnchorAttention,
+        }
+        # untied_config.physics_blocks is ["perceiver", "self_untied", "cross_untied", "joint_untied"].
+        for block, block_type in zip(
+            model.physics_blocks[1:], ["self_untied", "cross_untied", "joint_untied"], strict=True
+        ):
+            assert isinstance(block.attention_block, expected[block_type]), (
+                f"{block_type} should build {expected[block_type].__name__}, got {type(block.attention_block).__name__}"
+            )
+            # The inner mixed_attention is the per-type workhorse.
+            assert isinstance(block.attention_block.mixed_attention, UntiedMixedAttention)
+
+
+class TestMixedTiedAndUntiedBlocks:
+    """Models can mix shared (``self``) and untied (``cross_untied``) blocks in one list."""
+
+    def test_init_mixed_blocks(self, untied_mixed_model):
+        """Mixed physics_blocks yields the expected concrete block types in order."""
+        blocks = untied_mixed_model.physics_blocks
+        assert len(blocks) == 3
+        assert isinstance(blocks[0], FakePerceiverBlock)
+        assert isinstance(blocks[1], FakeTransformerBlock)  # "self" → shared TransformerBlock
+        assert isinstance(blocks[2], FakeUntiedTransformerBlock)  # "cross_untied" → untied
+
+    def test_forward_mixed_blocks(self, untied_mixed_model):
+        """Mixing tied and untied physics blocks runs end-to-end without errors."""
+        batch_size = 1
+
+        untied_mixed_model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 64, 32)
+        untied_mixed_model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 32)
+        untied_mixed_model.rope.forward = lambda *a, **k: torch.randn(batch_size, 1000, 8)
+
+        predictions, _ = untied_mixed_model(
+            geometry_position=torch.randn(10, 3),
+            geometry_supernode_idx=torch.zeros(10, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(10, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, 8, 3),
+                "volume": torch.randn(batch_size, 6, 3),
+            },
+        )
+
+        assert predictions["surface_pressure"].shape == (batch_size, 8, 1)
+        assert predictions["volume_velocity"].shape == (batch_size, 6, 3)

--- a/tests/unit/noether/modeling/models/test_ab_upt_performance.py
+++ b/tests/unit/noether/modeling/models/test_ab_upt_performance.py
@@ -164,6 +164,9 @@ HIDDEN_DIM_GRID = [64, 128, 256]
 PHYSICS_BLOCKS_GRID: dict[str, list[str]] = {
     "perceiver_self": ["perceiver", "self"],
     "perceiver_joint": ["perceiver", "joint"],
+    "perceiver_self_untied": ["perceiver", "self_untied"],
+    "perceiver_joint_untied": ["perceiver", "joint_untied"],
+    "perceiver_cross_untied": ["perceiver", "cross_untied"],
 }
 
 
@@ -264,3 +267,49 @@ def test_ab_upt_forward_backward_vs_physics_blocks(benchmark, device, cache_flus
     )
     step = _forward_backward_closure(model, inputs, device)
     benchmark.pedantic(step, setup=cache_flush, rounds=_ROUNDS, warmup_rounds=_WARMUP_ROUNDS, iterations=1)
+
+
+@pytest.mark.benchmark(group="ab_upt_untied_vs_decoder_blocks_forward_backward")
+@pytest.mark.parametrize("anchor_ratio", [1, 1.5, 2, 3])
+@pytest.mark.parametrize("untied", [False, True])
+def test_ab_upt_untied_vs_decoder(benchmark, device, cache_flush, anchor_ratio, untied):
+    """Forward+backward — compare physics blocks with untied weights to final domain-specific decoder blocks."""
+    torch.manual_seed(0)
+    if untied:
+        config = _make_config(
+            hidden_dim=256,
+            num_heads=4,
+            physics_blocks=["perceiver", "self_untied", "self_untied", "self_untied", "self_untied"],
+            decoder_blocks_per_domain=0,
+        )
+    else:
+        config = _make_config(
+            hidden_dim=256,
+            num_heads=4,
+            physics_blocks=["perceiver"],
+            decoder_blocks_per_domain=4,
+        )
+    model = AnchoredBranchedUPT(config).to(device).train()
+
+    total_anchors = 10_000
+    num_surface_anchors = int(total_anchors / (anchor_ratio + 1))
+    num_volume_anchors = total_anchors - num_surface_anchors
+
+    inputs = _make_inputs(
+        device,
+        batch_size=1,
+        num_geometry_points=512,
+        num_supernodes=128,
+        num_surface_anchors=num_surface_anchors,
+        num_volume_anchors=num_volume_anchors,
+    )
+
+    step_untied = _forward_backward_closure(model, inputs, device)
+
+    benchmark.pedantic(
+        step_untied,
+        setup=cache_flush,
+        rounds=_ROUNDS,
+        warmup_rounds=_WARMUP_ROUNDS,
+        iterations=1,
+    )

--- a/tests/unit/noether/modeling/modules/test_untied.py
+++ b/tests/unit/noether/modeling/modules/test_untied.py
@@ -106,9 +106,11 @@ class TestUntiedLinear:
         cfg = _linear_cfg(num_types=3, in_dim=8, out_dim=16)
         layer = UntiedLinear(cfg)
         assert layer.num_types == 3
-        assert layer.weight.shape == (3, 16, 8)
+        assert len(layer.weight) == 3
+        assert all(w.shape == (16, 8) for w in layer.weight)
         assert layer.bias is not None
-        assert layer.bias.shape == (3, 16)
+        assert len(layer.bias) == 3
+        assert all(b.shape == (16,) for b in layer.bias)
 
     def test_init_no_bias(self):
         cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, bias=False)
@@ -120,22 +122,23 @@ class TestUntiedLinear:
         """Supported ``init_weights`` modes run without error and produce non-zero weights."""
         cfg = _linear_cfg(num_types=2, in_dim=8, out_dim=8, init_weights=init_weights)
         layer = UntiedLinear(cfg)
-        assert not torch.all(layer.weight == 0)
+        assert not all(torch.all(w == 0) for w in layer.weight)
 
     def test_init_weights_zeros(self):
         """``"zeros"`` mode produces zero weight and zero bias."""
         cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, init_weights="zeros")
         layer = UntiedLinear(cfg)
-        assert torch.all(layer.weight == 0)
-        assert torch.all(layer.bias == 0)
+        assert all(torch.all(w == 0) for w in layer.weight)
+        assert all(torch.all(b == 0) for b in layer.bias)
 
     def test_init_weights_truncnormal_std(self):
         """``truncnormal002`` produces weights with std ≈ 0.02 and zero bias."""
         torch.manual_seed(0)
         cfg = _linear_cfg(num_types=2, in_dim=16, out_dim=16, init_weights="truncnormal002")
         layer = UntiedLinear(cfg)
-        assert 0.01 < layer.weight.std().item() < 0.04
-        assert torch.all(layer.bias == 0)
+        stacked = torch.stack(list(layer.weight))
+        assert 0.01 < stacked.std().item() < 0.04
+        assert all(torch.all(b == 0) for b in layer.bias)
 
     def test_init_weights_unknown_raises(self):
         """Unsupported ``init_weights`` values raise ``NotImplementedError`` at build time."""
@@ -164,8 +167,8 @@ class TestUntiedLinear:
         layer = UntiedLinear(cfg)
         # Make type 0's weight the identity, type 1's the zero map — easy to check.
         with torch.no_grad():
-            layer.weight[0] = torch.eye(4)
-            layer.weight[1] = torch.zeros(4, 4)
+            layer.weight[0].copy_(torch.eye(4))
+            layer.weight[1].copy_(torch.zeros(4, 4))
 
         specs = [TokenSpec(name="a", size=2), TokenSpec(name="b", size=3)]
         x = torch.randn(1, 5, 4)
@@ -197,19 +200,21 @@ class TestUntiedLinear:
         specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
         out = layer(torch.randn(2, 5, 4), specs)
         out.sum().backward()
-        assert layer.weight.grad is not None
-        assert layer.weight.grad.shape == layer.weight.shape
+        # Each per-type weight Parameter (2D) has its own grad of shape (D_out, D_in).
+        for w in layer.weight:
+            assert w.grad is not None
+            assert w.grad.shape == w.shape
         # Both type banks receive gradients (neither is all zero).
-        assert torch.any(layer.weight.grad[0] != 0)
-        assert torch.any(layer.weight.grad[1] != 0)
+        assert torch.any(layer.weight[0].grad != 0)
+        assert torch.any(layer.weight[1].grad != 0)
 
     def test_forward_multi_spec_per_domain(self):
         """Multiple specs sharing a domain are grouped and share one weight bank."""
         cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, bias=False)
         layer = UntiedLinear(cfg)
         with torch.no_grad():
-            layer.weight[0] = torch.eye(4)  # "surface" domain → identity
-            layer.weight[1] = torch.zeros(4, 4)  # "volume" domain → zero
+            layer.weight[0].copy_(torch.eye(4))  # "surface" domain → identity
+            layer.weight[1].copy_(torch.zeros(4, 4))  # "volume" domain → zero
 
         specs = [
             TokenSpec(name="surface_anchors", size=2),
@@ -266,7 +271,7 @@ class TestUntiedLinearStrategies:
 
         sizes = _domain_group_sizes(specs)
         B, S, D_in = x.shape
-        D_out = layer.weight.shape[1]
+        D_out = layer.output_dim
         T = len(sizes)
 
         out_loop = layer._split_loop_forward(x, sizes, D_out)
@@ -286,7 +291,7 @@ class TestUntiedLinearStrategies:
 
         sizes = _domain_group_sizes(specs)
         B, S, D_in = x.shape
-        D_out = layer.weight.shape[1]
+        D_out = layer.output_dim
         T = len(sizes)
 
         out_loop = layer._split_loop_forward(x, sizes, D_out)
@@ -301,7 +306,7 @@ class TestUntiedLinearStrategies:
         out = layer(torch.randn(2, 5, 4), specs)
         assert out.shape == (2, 5, 4)
         out.sum().backward()
-        assert layer.weight.grad is not None
+        assert all(w.grad is not None for w in layer.weight)
 
 
 # ---------------------------------------------------------------------------
@@ -336,11 +341,12 @@ def _all_to_all_patterns(specs: Sequence[TokenSpec]) -> list[AttentionPattern]:
 
 class TestUntiedMixedAttention:
     def test_init_uses_untied_projections(self):
-        """Q, K, V, and output projections are ``UntiedLinear`` with shape ``(num_types, hidden_dim, hidden_dim)``."""
+        """Q, K, V, and output projections are ``UntiedLinear`` with one ``(hidden_dim, hidden_dim)`` Parameter per type."""
         attn = _make_attn(hidden_dim=32, num_types=3)
         for proj in (attn.q, attn.k, attn.v, attn.proj):
             assert isinstance(proj, UntiedLinear)
-            assert proj.weight.shape == (3, 32, 32)
+            assert len(proj.weight) == 3
+            assert all(w.shape == (32, 32) for w in proj.weight)
 
     def test_forward_shape(self):
         attn = _make_attn()
@@ -373,10 +379,46 @@ class TestUntiedMixedAttention:
         out.sum().backward()
         # Per-type q/k/v weight banks all receive gradient signal.
         for proj in (attn.q, attn.k, attn.v):
-            assert proj.weight.grad is not None
-            assert proj.weight.grad.shape == (2, 32, 32)
-            assert torch.any(proj.weight.grad[0] != 0)
-            assert torch.any(proj.weight.grad[1] != 0)
+            for w in proj.weight:
+                assert w.grad is not None
+                assert w.grad.shape == (32, 32)
+            assert torch.any(proj.weight[0].grad != 0)
+            assert torch.any(proj.weight[1].grad != 0)
+
+    def test_cross_attention_actually_cross_attends(self):
+        """With a cross pattern (``a→b``, ``b→a``), ``a``'s output must depend on ``b``'s input.
+
+        Validates that ``AttentionPattern`` is honored end-to-end: when type ``a``
+        queries *only* type ``b``'s key/values, varying ``b``'s input must shift
+        ``a``'s output (b provides the K/V). Conversely, under a self-only pattern
+        (``a→a``, ``b→b``) ``a``'s output is invariant to ``b``. Together these
+        prove the module isn't silently collapsing to self-attention.
+        """
+        torch.manual_seed(0)
+        attn = _make_attn(num_types=2)
+        specs = [TokenSpec(name="a", size=4), TokenSpec(name="b", size=6)]
+        cross = [
+            AttentionPattern(query_tokens=["a"], key_value_tokens=["b"]),
+            AttentionPattern(query_tokens=["b"], key_value_tokens=["a"]),
+        ]
+        self_only = [
+            AttentionPattern(query_tokens=["a"], key_value_tokens=["a"]),
+            AttentionPattern(query_tokens=["b"], key_value_tokens=["b"]),
+        ]
+
+        x_a = torch.randn(1, 4, 32)
+        x_b1 = torch.randn(1, 6, 32)
+        x_b2 = torch.randn(1, 6, 32)
+
+        # Cross pattern: a queries b → changing b changes a's output.
+        out1_cross = attn(torch.cat([x_a, x_b1], dim=1), specs, cross)
+        out2_cross = attn(torch.cat([x_a, x_b2], dim=1), specs, cross)
+        assert not torch.allclose(out1_cross[:, :4], out2_cross[:, :4])
+
+        # Self-only pattern: a attends only to a → a's output is invariant to b.
+        out1_self = attn(torch.cat([x_a, x_b1], dim=1), specs, self_only)
+        out2_self = attn(torch.cat([x_a, x_b2], dim=1), specs, self_only)
+        assert torch.allclose(out1_self[:, :4], out2_self[:, :4], atol=1e-6)
 
     def test_no_cross_talk_between_types_in_projection(self):
         """Changing type ``b`` inputs shouldn't shift type ``a`` tokens' *projections*.
@@ -417,8 +459,12 @@ class TestUntiedMLP:
         """``num_layers=0`` produces the canonical up→act→down topology (2 linears)."""
         mlp = UntiedMLP(self._cfg(num_layers=0))
         assert len(mlp.layers) == 2
-        assert mlp.layers[0].weight.shape == (2, 32, 16)  # up: 16 → 32
-        assert mlp.layers[1].weight.shape == (2, 16, 32)  # down: 32 → 16
+        # up: 16 → 32
+        assert len(mlp.layers[0].weight) == 2
+        assert all(w.shape == (32, 16) for w in mlp.layers[0].weight)
+        # down: 32 → 16
+        assert len(mlp.layers[1].weight) == 2
+        assert all(w.shape == (16, 32) for w in mlp.layers[1].weight)
 
     def test_init_num_layers_two_gives_four_projections(self):
         """``num_layers=2`` produces input + 2 hidden + output (4 linears total)."""
@@ -438,7 +484,7 @@ class TestUntiedMLP:
         out = mlp(torch.randn(2, 5, 16), specs)
         out.sum().backward()
         for layer in mlp.layers:
-            assert layer.weight.grad is not None
+            assert all(w.grad is not None for w in layer.weight)
 
     def test_all_layers_are_untied_linear(self):
         """Every linear layer in the MLP is a :class:`UntiedLinear`."""
@@ -545,10 +591,11 @@ class TestUntiedTransformerBlock:
         out.sum().backward()
         # Both attention and MLP have gradient signal in their per-type weight banks.
         for proj in (tb.attention_block.q, tb.attention_block.k, tb.attention_block.v):
-            assert proj.weight.grad is not None
-            assert torch.any(proj.weight.grad != 0)
+            for w in proj.weight:
+                assert w.grad is not None
+                assert torch.any(w.grad != 0)
         for layer in tb.mlp.layers:
-            assert layer.weight.grad is not None
+            assert all(w.grad is not None for w in layer.weight)
 
     def test_forward_with_multi_spec_per_domain(self):
         """Multiple specs per domain (anchors + queries) use the same weight bank."""

--- a/tests/unit/noether/modeling/modules/test_untied.py
+++ b/tests/unit/noether/modeling/modules/test_untied.py
@@ -1,0 +1,591 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+"""Unit tests for :mod:`noether.modeling.modules.untied`.
+
+Covers :class:`UntiedLinear` (unified class with auto-selected strategy),
+:class:`UntiedMixedAttention`, :class:`UntiedMLP`, and
+:class:`UntiedTransformerBlock`.
+"""
+
+from collections.abc import Sequence
+
+import pytest
+import torch
+from pydantic import ValidationError
+
+from noether.core.schemas.modules.attention import AttentionPattern, TokenSpec
+from noether.core.schemas.modules.blocks import TransformerBlockConfig
+from noether.core.schemas.modules.layers import LinearProjectionConfig
+from noether.core.schemas.modules.mlp import MLPConfig
+from noether.core.schemas.modules.untied import (
+    UntiedLinearConfig,
+    UntiedMixedAttentionConfig,
+    UntiedMLPConfig,
+    UntiedTransformerBlockConfig,
+)
+from noether.modeling.modules.untied import (
+    UntiedLinear,
+    UntiedMixedAttention,
+    UntiedMLP,
+    UntiedTransformerBlock,
+    _domain_group_sizes,
+)
+
+
+def _linear_cfg(
+    num_types: int,
+    in_dim: int,
+    out_dim: int,
+    *,
+    bias: bool = True,
+    init_weights: str = "torch",
+) -> UntiedLinearConfig:
+    """Helper to construct a :class:`UntiedLinearConfig`."""
+    return UntiedLinearConfig(
+        num_types=num_types,
+        linear_projection=LinearProjectionConfig(
+            input_dim=in_dim,
+            output_dim=out_dim,
+            bias=bias,
+            init_weights=init_weights,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Domain helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDomainGroupSizes:
+    """Tests for :func:`_domain_group_sizes` — sums sizes per consecutive domain."""
+
+    def test_single_spec_per_domain(self):
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        assert _domain_group_sizes(specs) == [3, 2]
+
+    def test_multiple_specs_per_domain(self):
+        """surface_anchors + surface_queries → single "surface" group."""
+        specs = [
+            TokenSpec(name="surface_anchors", size=10),
+            TokenSpec(name="surface_queries", size=5),
+            TokenSpec(name="volume_anchors", size=8),
+            TokenSpec(name="volume_queries", size=3),
+        ]
+        assert _domain_group_sizes(specs) == [15, 11]
+
+    def test_skips_none_and_zero(self):
+        specs = [
+            TokenSpec(name="surface_anchors", size=4),
+            TokenSpec(name="surface_queries", size=None),
+            TokenSpec(name="volume_anchors", size=0),
+            TokenSpec(name="volume_queries", size=3),
+        ]
+        assert _domain_group_sizes(specs) == [4, 3]
+
+    def test_empty_specs(self):
+        assert _domain_group_sizes([]) == []
+
+    def test_non_consecutive_domains_raises(self):
+        """Domains that appear, disappear, and reappear must raise."""
+        specs = [
+            TokenSpec(name="surface_anchors", size=2),
+            TokenSpec(name="volume_anchors", size=3),
+            TokenSpec(name="surface_queries", size=1),  # surface reappears!
+        ]
+        with pytest.raises(ValueError, match="not consecutive"):
+            _domain_group_sizes(specs)
+
+
+# ---------------------------------------------------------------------------
+# UntiedLinear
+# ---------------------------------------------------------------------------
+
+
+class TestUntiedLinear:
+    def test_init_shapes(self):
+        cfg = _linear_cfg(num_types=3, in_dim=8, out_dim=16)
+        layer = UntiedLinear(cfg)
+        assert layer.num_types == 3
+        assert layer.weight.shape == (3, 16, 8)
+        assert layer.bias is not None
+        assert layer.bias.shape == (3, 16)
+
+    def test_init_no_bias(self):
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, bias=False)
+        layer = UntiedLinear(cfg)
+        assert layer.bias is None
+
+    @pytest.mark.parametrize("init_weights", ["torch", "truncnormal", "truncnormal002"])
+    def test_init_weights_modes_run(self, init_weights):
+        """Supported ``init_weights`` modes run without error and produce non-zero weights."""
+        cfg = _linear_cfg(num_types=2, in_dim=8, out_dim=8, init_weights=init_weights)
+        layer = UntiedLinear(cfg)
+        assert not torch.all(layer.weight == 0)
+
+    def test_init_weights_zeros(self):
+        """``"zeros"`` mode produces zero weight and zero bias."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, init_weights="zeros")
+        layer = UntiedLinear(cfg)
+        assert torch.all(layer.weight == 0)
+        assert torch.all(layer.bias == 0)
+
+    def test_init_weights_truncnormal_std(self):
+        """``truncnormal002`` produces weights with std ≈ 0.02 and zero bias."""
+        torch.manual_seed(0)
+        cfg = _linear_cfg(num_types=2, in_dim=16, out_dim=16, init_weights="truncnormal002")
+        layer = UntiedLinear(cfg)
+        assert 0.01 < layer.weight.std().item() < 0.04
+        assert torch.all(layer.bias == 0)
+
+    def test_init_weights_unknown_raises(self):
+        """Unsupported ``init_weights`` values raise ``NotImplementedError`` at build time."""
+        # The schema only accepts a fixed Literal, so truly-invalid strings are rejected by pydantic.
+        with pytest.raises(ValidationError):
+            _linear_cfg(num_types=2, in_dim=4, out_dim=4, init_weights="nonsense")
+
+    def test_init_weights_unsupported_raises_not_implemented(self):
+        """A valid ``InitWeightsMode`` that :class:`UntiedLinear` doesn't handle raises."""
+        # "truncnormal002-identity" is a valid InitWeightsMode value but not handled by UntiedLinear.
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, init_weights="truncnormal002-identity")
+        with pytest.raises(NotImplementedError, match="truncnormal002-identity"):
+            UntiedLinear(cfg)
+
+    def test_forward_shape(self):
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=6)
+        layer = UntiedLinear(cfg)
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        x = torch.randn(2, 5, 4)
+        out = layer(x, specs)
+        assert out.shape == (2, 5, 6)
+
+    def test_forward_respects_per_type_weights(self):
+        """Each per-type weight bank is actually applied to its own tokens."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, bias=False)
+        layer = UntiedLinear(cfg)
+        # Make type 0's weight the identity, type 1's the zero map — easy to check.
+        with torch.no_grad():
+            layer.weight[0] = torch.eye(4)
+            layer.weight[1] = torch.zeros(4, 4)
+
+        specs = [TokenSpec(name="a", size=2), TokenSpec(name="b", size=3)]
+        x = torch.randn(1, 5, 4)
+        out = layer(x, specs)
+        # "a" rows (first 2) must pass through unchanged.
+        assert torch.allclose(out[:, :2], x[:, :2])
+        # "b" rows (last 3) must be zeroed.
+        assert torch.all(out[:, 2:] == 0)
+
+    def test_forward_skips_empty_and_cached_specs(self):
+        """Empty (size=0) and cached (size=None) specs contribute no output tokens."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4)
+        layer = UntiedLinear(cfg)
+        specs = [
+            TokenSpec(name="a", size=2),
+            TokenSpec(name="empty", size=0),
+            TokenSpec(name="cached", size=None),
+            TokenSpec(name="b", size=3),
+        ]
+        x = torch.randn(2, 5, 4)
+        out = layer(x, specs)
+        # Only the 2 + 3 real tokens remain in the output.
+        assert out.shape == (2, 5, 4)
+
+    def test_forward_backward_produces_per_type_grads(self):
+        """Backward pass populates all per-type weight banks with gradients."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4)
+        layer = UntiedLinear(cfg)
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        out = layer(torch.randn(2, 5, 4), specs)
+        out.sum().backward()
+        assert layer.weight.grad is not None
+        assert layer.weight.grad.shape == layer.weight.shape
+        # Both type banks receive gradients (neither is all zero).
+        assert torch.any(layer.weight.grad[0] != 0)
+        assert torch.any(layer.weight.grad[1] != 0)
+
+    def test_forward_multi_spec_per_domain(self):
+        """Multiple specs sharing a domain are grouped and share one weight bank."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4, bias=False)
+        layer = UntiedLinear(cfg)
+        with torch.no_grad():
+            layer.weight[0] = torch.eye(4)  # "surface" domain → identity
+            layer.weight[1] = torch.zeros(4, 4)  # "volume" domain → zero
+
+        specs = [
+            TokenSpec(name="surface_anchors", size=2),
+            TokenSpec(name="surface_queries", size=1),
+            TokenSpec(name="volume_anchors", size=2),
+        ]
+        x = torch.randn(1, 5, 4)
+        out = layer(x, specs)
+        # surface (first 3 tokens) pass through; volume (last 2) zeroed.
+        assert torch.allclose(out[:, :3], x[:, :3])
+        assert torch.all(out[:, 3:] == 0)
+
+    def test_forward_non_consecutive_domain_raises(self):
+        """Non-consecutive domains are rejected at forward time."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4)
+        layer = UntiedLinear(cfg)
+        specs = [
+            TokenSpec(name="surface_anchors", size=2),
+            TokenSpec(name="volume_anchors", size=3),
+            TokenSpec(name="surface_queries", size=1),  # surface reappears
+        ]
+        with pytest.raises(ValueError, match="not consecutive"):
+            layer(torch.randn(1, 6, 4), specs)
+
+    def test_no_cross_talk_between_types(self):
+        """Changing type ``b`` inputs must not affect type ``a`` outputs."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4)
+        layer = UntiedLinear(cfg)
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        x_a = torch.randn(1, 3, 4)
+        x_b1 = torch.randn(1, 2, 4)
+        x_b2 = torch.randn(1, 2, 4) + 100.0  # vastly different
+
+        out1 = layer(torch.cat([x_a, x_b1], dim=1), specs)
+        out2 = layer(torch.cat([x_a, x_b2], dim=1), specs)
+
+        assert torch.allclose(out1[:, :3], out2[:, :3], atol=1e-6)
+        assert not torch.allclose(out1[:, 3:], out2[:, 3:])
+
+
+class TestUntiedLinearStrategies:
+    """The internal strategies (split-loop, equal-size bmm, padded bmm) must agree."""
+
+    def test_split_loop_and_equal_size_bmm_agree(self):
+        """Both strategies produce the same output when domain sizes are equal."""
+        torch.manual_seed(0)
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=6)
+        layer = UntiedLinear(cfg)
+
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=3)]
+        x = torch.randn(2, 6, 4)
+
+        from noether.modeling.modules.untied import _domain_group_sizes
+
+        sizes = _domain_group_sizes(specs)
+        B, S, D_in = x.shape
+        D_out = layer.weight.shape[1]
+        T = len(sizes)
+
+        out_loop = layer._split_loop_forward(x, sizes, D_out)
+        out_bmm = layer._equal_size_bmm_forward(x, sizes[0], B, S, D_in, D_out, T)
+        assert torch.allclose(out_loop, out_bmm, atol=1e-5)
+
+    def test_split_loop_and_padded_bmm_agree(self):
+        """Both strategies produce the same output for unequal sizes."""
+        torch.manual_seed(0)
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=6)
+        layer = UntiedLinear(cfg)
+
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        x = torch.randn(2, 5, 4)
+
+        from noether.modeling.modules.untied import _domain_group_sizes
+
+        sizes = _domain_group_sizes(specs)
+        B, S, D_in = x.shape
+        D_out = layer.weight.shape[1]
+        T = len(sizes)
+
+        out_loop = layer._split_loop_forward(x, sizes, D_out)
+        out_padded = layer._padded_bmm_forward(x, sizes, B, S, D_in, D_out, T, max(sizes))
+        assert torch.allclose(out_loop, out_padded, atol=1e-5)
+
+    def test_auto_forward_backward(self):
+        """The auto-selected strategy supports forward + backward."""
+        cfg = _linear_cfg(num_types=2, in_dim=4, out_dim=4)
+        layer = UntiedLinear(cfg)
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        out = layer(torch.randn(2, 5, 4), specs)
+        assert out.shape == (2, 5, 4)
+        out.sum().backward()
+        assert layer.weight.grad is not None
+
+
+# ---------------------------------------------------------------------------
+# UntiedMixedAttention
+# ---------------------------------------------------------------------------
+
+
+def _make_attn(
+    *,
+    hidden_dim: int = 32,
+    num_heads: int = 4,
+    num_types: int = 2,
+    use_rope: bool = False,
+    dropout: float = 0.0,
+) -> UntiedMixedAttention:
+    cfg = UntiedMixedAttentionConfig(
+        hidden_dim=hidden_dim,
+        num_heads=num_heads,
+        dropout=dropout,
+        bias=True,
+        use_rope=use_rope,
+        num_types=num_types,
+    )
+    return UntiedMixedAttention(config=cfg).eval()
+
+
+def _all_to_all_patterns(specs: Sequence[TokenSpec]) -> list[AttentionPattern]:
+    """Single all-to-all attention pattern over every name in ``specs``."""
+    names = [s.name for s in specs if s.size is not None]
+    return [AttentionPattern(query_tokens=names, key_value_tokens=names)]
+
+
+class TestUntiedMixedAttention:
+    def test_init_uses_untied_projections(self):
+        """Q, K, V, and output projections are ``UntiedLinear`` with shape ``(num_types, hidden_dim, hidden_dim)``."""
+        attn = _make_attn(hidden_dim=32, num_types=3)
+        for proj in (attn.q, attn.k, attn.v, attn.proj):
+            assert isinstance(proj, UntiedLinear)
+            assert proj.weight.shape == (3, 32, 32)
+
+    def test_forward_shape(self):
+        attn = _make_attn()
+        specs = [TokenSpec(name="a", size=4), TokenSpec(name="b", size=6)]
+        x = torch.randn(2, 10, 32)
+        out = attn(x, specs, _all_to_all_patterns(specs))
+        assert out.shape == (2, 10, 32)
+
+    def test_forward_with_key_padding_mask(self):
+        attn = _make_attn()
+        specs = [TokenSpec(name="a", size=4), TokenSpec(name="b", size=6)]
+        x = torch.randn(2, 10, 32)
+        mask = torch.ones(2, 10, dtype=torch.bool)
+        mask[0, -3:] = False  # last 3 of the b-group are padding in batch 0
+        out = attn(x, specs, _all_to_all_patterns(specs), key_padding_mask=mask)
+        assert out.shape == (2, 10, 32)
+
+    def test_kv_cache_not_implemented(self):
+        """Supplying ``kv_cache`` is not yet supported and raises."""
+        attn = _make_attn()
+        specs = [TokenSpec(name="a", size=4), TokenSpec(name="b", size=6)]
+        x = torch.randn(2, 10, 32)
+        with pytest.raises(NotImplementedError, match="kv caching"):
+            attn(x, specs, _all_to_all_patterns(specs), kv_cache={"a": torch.randn(1)})
+
+    def test_backward_populates_per_type_grads(self):
+        attn = _make_attn(num_types=2)
+        specs = [TokenSpec(name="a", size=4), TokenSpec(name="b", size=6)]
+        out = attn(torch.randn(2, 10, 32), specs, _all_to_all_patterns(specs))
+        out.sum().backward()
+        # Per-type q/k/v weight banks all receive gradient signal.
+        for proj in (attn.q, attn.k, attn.v):
+            assert proj.weight.grad is not None
+            assert proj.weight.grad.shape == (2, 32, 32)
+            assert torch.any(proj.weight.grad[0] != 0)
+            assert torch.any(proj.weight.grad[1] != 0)
+
+    def test_no_cross_talk_between_types_in_projection(self):
+        """Changing type ``b`` inputs shouldn't shift type ``a`` tokens' *projections*.
+
+        Attention itself mixes all tokens, so the final attention output naturally
+        depends on every token. We isolate the projection path by giving the attention
+        output a trivial structure: with identity q/k/v and zero values for type b,
+        type a tokens' q/k/v are untouched by type b inputs at the projection layer.
+        Here we just verify the projection weights are keyed per-type.
+        """
+        attn = _make_attn()
+        # Spec names → projection weight index: a→0, b→1. Verify they're distinct
+        # parameter tensors (not aliases) for each of q/k/v.
+        for proj in (attn.q, attn.k, attn.v):
+            assert proj.weight[0].data_ptr() != proj.weight[1].data_ptr() or torch.any(proj.weight[0] != proj.weight[1])
+
+
+# ---------------------------------------------------------------------------
+# UntiedMLP
+# ---------------------------------------------------------------------------
+
+
+class TestUntiedMLP:
+    def _cfg(self, *, num_layers: int = 0) -> UntiedMLPConfig:
+        return UntiedMLPConfig(
+            num_types=2,
+            mlp=MLPConfig(
+                input_dim=16,
+                output_dim=16,
+                hidden_dim=32,
+                num_layers=num_layers,
+                activation="GELU",
+                init_weights="truncnormal002",
+            ),
+        )
+
+    def test_init_num_layers_zero_gives_two_projections(self):
+        """``num_layers=0`` produces the canonical up→act→down topology (2 linears)."""
+        mlp = UntiedMLP(self._cfg(num_layers=0))
+        assert len(mlp.layers) == 2
+        assert mlp.layers[0].weight.shape == (2, 32, 16)  # up: 16 → 32
+        assert mlp.layers[1].weight.shape == (2, 16, 32)  # down: 32 → 16
+
+    def test_init_num_layers_two_gives_four_projections(self):
+        """``num_layers=2`` produces input + 2 hidden + output (4 linears total)."""
+        mlp = UntiedMLP(self._cfg(num_layers=2))
+        assert len(mlp.layers) == 4
+
+    def test_forward_shape(self):
+        mlp = UntiedMLP(self._cfg())
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        x = torch.randn(2, 5, 16)
+        out = mlp(x, specs)
+        assert out.shape == (2, 5, 16)
+
+    def test_forward_backward(self):
+        mlp = UntiedMLP(self._cfg(num_layers=1))
+        specs = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=2)]
+        out = mlp(torch.randn(2, 5, 16), specs)
+        out.sum().backward()
+        for layer in mlp.layers:
+            assert layer.weight.grad is not None
+
+    def test_all_layers_are_untied_linear(self):
+        """Every linear layer in the MLP is a :class:`UntiedLinear`."""
+        mlp = UntiedMLP(self._cfg(num_layers=1))
+        assert all(isinstance(layer, UntiedLinear) for layer in mlp.layers)
+
+
+# ---------------------------------------------------------------------------
+# UntiedTransformerBlock
+# ---------------------------------------------------------------------------
+
+
+def _tb_cfg(
+    *,
+    hidden_dim: int = 32,
+    num_heads: int = 4,
+    condition_dim: int | None = None,
+    drop_path: float = 0.0,
+    layerscale: float | None = None,
+) -> TransformerBlockConfig:
+    return TransformerBlockConfig(
+        hidden_dim=hidden_dim,
+        num_heads=num_heads,
+        mlp_expansion_factor=2,
+        drop_path=drop_path,
+        condition_dim=condition_dim,
+        use_rope=False,
+        bias=True,
+        layerscale=layerscale,
+    )
+
+
+def _block_cfg(**tb_kwargs: object) -> UntiedTransformerBlockConfig:
+    return UntiedTransformerBlockConfig(
+        num_types=2,
+        transformer_block=_tb_cfg(**tb_kwargs),
+    )
+
+
+def _specs() -> Sequence[TokenSpec]:
+    return [TokenSpec(name="a", size=4), TokenSpec(name="b", size=6)]
+
+
+class TestUntiedTransformerBlock:
+    def test_init_assembles_submodules(self):
+        block = _block_cfg()
+        tb = UntiedTransformerBlock(config=block)
+        assert isinstance(tb.attention_block, UntiedMixedAttention)
+        assert isinstance(tb.mlp, UntiedMLP)
+        assert tb.modulation is None  # no condition_dim → no modulation
+
+    def test_forward_shape(self):
+        tb = UntiedTransformerBlock(config=_block_cfg())
+        x = torch.randn(2, 10, 32)
+        specs = _specs()
+        out, cache = tb(x, attn_kwargs={"token_specs": specs, "attention_patterns": _all_to_all_patterns(specs)})
+        assert out.shape == (2, 10, 32)
+        # UntiedMixedAttention returns a bare tensor (no cache), so block's cache is None.
+        assert cache is None
+
+    def test_forward_missing_token_specs_raises(self):
+        """``attn_kwargs`` must include ``token_specs`` — otherwise a clear error is raised."""
+        tb = UntiedTransformerBlock(config=_block_cfg())
+        x = torch.randn(2, 10, 32)
+        with pytest.raises(ValueError, match="token_specs"):
+            tb(x, attn_kwargs={})
+        with pytest.raises(ValueError, match="token_specs"):
+            tb(x, attn_kwargs=None)
+        with pytest.raises(ValueError, match="token_specs"):
+            tb(x, attn_kwargs={"token_specs": None})
+
+    def test_forward_rejects_condition_without_modulation(self):
+        """Passing ``condition`` when ``condition_dim`` is ``None`` must raise."""
+        tb = UntiedTransformerBlock(config=_block_cfg())
+        x = torch.randn(2, 10, 32)
+        with pytest.raises(ValueError, match="not configured for conditioning"):
+            tb(x, attn_kwargs={"token_specs": _specs()}, condition=torch.randn(2, 4))
+
+    def test_init_with_condition_dim_builds_modulation(self):
+        """``condition_dim`` wires up the modulation projection; leaves attention/MLP as-is."""
+        tb = UntiedTransformerBlock(config=_block_cfg(condition_dim=8))
+        assert tb.modulation is not None
+        assert isinstance(tb.attention_block, UntiedMixedAttention)
+        assert isinstance(tb.mlp, UntiedMLP)
+
+    def test_forward_missing_condition_when_required_raises(self):
+        """With ``condition_dim`` set, forward without ``condition`` must raise."""
+        tb = UntiedTransformerBlock(config=_block_cfg(condition_dim=8))
+        x = torch.randn(2, 10, 32)
+        with pytest.raises(ValueError, match="No conditioning vector provided"):
+            tb(x, attn_kwargs={"token_specs": _specs()})
+
+    def test_forward_condition_shape_mismatch_raises(self):
+        tb = UntiedTransformerBlock(config=_block_cfg(condition_dim=8))
+        x = torch.randn(2, 10, 32)
+        with pytest.raises(ValueError, match="incorrect shape"):
+            tb(x, attn_kwargs={"token_specs": _specs()}, condition=torch.randn(2, 4))
+
+    def test_forward_backward(self):
+        tb = UntiedTransformerBlock(config=_block_cfg())
+        x = torch.randn(2, 10, 32)
+        specs = _specs()
+        out, _ = tb(x, attn_kwargs={"token_specs": specs, "attention_patterns": _all_to_all_patterns(specs)})
+        out.sum().backward()
+        # Both attention and MLP have gradient signal in their per-type weight banks.
+        for proj in (tb.attention_block.q, tb.attention_block.k, tb.attention_block.v):
+            assert proj.weight.grad is not None
+            assert torch.any(proj.weight.grad != 0)
+        for layer in tb.mlp.layers:
+            assert layer.weight.grad is not None
+
+    def test_forward_with_multi_spec_per_domain(self):
+        """Multiple specs per domain (anchors + queries) use the same weight bank."""
+        tb = UntiedTransformerBlock(config=_block_cfg())
+        specs = [
+            TokenSpec(name="a_anchors", size=4),
+            TokenSpec(name="a_queries", size=2),
+            TokenSpec(name="b_anchors", size=3),
+            TokenSpec(name="b_queries", size=1),
+        ]
+        x = torch.randn(2, 10, 32)
+        out, _ = tb(x, attn_kwargs={"token_specs": specs, "attention_patterns": _all_to_all_patterns(specs)})
+        assert out.shape == (2, 10, 32)
+
+    def test_forward_non_consecutive_domain_raises(self):
+        """Interleaved domains are caught by the block's validation."""
+        tb = UntiedTransformerBlock(config=_block_cfg())
+        specs = [
+            TokenSpec(name="a_anchors", size=3),
+            TokenSpec(name="b_anchors", size=3),
+            TokenSpec(name="a_queries", size=2),  # "a" domain reappears
+            TokenSpec(name="b_queries", size=2),
+        ]
+        with pytest.raises(ValueError, match="not consecutive"):
+            tb(torch.randn(1, 10, 32), attn_kwargs={"token_specs": specs})
+
+    def test_different_partitions_produce_different_outputs(self):
+        """Moving the a/b split point changes which tokens use which weight bank."""
+        torch.manual_seed(0)
+        tb = UntiedTransformerBlock(config=_block_cfg()).eval()
+        x = torch.randn(1, 10, 32)
+
+        # Same input, different a/b partitions. The block has distinct per-type
+        # weights, so a different partition must produce a different output.
+        specs_v1 = [TokenSpec(name="a", size=5), TokenSpec(name="b", size=5)]
+        specs_v2 = [TokenSpec(name="a", size=3), TokenSpec(name="b", size=7)]
+
+        out1, _ = tb(x, attn_kwargs={"token_specs": specs_v1, "attention_patterns": _all_to_all_patterns(specs_v1)})
+        out2, _ = tb(x, attn_kwargs={"token_specs": specs_v2, "attention_patterns": _all_to_all_patterns(specs_v2)})
+        assert not torch.allclose(out1, out2)

--- a/tests/unit/noether/modeling/modules/test_untied_performance.py
+++ b/tests/unit/noether/modeling/modules/test_untied_performance.py
@@ -67,7 +67,7 @@ def _run_strategy(
     """Dispatch to a specific forward strategy (or ``auto`` for the default)."""
     sizes = _domain_group_sizes(token_specs)
     B, S, D_in = x.shape
-    D_out = layer.weight.shape[1]
+    D_out = layer.output_dim
     T = len(sizes)
 
     if strategy == "split_loop":

--- a/tests/unit/noether/modeling/modules/test_untied_performance.py
+++ b/tests/unit/noether/modeling/modules/test_untied_performance.py
@@ -1,0 +1,250 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+"""Benchmarks for :class:`UntiedLinear`'s internal forward strategies.
+
+Excluded from the default test run — invoke explicitly with ``pytest -m benchmark``.
+
+:class:`UntiedLinear` auto-selects the fastest strategy at runtime.
+These benchmarks force each strategy individually so we can track their
+relative performance across sequence lengths, feature dims, and type counts.
+
+Strategies:
+
+- **split_loop**: ``split`` + one ``F.linear`` per domain (Python loop).
+- **equal_size_bmm**: reshape ``(B, S, D)`` → ``(T, B*n, D)`` + single ``torch.bmm``.
+  Only valid when all domain sizes are equal.
+- **padded_bmm**: pad each chunk to ``max(sizes)``, one ``torch.bmm``, unpad.
+  General but wastes FLOPs proportional to padding.
+- **grouped_mm**: :func:`torch.nn.functional.grouped_mm` (CUDA only).
+  Skipped when unavailable (e.g. CPU or unsupported dtype).
+"""
+
+from collections.abc import Sequence
+
+import pytest
+import torch
+
+from noether.core.schemas.modules.attention import TokenSpec
+from noether.core.schemas.modules.layers import LinearProjectionConfig
+from noether.core.schemas.modules.untied import UntiedLinearConfig
+from noether.modeling.modules.untied import UntiedLinear, _domain_group_sizes
+
+
+def _make_layer(num_types: int, dim: int, *, bias: bool = True) -> UntiedLinear:
+    """Build an UntiedLinear with ``dim -> dim``."""
+    cfg = UntiedLinearConfig(
+        num_types=num_types,
+        linear_projection=LinearProjectionConfig(input_dim=dim, output_dim=dim, bias=bias, init_weights="torch"),
+    )
+    return UntiedLinear(cfg)
+
+
+def _specs_for(seq_len: int, num_types: int, distribution: str) -> Sequence[TokenSpec]:
+    """Build token specs totaling ``seq_len`` tokens across ``num_types`` domains.
+
+    ``balanced``: every domain gets roughly ``seq_len / num_types`` tokens.
+    ``skewed``: domain 0 gets ~80%, remaining domains share the rest equally.
+    """
+    if distribution == "balanced":
+        base, rem = divmod(seq_len, num_types)
+        sizes = [base + (1 if i < rem else 0) for i in range(num_types)]
+    elif distribution == "skewed":
+        dominant = int(seq_len * 0.8)
+        tail = seq_len - dominant
+        tail_base, tail_rem = divmod(tail, max(num_types - 1, 1))
+        sizes = [dominant] + [tail_base + (1 if i < tail_rem else 0) for i in range(num_types - 1)]
+    else:
+        raise ValueError(f"Unknown distribution: {distribution}")
+    assert sum(sizes) == seq_len
+    return [TokenSpec(name=f"t{i}", size=s) for i, s in enumerate(sizes)]
+
+
+def _run_strategy(
+    layer: UntiedLinear,
+    x: torch.Tensor,
+    token_specs: Sequence[TokenSpec],
+    strategy: str,
+) -> torch.Tensor:
+    """Dispatch to a specific forward strategy (or ``auto`` for the default)."""
+    sizes = _domain_group_sizes(token_specs)
+    B, S, D_in = x.shape
+    D_out = layer.weight.shape[1]
+    T = len(sizes)
+
+    if strategy == "split_loop":
+        return layer._split_loop_forward(x, sizes, D_out)
+    elif strategy == "equal_size_bmm":
+        assert all(s == sizes[0] for s in sizes), "equal_size_bmm requires balanced sizes"
+        return layer._equal_size_bmm_forward(x, sizes[0], B, S, D_in, D_out, T)
+    elif strategy == "padded_bmm":
+        return layer._padded_bmm_forward(x, sizes, B, S, D_in, D_out, T, max(sizes))
+    elif strategy == "grouped_mm":
+        try:
+            return layer._grouped_mm_forward(x, sizes, B, S, D_in, D_out, T)
+        except (RuntimeError, NotImplementedError, ValueError) as e:
+            pytest.skip(f"grouped_mm unavailable: {e}")
+    else:
+        raise ValueError(f"Unknown strategy: {strategy}")
+
+
+# --- Parametrization grids ---------------------------------------------------
+
+SEQLEN_GRID = [256, 1024, 4096, 16384]
+DIM_GRID = [64, 256, 512, 1024]
+NUM_TYPES_GRID = [2, 4, 8, 16]
+DIST_GRID = ["balanced", "skewed"]
+BIAS_GRID = [True, False]
+DTYPE_GRID = [torch.float32, torch.bfloat16, torch.float16]
+BALANCED_STRATEGIES = ["split_loop", "equal_size_bmm", "grouped_mm"]
+ALL_STRATEGIES = ["split_loop", "padded_bmm", "grouped_mm"]
+
+
+# --- Benchmarks ---------------------------------------------------------------
+
+
+def _available_devices() -> list[str]:
+    devices = ["cpu"]
+    if torch.cuda.is_available():
+        devices.append("cuda")
+    return devices
+
+
+@pytest.fixture(params=_available_devices())
+def device(request: pytest.FixtureRequest) -> torch.device:
+    return torch.device(request.param)
+
+
+@pytest.mark.benchmark(group="untied_linear_seqlen")
+@pytest.mark.parametrize("strategy", BALANCED_STRATEGIES)
+@pytest.mark.parametrize("seq_len", SEQLEN_GRID)
+def test_untied_linear_vs_seqlen(benchmark, device, strategy, seq_len):
+    """How does runtime scale with sequence length?
+
+    Fixed: ``dim=256``, ``num_types=4``, balanced distribution.
+    """
+    dim, num_types = 256, 4
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim).to(device).eval()
+    specs = _specs_for(seq_len, num_types, "balanced")
+    x = torch.randn(1, seq_len, dim, device=device)
+
+    with torch.inference_mode():
+        _run_strategy(layer, x, specs, strategy)
+        benchmark(lambda: _run_strategy(layer, x, specs, strategy))
+
+
+@pytest.mark.benchmark(group="untied_linear_dim")
+@pytest.mark.parametrize("strategy", BALANCED_STRATEGIES)
+@pytest.mark.parametrize("dim", DIM_GRID)
+def test_untied_linear_vs_dim(benchmark, device, strategy, dim):
+    """How does runtime scale with the feature dimension?
+
+    Fixed: ``seq_len=2048``, ``num_types=4``, balanced distribution.
+    """
+    seq_len, num_types = 2048, 4
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim).to(device).eval()
+    specs = _specs_for(seq_len, num_types, "balanced")
+    x = torch.randn(1, seq_len, dim, device=device)
+
+    with torch.inference_mode():
+        _run_strategy(layer, x, specs, strategy)
+        benchmark(lambda: _run_strategy(layer, x, specs, strategy))
+
+
+@pytest.mark.benchmark(group="untied_linear_num_types")
+@pytest.mark.parametrize("strategy", BALANCED_STRATEGIES)
+@pytest.mark.parametrize("num_types", NUM_TYPES_GRID)
+def test_untied_linear_vs_num_types(benchmark, device, strategy, num_types):
+    """How does runtime scale with the number of token types?
+
+    Fixed: ``seq_len=2048``, ``dim=256``, balanced distribution.
+    """
+    seq_len, dim = 2048, 256
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim).to(device).eval()
+    specs = _specs_for(seq_len, num_types, "balanced")
+    x = torch.randn(1, seq_len, dim, device=device)
+
+    with torch.inference_mode():
+        _run_strategy(layer, x, specs, strategy)
+        benchmark(lambda: _run_strategy(layer, x, specs, strategy))
+
+
+@pytest.mark.benchmark(group="untied_linear_distribution")
+@pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+@pytest.mark.parametrize("distribution", DIST_GRID)
+def test_untied_linear_vs_distribution(benchmark, device, strategy, distribution):
+    """How sensitive is each strategy to a skewed distribution?
+
+    Fixed: ``seq_len=2048``, ``dim=256``, ``num_types=4``.
+    Note: ``equal_size_bmm`` cannot run on skewed distributions.
+    """
+    seq_len, dim, num_types = 2048, 256, 4
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim).to(device).eval()
+    specs = _specs_for(seq_len, num_types, distribution)
+    x = torch.randn(1, seq_len, dim, device=device)
+
+    with torch.inference_mode():
+        _run_strategy(layer, x, specs, strategy)
+        benchmark(lambda: _run_strategy(layer, x, specs, strategy))
+
+
+@pytest.mark.benchmark(group="untied_linear_bias")
+@pytest.mark.parametrize("strategy", BALANCED_STRATEGIES)
+@pytest.mark.parametrize("bias", BIAS_GRID)
+def test_untied_linear_vs_bias(benchmark, device, strategy, bias):
+    """How does the bias term affect runtime?
+
+    Fixed: ``seq_len=2048``, ``dim=256``, ``num_types=4``, balanced distribution.
+    """
+    seq_len, dim, num_types = 2048, 256, 4
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim, bias=bias).to(device).eval()
+    specs = _specs_for(seq_len, num_types, "balanced")
+    x = torch.randn(1, seq_len, dim, device=device)
+
+    with torch.inference_mode():
+        _run_strategy(layer, x, specs, strategy)
+        benchmark(lambda: _run_strategy(layer, x, specs, strategy))
+
+
+@pytest.mark.benchmark(group="untied_linear_dtype")
+@pytest.mark.parametrize("strategy", BALANCED_STRATEGIES)
+@pytest.mark.parametrize("dtype", DTYPE_GRID, ids=lambda d: d.__repr__().split(".")[-1])
+def test_untied_linear_vs_dtype(benchmark, device, strategy, dtype):
+    """How does runtime vary across data types?
+
+    Fixed: ``seq_len=2048``, ``dim=256``, ``num_types=4``, balanced distribution.
+    """
+    seq_len, dim, num_types = 2048, 256, 4
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim, bias=False).to(device=device, dtype=dtype).eval()
+    specs = _specs_for(seq_len, num_types, "balanced")
+    x = torch.randn(1, seq_len, dim, device=device, dtype=dtype)
+
+    with torch.inference_mode():
+        _run_strategy(layer, x, specs, strategy)
+        benchmark(lambda: _run_strategy(layer, x, specs, strategy))
+
+
+@pytest.mark.benchmark(group="untied_linear_backward")
+@pytest.mark.parametrize("strategy", BALANCED_STRATEGIES)
+@pytest.mark.parametrize("seq_len", [1024, 4096])
+@pytest.mark.parametrize("num_types", [2, 8])
+def test_untied_linear_forward_backward(benchmark, device, strategy, seq_len, num_types):
+    """Forward+backward — relevant for training-time cost."""
+    dim = 256
+    torch.manual_seed(0)
+    layer = _make_layer(num_types, dim).to(device).train()
+    specs = _specs_for(seq_len, num_types, "balanced")
+    x = torch.randn(1, seq_len, dim, device=device, requires_grad=True)
+
+    def step() -> None:
+        for p in layer.parameters():
+            p.grad = None
+        out = _run_strategy(layer, x, specs, strategy)
+        out.sum().backward()
+
+    step()
+    benchmark(step)


### PR DESCRIPTION
Currently ABUPT uses two sections of blocks: physics blocks that share parameters across all branches and that either self-attend within a branch or cross-attend between branches and decoder blocks that have branch specific parameters and only use self attention. The physics blocks are configured with the list of any of the possible physics block types (perceiver, self, cross, joint) and decoder blocks are just configured by their depth per branch.

We can generalise these two sections by adding new block types that mirror the existing block types but use untied weights, i.e. we learn MLP and projection parameters per branch instead of sharing them among all branches.

Effectively what was previously a decoder block is now a simple `self_untied` block: We do self attention but with untied weights. This formulation allows us to easily add new variants as well: `cross_untied` is a block with cross attention between branches while keeping parameters untied, something that wasn't possible before. For completness sake I also added a `perceiver_untied`.

This generalisation has the advantage of new functionality and simple configuration. We don't need to configure the number of decoder blocks per domain anymore. On top of this, the `UntiedLinear` implementation has a slight performance advantage over the per-branch loop, since we can use either batched matmul or grouped matmul depending on the per-branch shape.

## Experiments
https://wandb.ai/emmi-ai/drivaerml/reports/AB-UPT-Decoder-cross-branch-attention--VmlldzoxNjcwMDI5Ng

## Benchmark
The performance tests show that ABUPT with untied blocks has roughly the same forward time as ABUPT with branch wise decoders. These could vary across model size, I found that for smaller models the untied blocks outperform the looped decoders, but this washes out as scale increases.
<img width="1402" height="413" alt="image" src="https://github.com/user-attachments/assets/5cae5b74-e473-476e-a862-a41a46dbae52" />


## Open Choices
* (Layer)Norm parameters are currently shared between all branches, this could change to per-branch norms
* In a transformer block all the Linear layers are now untied. It is also valid to still share any of the Q,K,V projections though. 
* Sharing the Q,K,V projections makes this more akin to a Mixture-of-Experts model, with "manual" expert selection
