### PR TITLE
fix: flush tracker on eval and exception

### DIFF
--- a/src/noether/core/writers/log_writer.py
+++ b/src/noether/core/writers/log_writer.py
@@ -2,7 +2,8 @@
 
 import logging
 from collections import defaultdict
-from typing import Any
+from types import TracebackType
+from typing import Any, Self
 
 import numpy as np
 import torch
@@ -46,8 +47,22 @@ class LogWriter:
         """
         return [entry[key] for entry in self.log_entries if key in entry]
 
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.finish()
+
     def finish(self) -> None:
         """Stores all logs from the training to the disk."""
+
+        self.flush()
+
         if len(self.log_entries) == 0 or not is_rank0():
             return
         entries_uri = self.path_provider.basetracker_entries_uri

--- a/src/noether/training/trainers/base.py
+++ b/src/noether/training/trainers/base.py
@@ -645,27 +645,28 @@ class BaseTrainer:
         batch_size, accumulation_steps_total, train_batches_per_epoch = self._prepare_batch_size()
 
         data_loader = self.get_data_loader(iterator_callbacks=iterator_callbacks, batch_size=batch_size)
-        dist_model.eval()
-        self.call_before_training(self.callbacks)
-        dist_model.train()
 
-        self._train(
-            model=model,
-            dist_model=dist_model,
-            batch_size=batch_size,
-            accumulation_steps_total=accumulation_steps_total,
-            data_loader=data_loader,
-            train_batches_per_epoch=train_batches_per_epoch,
-            periodic_callbacks=[
-                callback_instance
-                for callback_instance in self.callbacks
-                if isinstance(callback_instance, PeriodicCallback)
-            ],
-        )
+        with self.log_writer:
+            dist_model.eval()
+            self.call_before_training(self.callbacks)
+            dist_model.train()
 
-        dist_model.eval()
-        self.call_after_training(callbacks=self.callbacks)
-        self.log_writer.finish()
+            self._train(
+                model=model,
+                dist_model=dist_model,
+                batch_size=batch_size,
+                accumulation_steps_total=accumulation_steps_total,
+                data_loader=data_loader,
+                train_batches_per_epoch=train_batches_per_epoch,
+                periodic_callbacks=[
+                    callback_instance
+                    for callback_instance in self.callbacks
+                    if isinstance(callback_instance, PeriodicCallback)
+                ],
+            )
+
+            dist_model.eval()
+            self.call_after_training(callbacks=self.callbacks)
 
     def _train(
         self,
@@ -1077,7 +1078,6 @@ class BaseTrainer:
         for callback in callbacks:
             callback.after_training(update_counter=self.update_counter)
             self.logger.debug(f"Executing {callback}")
-        self.log_writer.flush()
 
     def eval(self, model: ModelBase) -> None:
         """Run evaluation by executing all configured callbacks."""
@@ -1097,20 +1097,21 @@ class BaseTrainer:
         )
         data_iter = iter(data_loader)
 
-        for callback in callbacks:
-            if not isinstance(callback, PeriodicCallback):
-                continue
-            self.logger.info(f"Running periodic callback: {callback}")
-            iterator_callback_args = (
-                dict(
-                    trainer_model=dist_model,
-                    data_iter=map(BaseTrainer.drop_metadata, data_iter),
-                    batch_size=batch_size,
+        with self.log_writer:
+            for callback in callbacks:
+                if not isinstance(callback, PeriodicCallback):
+                    continue
+                self.logger.info(f"Running periodic callback: {callback}")
+                iterator_callback_args = (
+                    dict(
+                        trainer_model=dist_model,
+                        data_iter=map(BaseTrainer.drop_metadata, data_iter),
+                        batch_size=batch_size,
+                    )
+                    if _needs_iterator_args(callback)
+                    else {}
                 )
-                if _needs_iterator_args(callback)
-                else {}
-            )
-            callback.at_eval(self.update_counter, **iterator_callback_args)
+                callback.at_eval(self.update_counter, **iterator_callback_args)
 
     @property
     def total_training_updates(self) -> int:

--- a/tests/unit/noether/core/writers/test_log_writer.py
+++ b/tests/unit/noether/core/writers/test_log_writer.py
@@ -266,3 +266,20 @@ class TestFinish:
         data = torch.load(lw.path_provider.basetracker_entries_uri, weights_only=False)
         # "update" key should not appear as a top-level metric:
         assert "update" not in data
+
+
+class TestContextManager:
+    def test_exit_calls_finish_on_normal_exit(self, tmp_path):
+        lw = _make_log_writer(tmp_path)
+        with patch.object(lw, "finish") as mock_finish:
+            with lw as entered:
+                assert entered is lw
+        mock_finish.assert_called_once()
+
+    def test_exit_calls_finish_on_exception(self, tmp_path):
+        lw = _make_log_writer(tmp_path)
+        with patch.object(lw, "finish") as mock_finish:
+            with pytest.raises(RuntimeError, match="boom"):
+                with lw:
+                    raise RuntimeError("boom")
+        mock_finish.assert_called_once()

--- a/tests/unit/noether/training/test_base_trainer.py
+++ b/tests/unit/noether/training/test_base_trainer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1214,12 +1215,11 @@ class TestTrainingHooks:
         cb1.before_training.assert_called_once_with(update_counter=trainer.update_counter)
         cb2.before_training.assert_called_once_with(update_counter=trainer.update_counter)
 
-    def test_call_after_training_invokes_callbacks_and_flushes(self):
+    def test_call_after_training_invokes_callbacks(self):
         trainer = _make_trainer()
         cb = MagicMock()
         trainer.call_after_training([cb])
         cb.after_training.assert_called_once_with(update_counter=trainer.update_counter)
-        trainer.log_writer.flush.assert_called_once()
 
 
 class TestApplyResumeInitializer:
@@ -1477,6 +1477,91 @@ class TestSkipRemainingBatches:
         data_iter = MagicMock(spec=[])  # no batch_sampler attribute
         # Should not raise
         trainer._skip_remaining_batches(data_iter, remaining_batches=5, accumulation_steps_total=2, batch_size=4)
+
+
+class _FakeLogWriter:
+    """Mimics the ``LogWriter`` context-manager contract: ``__exit__`` calls ``finish``."""
+
+    def __init__(self):
+        self.finish = MagicMock()
+        self.flush = MagicMock()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.finish()
+        return None
+
+
+class TestLogWriterFinishedInTrainAndEval:
+    """``train`` and ``eval`` must call ``log_writer.finish`` even when the body raises."""
+
+    @staticmethod
+    def _enter_train_patches(stack, trainer, _train_side_effect=None):
+        model = MagicMock()
+        model.device = torch.device("cpu")
+        model.to.return_value = model
+        stack.enter_context(patch.object(trainer, "get_all_callbacks", return_value=[]))
+        stack.enter_context(patch.object(trainer, "_prepare_model", return_value=model))
+        stack.enter_context(patch.object(trainer, "wrap_model", return_value=model))
+        stack.enter_context(patch.object(trainer, "_prepare_batch_size", return_value=(4, 1, 25)))
+        stack.enter_context(patch.object(trainer, "get_data_loader", return_value=iter([])))
+        stack.enter_context(patch.object(trainer, "call_before_training"))
+        stack.enter_context(patch.object(trainer, "call_after_training"))
+        stack.enter_context(patch.object(trainer, "_train", side_effect=_train_side_effect))
+        return model
+
+    @staticmethod
+    def _enter_eval_patches(stack, trainer, callbacks=None):
+        model = MagicMock()
+        model.device = torch.device("cpu")
+        model.to.return_value = model
+        model.eval.return_value = model
+        stack.enter_context(patch.object(trainer, "get_user_callbacks", return_value=callbacks or []))
+        stack.enter_context(patch.object(trainer, "_prepare_model", return_value=model))
+        stack.enter_context(patch.object(trainer, "wrap_model", return_value=model))
+        stack.enter_context(patch.object(trainer, "_prepare_batch_size", return_value=(4, 1, 25)))
+        stack.enter_context(patch.object(trainer, "get_data_loader", return_value=iter([])))
+        return model
+
+    def test_train_calls_finish_on_success(self):
+        trainer = _make_trainer()
+        trainer.log_writer = _FakeLogWriter()
+        with ExitStack() as stack:
+            model = self._enter_train_patches(stack, trainer)
+            trainer.train(model)
+        trainer.log_writer.finish.assert_called_once()
+
+    def test_train_calls_finish_on_exception(self):
+        trainer = _make_trainer()
+        trainer.log_writer = _FakeLogWriter()
+        with ExitStack() as stack:
+            model = self._enter_train_patches(stack, trainer, _train_side_effect=RuntimeError("boom"))
+            with pytest.raises(RuntimeError, match="boom"):
+                trainer.train(model)
+        trainer.log_writer.finish.assert_called_once()
+
+    def test_eval_calls_finish_on_success(self):
+        trainer = _make_trainer()
+        trainer.log_writer = _FakeLogWriter()
+        with ExitStack() as stack:
+            model = self._enter_eval_patches(stack, trainer)
+            trainer.eval(model)
+        trainer.log_writer.finish.assert_called_once()
+
+    def test_eval_calls_finish_on_exception(self):
+        from noether.core.callbacks import PeriodicCallback
+
+        trainer = _make_trainer()
+        trainer.log_writer = _FakeLogWriter()
+        cb = MagicMock(spec=PeriodicCallback)
+        cb.at_eval.side_effect = RuntimeError("boom")
+        with ExitStack() as stack:
+            model = self._enter_eval_patches(stack, trainer, callbacks=[cb])
+            with pytest.raises(RuntimeError, match="boom"):
+                trainer.eval(model)
+        trainer.log_writer.finish.assert_called_once()
 
 
 class TestEval:


### PR DESCRIPTION
We weren't calling tracker.flush in the eval path. This was missed because it was part of `call_after_training`. We always want to call flush before finish, thus we can make log_writer a context manager that calls finish on exit and inside finish we now call flush. 