### PR TITLE
feat: seed DataLoader workers and use_deterministic_algorithms

### DIFF
--- a/src/noether/core/utils/seed.py
+++ b/src/noether/core/utils/seed.py
@@ -24,3 +24,26 @@ def set_seed(seed: int) -> None:
         torch.cuda.manual_seed_all(seed)
     if torch.backends.mps.is_available():
         torch.mps.manual_seed(seed)
+
+
+def seed_worker(worker_id: int) -> None:
+    """DataLoader ``worker_init_fn`` that re-seeds Python ``random`` and ``numpy``
+    inside each worker.
+
+    PyTorch already derives a per-worker torch seed from the ``DataLoader``'s
+    ``generator`` (or ``base_seed``) combined with ``worker_id``, so
+    ``torch.randperm``, ``torch.randn``, etc. inside workers are deterministic
+    as long as the ``DataLoader`` receives a seeded ``generator``. However,
+    ``random`` and ``numpy.random`` are forked from the main process unseeded
+    per-worker, which makes any code using them in a worker non-deterministic
+    across runs. This function pulls the torch worker seed and uses it to
+    reseed ``random`` and ``numpy`` so the whole worker is deterministic.
+
+    Args:
+        worker_id: Worker id passed by the DataLoader. Unused; kept to match
+            the ``worker_init_fn`` signature.
+    """
+    del worker_id  # torch.initial_seed() already encodes the worker id
+    worker_seed = torch.initial_seed() % 2**32
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)

--- a/src/noether/data/container.py
+++ b/src/noether/data/container.py
@@ -2,6 +2,7 @@
 
 import functools
 import logging
+from collections.abc import Callable
 
 import torch
 from torch.utils.data import DataLoader, DistributedSampler, RandomSampler, Sampler, SequentialSampler
@@ -10,6 +11,7 @@ from noether.core.distributed import is_distributed
 from noether.core.schemas.dataset import ShuffleWrapperConfig, SubsetWrapperConfig
 from noether.core.utils.common.stopwatch import Stopwatch
 from noether.core.utils.platform import get_fair_cpu_count, get_total_cpu_count
+from noether.core.utils.seed import seed_worker
 from noether.data import Dataset
 from noether.data.base.wrapper import DatasetWrapper
 from noether.data.base.wrappers import (
@@ -42,13 +44,23 @@ def _timing_collate_fn(collator, batch):
 class DataContainer:
     """Container that holds datasets and provides utilities for datasets and data loading."""
 
-    def __init__(self, datasets: dict[str, Dataset], num_workers: int | None = None, pin_memory: bool = True):
+    def __init__(
+        self,
+        datasets: dict[str, Dataset],
+        num_workers: int | None = None,
+        pin_memory: bool = True,
+        seed: int | None = None,
+    ):
         """
         Args:
             datasets: A dictionary with datasets for the training run.
             num_workers: Number of data loading workers to use. If None, will use (#CPUs / #GPUs - 1) workers.
                 The `-1` keeps 1 CPU free for the main process. Defaults to None.
             pin_memory: Is passed as `pin_memory` to `torch.utils.data.DataLoader`. Defaults to True.
+            seed: Optional seed used to initialize a ``torch.Generator`` for the ``DataLoader`` and
+                to reseed ``random``/``numpy`` inside each worker via ``worker_init_fn``. When None,
+                no generator is attached and workers are not explicitly reseeded (matches legacy behavior).
+                Typically the training seed (already rank-offset) should be passed here.
         """
         self.logger = logging.getLogger(type(self).__name__)
         if len(datasets) == 0:
@@ -56,6 +68,7 @@ class DataContainer:
         self.datasets = datasets
         self.num_workers = num_workers
         self.pin_memory = pin_memory
+        self.seed = seed
 
         # set first dataset as "train" dataset in place of an actual dataset
         # the "train" dataset is used to propagate shapes, so in evaluation runs if no train dataset is present,
@@ -182,6 +195,19 @@ class DataContainer:
         else:
             num_workers = self.num_workers
 
+        # Attach a seeded generator + worker_init_fn so that per-worker RNGs are deterministic given
+        # a training seed. The worker_init_fn reseeds `random` and `numpy.random` from the torch
+        # per-worker seed that PyTorch derives from the generator.
+        generator: torch.Generator | None
+        worker_init_fn: Callable[[int], None] | None
+        if self.seed is not None:
+            generator = torch.Generator()
+            generator.manual_seed(self.seed)
+            worker_init_fn = seed_worker
+        else:
+            generator = None
+            worker_init_fn = None
+
         loader = DataLoader(
             dataset=sampler.dataset,
             batch_sampler=sampler.batch_sampler,
@@ -189,11 +215,13 @@ class DataContainer:
             num_workers=num_workers,
             pin_memory=self.pin_memory,
             prefetch_factor=prefetch_factor,
+            worker_init_fn=worker_init_fn,
+            generator=generator,
         )
 
         self.logger.info(
             f"Created dataloader (batch_size={batch_size} num_workers={loader.num_workers} "
             f"pin_memory={loader.pin_memory} total_cpu_count={get_total_cpu_count()} "
-            f"prefetch_factor={loader.prefetch_factor})"
+            f"prefetch_factor={loader.prefetch_factor} seeded={self.seed is not None})"
         )
         return loader

--- a/src/noether/training/runners/hydra_runner.py
+++ b/src/noether/training/runners/hydra_runner.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import platform
+import typing
 from collections.abc import Iterator
 from functools import partial
 from pathlib import Path
@@ -169,6 +170,7 @@ class HydraRunner:
                 logger.warning("disabled cudnn benchmark")
                 if config.cudnn_deterministic:
                     torch.backends.cudnn.deterministic = True
+                    torch.use_deterministic_algorithms(True, warn_only=False)
                     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
                     logger.warning("enabled cudnn deterministic")
 
@@ -178,11 +180,12 @@ class HydraRunner:
             if is_distributed():
                 object_list = [run_id] if is_rank0() else [0]  # type: ignore
                 broadcast_object_list(object_list, src=0)
-                run_id = object_list[0]
+                run_id = typing.cast("str", object_list[0])
                 assert run_id is not None, "run_id should have been broadcasted to all ranks"
 
         # initialize path where to store logs/checkpoints/...
         output_path = config.output_path
+        assert output_path is not None, "output_path must be specified in the config"
 
         # initialize logging
         path_provider = PathProvider(
@@ -300,7 +303,12 @@ class HydraRunner:
             dataset.pipeline = pipeline
             datasets[dataset_key] = dataset
 
-        data_container = DataContainer(datasets=datasets, num_workers=config.num_workers, pin_memory=device == "cuda")
+        data_container = DataContainer(
+            datasets=datasets,
+            num_workers=config.num_workers,
+            pin_memory=device == "cuda",
+            seed=seed,
+        )
 
         # init trainer
         trainer = Factory().create(

--- a/tests/integration/noether/data/test_pipeline_determinism.py
+++ b/tests/integration/noether/data/test_pipeline_determinism.py
@@ -1,0 +1,117 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Integration test: a MultiStagePipeline whose sample processors use the global torch RNG must
+produce the *exact same* batches across runs when the training seed is set and the DataLoader is
+configured with a seeded generator + ``seed_worker`` ``worker_init_fn``.
+
+This is the end-to-end guarantee behind the bug where ABUPT training on ``aero_cfd`` showed variance
+between runs that used the same seed: without worker seeding the ``torch.randperm`` inside
+``PointSamplingSampleProcessor`` / ``SupernodeSamplingSampleProcessor`` was driven by a per-worker
+RNG that drifted between runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from noether.core.utils.seed import seed_worker, set_seed
+from noether.data.pipeline.multistage import MultiStagePipeline
+from noether.data.pipeline.sample_processors.point_sampling import PointSamplingSampleProcessor
+from noether.data.pipeline.sample_processors.supernode_sampling import SupernodeSamplingSampleProcessor
+
+
+class _FixedPointCloudDataset(Dataset):
+    """Tiny dataset of fixed pointclouds with no internal randomness.
+
+    Each sample is generated once at construction time from a dedicated generator so the dataset
+    itself contributes zero variance — any difference observed between runs is purely from the
+    pipeline / DataLoader RNG path.
+    """
+
+    def __init__(self, num_samples: int, points_per_sample: int, feature_dim: int = 3):
+        gen = torch.Generator().manual_seed(0)
+        self._items: list[dict[str, torch.Tensor | int]] = [
+            {
+                "input_position": torch.randn(points_per_sample, feature_dim, generator=gen),
+                "index": i,
+            }
+            for i in range(num_samples)
+        ]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor | int]:
+        # Return a shallow copy: MultiStagePipeline already deep-copies each sample before
+        # handing it to the sample processors, but keeping this dataset side-effect-free avoids
+        # worker-to-worker coupling through shared tensors.
+        return dict(self._items[idx])
+
+
+def _build_pipeline() -> MultiStagePipeline:
+    """A pipeline with two stochastic sample processors that both rely on the global torch RNG."""
+    return MultiStagePipeline(
+        sample_processors=[
+            PointSamplingSampleProcessor(items={"input_position"}, num_points=32),
+            SupernodeSamplingSampleProcessor(
+                item="input_position",
+                num_supernodes=4,
+                items_at_supernodes={"input_position"},
+            ),
+        ],
+    )
+
+
+def _drain(loader: DataLoader) -> list[dict[str, torch.Tensor]]:
+    """Materialize every batch so we can compare across runs without lazy-iterator surprises."""
+    return [{k: v.clone() for k, v in batch.items() if torch.is_tensor(v)} for batch in loader]
+
+
+def _assert_batches_equal(run_a: list[dict[str, torch.Tensor]], run_b: list[dict[str, torch.Tensor]]) -> None:
+    assert len(run_a) == len(run_b), f"different number of batches: {len(run_a)} vs {len(run_b)}"
+    for i, (ba, bb) in enumerate(zip(run_a, run_b, strict=True)):
+        assert ba.keys() == bb.keys(), f"batch {i} key mismatch: {ba.keys()} vs {bb.keys()}"
+        for k in ba:
+            assert torch.equal(ba[k], bb[k]), f"batch {i} key {k!r} differs"
+
+
+def _run_pipeline(seed: int, num_workers: int) -> list[dict[str, torch.Tensor]]:
+    set_seed(seed)
+    dataset = _FixedPointCloudDataset(num_samples=8, points_per_sample=64)
+    pipeline = _build_pipeline()
+
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        dataset,
+        batch_size=2,
+        shuffle=True,
+        collate_fn=pipeline,
+        num_workers=num_workers,
+        worker_init_fn=seed_worker if num_workers > 0 else None,
+        generator=generator,
+    )
+    return _drain(loader)
+
+
+@pytest.mark.parametrize("num_workers", [0, 2])
+def test_multistage_pipeline_with_sampling_processors_is_deterministic(num_workers: int):
+    """Two runs with the same seed must produce identical batches — both when sampling happens
+    in the main process (``num_workers=0``) and when it happens in forked workers
+    (``num_workers>0``, which is where the worker seeding bug used to bite)."""
+    run_a = _run_pipeline(seed=1337, num_workers=num_workers)
+    run_b = _run_pipeline(seed=1337, num_workers=num_workers)
+    _assert_batches_equal(run_a, run_b)
+
+
+def test_multistage_pipeline_with_sampling_processors_changes_with_seed():
+    """Sanity check: different seeds must produce different batches, otherwise the test above
+    would trivially pass even if seeding was broken."""
+    run_a = _run_pipeline(seed=1337, num_workers=0)
+    run_b = _run_pipeline(seed=7331, num_workers=0)
+
+    # At least one tensor across the run must differ — the sampling is ordered + subset selection,
+    # so identical output would be extremely unlikely.
+    any_difference = any(not torch.equal(a[k], b[k]) for a, b in zip(run_a, run_b, strict=True) for k in a if k in b)
+    assert any_difference, "different seeds produced identical batches — seeding is not taking effect"

--- a/tests/unit/noether/core/utils/test_seed.py
+++ b/tests/unit/noether/core/utils/test_seed.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import numpy as np
 import torch
 
-from noether.core.utils.seed import set_seed
+from noether.core.utils.seed import seed_worker, set_seed
 
 
 def test_set_seed_calls_libraries_cpu():
@@ -85,3 +85,39 @@ def test_set_seed_reproducibility():
     val2_torch = torch.randn(5)
 
     assert torch.equal(val1_torch, val2_torch)
+
+
+def test_seed_worker_reseeds_random_and_numpy():
+    """seed_worker should derive its seed from torch.initial_seed() and reseed
+    `random` and `numpy.random` accordingly so workers are deterministic."""
+    fake_worker_seed = 424242
+
+    with (
+        patch("torch.initial_seed", return_value=fake_worker_seed),
+        patch("numpy.random.seed") as mock_np_seed,
+        patch("random.seed") as mock_random_seed,
+    ):
+        seed_worker(worker_id=0)
+
+        expected = fake_worker_seed % 2**32
+        mock_np_seed.assert_called_once_with(expected)
+        mock_random_seed.assert_called_once_with(expected)
+
+
+def test_seed_worker_different_workers_different_seeds():
+    """Different torch worker seeds should produce different random/numpy seeds."""
+    np_seeds: list[int] = []
+    random_seeds: list[int] = []
+
+    for fake_seed in [1, 2, 3]:
+        with (
+            patch("torch.initial_seed", return_value=fake_seed),
+            patch("numpy.random.seed") as mock_np_seed,
+            patch("random.seed") as mock_random_seed,
+        ):
+            seed_worker(worker_id=0)
+            np_seeds.append(mock_np_seed.call_args.args[0])
+            random_seeds.append(mock_random_seed.call_args.args[0])
+
+    assert len(set(np_seeds)) == 3
+    assert len(set(random_seeds)) == 3

--- a/tests/unit/noether/data/test_container.py
+++ b/tests/unit/noether/data/test_container.py
@@ -1,0 +1,77 @@
+#  Copyright © 2025 Emmi AI GmbH. All rights reserved.
+
+"""Tests for the DataContainer DataLoader seeding behavior."""
+
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from noether.core.utils.seed import seed_worker
+from noether.data.container import DataContainer
+
+
+def _make_container(seed: int | None) -> DataContainer:
+    """Build a DataContainer with a dummy dataset that never gets used (DataLoader is mocked)."""
+    dataset = MagicMock()
+    # DataContainer refuses empty dataset dicts but otherwise does not touch the dataset here.
+    return DataContainer(datasets={"train": dataset}, num_workers=0, pin_memory=False, seed=seed)
+
+
+def _call_get_data_loader(container: DataContainer):
+    """Drive get_data_loader with an InterleavedSampler that is fully mocked so we can observe the
+    kwargs that DataContainer forwards to torch.utils.data.DataLoader."""
+    sampler = MagicMock()
+    sampler.dataset = MagicMock()
+    sampler.batch_sampler = MagicMock()
+    sampler.collator = MagicMock()
+
+    with (
+        patch("noether.data.container.InterleavedSampler", return_value=sampler),
+        patch("noether.data.container.DataLoader") as mock_loader_cls,
+    ):
+        mock_loader = MagicMock()
+        mock_loader.num_workers = 0
+        mock_loader.pin_memory = False
+        mock_loader.prefetch_factor = None
+        mock_loader_cls.return_value = mock_loader
+
+        container.get_data_loader(
+            train_sampler=MagicMock(),
+            train_collator=None,
+            batch_size=2,
+            epochs=1,
+            updates=None,
+            samples=None,
+            callback_samplers=[],
+        )
+
+        assert mock_loader_cls.called, "DataLoader should have been constructed"
+        return mock_loader_cls.call_args.kwargs
+
+
+def test_data_container_seeded_passes_generator_and_worker_init_fn():
+    seed = 1234
+    container = _make_container(seed=seed)
+    kwargs = _call_get_data_loader(container)
+
+    assert kwargs["worker_init_fn"] is seed_worker
+
+    generator = kwargs["generator"]
+    assert isinstance(generator, torch.Generator)
+
+    # The generator should be seeded deterministically from the given seed: constructing a second
+    # generator with the same seed must produce identical draws.
+    reference = torch.Generator()
+    reference.manual_seed(seed)
+    assert torch.equal(
+        torch.randint(0, 2**31 - 1, (8,), generator=generator),
+        torch.randint(0, 2**31 - 1, (8,), generator=reference),
+    )
+
+
+def test_data_container_unseeded_passes_none():
+    container = _make_container(seed=None)
+    kwargs = _call_get_data_loader(container)
+
+    assert kwargs["worker_init_fn"] is None
+    assert kwargs["generator"] is None


### PR DESCRIPTION
Passes the (rank-offset) training seed to the DataLoader via a seeded ``torch.Generator`` and a ``worker_init_fn`` that reseeds ``random`` and ``numpy`` inside each worker from the torch per-worker seed. Without this, multi-worker data loading drew new per-worker RNG state on every run even when the main-process seed was fixed.

test: multistage pipeline with sampling processors is seed-deterministic

End-to-end regression guard for the worker-seeding fix: builds a real MultiStagePipeline with PointSamplingSampleProcessor + SupernodeSamplingSampleProcessor (both relying on the global torch RNG), runs it through a DataLoader twice with the same seed, and asserts every batch is bit-exact identical. Covers num_workers=0 and num_workers>0 so the worker_init_fn / seeded-generator path is exercised, plus a sanity check that different seeds produce different batches.
