### PR TITLE
feat: functionality to evaluate on EMA weights

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   hooks:
     - id: mypy
       name: mypy (via uv)
-      entry: uv run mypy
+      entry: uv run mypy --show-traceback
       language: system
       types: [python]
       # Only check files in src/noether, exclude template files due to placeholders

--- a/docs/source/guides/training/use_callbacks.rst
+++ b/docs/source/guides/training/use_callbacks.rst
@@ -61,11 +61,30 @@ Noether includes many pre-defined callbacks organized by their purpose:
    * - **Monitoring**
      - :class:`~noether.core.callbacks.default.ProgressCallback`, :class:`~noether.core.callbacks.default.DatasetStatsCallback`, :class:`~noether.core.callbacks.default.LrCallback`, :class:`~noether.core.callbacks.default.PeakMemoryCallback`, :class:`~noether.core.callbacks.default.OnlineLossCallback`, :class:`~noether.core.callbacks.default.ParamCountCallback`, :class:`~noether.core.callbacks.default.EtaCallback`, :class:`~noether.core.callbacks.default.TrainTimeCallback`. Used for real-time tracking of training progress and hardware usage. These callbacks are all initialized by default by the :class:`~noether.training.trainers.BaseTrainer`, the user does not need to add them manually.
    * - **Checkpointing**
-     - :class:`~noether.core.callbacks.checkpoint.best_checkpoint.BestCheckpointCallback`, :class:`~noether.core.callbacks.checkpoint.checkpoint.CheckpointCallback`, :class:`~noether.core.callbacks.checkpoint.ema.EMACallback`. Used to save model weights periodically or when a new best metric is achieved.
+     - :class:`~noether.core.callbacks.checkpoint.best_checkpoint.BestCheckpointCallback`, :class:`~noether.core.callbacks.checkpoint.checkpoint.CheckpointCallback`, :class:`~noether.core.callbacks.checkpoint.ema.EmaCallback`. Used to save model weights periodically or when a new best metric is achieved.
    * - **Early Stopping**
      - :class:`~noether.core.callbacks.early_stoppers.metric.MetricEarlyStopper`, :class:`~noether.core.callbacks.early_stoppers.fixed.FixedEarlyStopper`. Used to stop training automatically if progress plateaus.
    * - **Evaluation**
      - :class:`~noether.core.callbacks.online.best_metric.BestMetricCallback`, :class:`~noether.core.callbacks.online.track_outputs. TrackOutputsCallback`. Specialized monitoring for tracked metrics.
+
+Evaluating Against EMA Weights
+------------------------------
+
+:class:`~noether.core.callbacks.checkpoint.ema.EmaCallback` maintains exponential moving averages of the model weights and checkpoints them to disk. It can also own a list of nested periodic callbacks via the ``eval_callbacks`` field. At each eval-time hook the EMA weights are swapped into the live model, the nested callbacks are dispatched (so they run against EMA weights), and the live weights are restored.
+
+Children keep their own schedule (``every_n_epochs`` etc.), run once per ``target_factor``, and have their logged metric keys auto-prefixed with ``ema=<factor>/`` to avoid collisions with live-model metrics.
+
+.. code-block:: yaml
+
+   - kind: noether.core.callbacks.EmaCallback
+     every_n_epochs: 10
+     target_factors: [0.9999]
+     save_latest_weights: true
+     eval_callbacks:
+       - kind: noether.training.callbacks.OfflineLossCallback
+         every_n_epochs: 1
+         dataset_key: val
+       # logs as ``ema=0.9999/loss/val/total``
 
 When to Use What?
 -----------------

--- a/recipes/aero_cfd/configs/callbacks/training_callbacks_caeml.yaml
+++ b/recipes/aero_cfd/configs/callbacks/training_callbacks_caeml.yaml
@@ -33,7 +33,15 @@
   save_latest_weights: true
   target_factors:
     - 0.9999
-  # example of how to save/load only specific submodules of a composite model
-  # model_paths:
-  #    - low_level_blocks
-  #    - high_level_blocks
+  # nested eval callbacks: run validation with EMA weights swapped in. Metric keys are auto-prefixed
+  # with ``ema=<factor>/`` (e.g. ``ema=0.9999/loss/val/total``).
+  eval_callbacks:
+    - kind: noether.training.callbacks.OfflineLossCallback
+      batch_size: 1
+      every_n_epochs: 1
+      dataset_key: val
+    - kind: callbacks.AeroMetricsCallback
+      batch_size: 1
+      every_n_epochs: ${trainer.max_epochs}
+      dataset_key: chunked_test
+      forward_properties: ${model.forward_properties}

--- a/recipes/aero_cfd/configs/callbacks/training_callbacks_shapenet.yaml
+++ b/recipes/aero_cfd/configs/callbacks/training_callbacks_shapenet.yaml
@@ -31,3 +31,13 @@
   save_latest_weights: true
   target_factors:
     - 0.9999
+  eval_callbacks:
+    - kind: noether.training.callbacks.OfflineLossCallback
+      batch_size: 1
+      every_n_epochs: 1
+      dataset_key: test
+    - kind: callbacks.AeroMetricsCallback
+      batch_size: 1
+      every_n_epochs: ${trainer.max_epochs}
+      dataset_key: test_repeat
+      forward_properties: ${model.forward_properties}

--- a/src/noether/core/callbacks/base.py
+++ b/src/noether/core/callbacks/base.py
@@ -107,6 +107,20 @@ class CallbackBase:
         self.metric_property_provider = metric_property_provider
         self.checkpoint_writer = checkpoint_writer
 
+    def get_children(self) -> list[CallbackBase]:
+        """Return nested callbacks owned by this callback, if any.
+
+        Composite callbacks (e.g. :class:`~noether.core.callbacks.checkpoint.ema.EmaCallback` when it owns
+        ``eval_callbacks``) use this to expose their children to the trainer so nested
+        :class:`~noether.core.callbacks.periodic.PeriodicDataIteratorCallback` instances still get their
+        samplers registered on the shared data loader. Dispatch of lifecycle hooks on the children remains
+        the responsibility of the owning callback.
+
+        Returns:
+            List of child callbacks (empty by default).
+        """
+        return []
+
     @property
     def checkpoint_key(self) -> str:
         """Key used to identify this callback's state in checkpoints.

--- a/src/noether/core/callbacks/checkpoint/ema.py
+++ b/src/noether/core/callbacks/checkpoint/ema.py
@@ -1,22 +1,39 @@
 #  Copyright © 2025 Emmi AI GmbH. All rights reserved.
 
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 
 import torch
+import torch.distributed as dist
 
+from noether.core.callbacks.base import CallbackBase
 from noether.core.callbacks.periodic import IntervalType, PeriodicCallback
-from noether.core.distributed import is_rank0
+from noether.core.distributed import is_distributed, is_rank0
+from noether.core.factory import Factory
 from noether.core.models.base import ModelBase
 from noether.core.providers.path import PathProvider
 from noether.core.schemas.callbacks import EmaCallbackConfig
 from noether.core.types import CheckpointKeys
 from noether.core.utils.common import select_with_path
+from noether.core.utils.training.counter import UpdateCounter
 from noether.core.utils.training.training_iteration import TrainingIteration
+from noether.core.writers import PrefixedLogWriter
 
 
 class EmaCallback(PeriodicCallback):
     """Callback for exponential moving average (EMA) of model weights.
+
+    In addition to maintaining and checkpointing EMA weights, this callback can optionally own a list of
+    child evaluation callbacks via ``eval_callbacks``. At each eval-time hook (``after_epoch``,
+    ``after_update``, ``at_eval``) the EMA weights are swapped into the live model, the children are
+    dispatched, and the live weights are restored. Children are dispatched once per ``target_factor`` and
+    their metric keys are automatically prefixed with ``ema=<factor>/`` to avoid collisions with live-model
+    metrics.
 
     Example config:
 
@@ -30,6 +47,10 @@ class EmaCallback(PeriodicCallback):
           target_factors:
             - 0.9999
           name: EmaCallback
+          eval_callbacks:
+            - kind: noether.training.callbacks.OfflineLossCallback
+              every_n_epochs: 1
+              dataset_key: val
     """
 
     def __init__(
@@ -54,6 +75,30 @@ class EmaCallback(PeriodicCallback):
         self.parameters: dict[tuple[str | None, float], dict[str, torch.Tensor]] = defaultdict(dict)
         self.buffers: dict[str | None, dict[str, torch.Tensor]] = defaultdict(dict)
         self._was_resumed = False
+
+        # Build nested eval callbacks (one set per target_factor). Each child gets a PrefixedLogWriter so its
+        # metric keys are namespaced as ``ema=<factor>/<original_key>``. Dispatch (including schedule gating)
+        # is still handled by each child's own ``after_epoch`` / ``after_update`` / ``at_eval`` methods.
+        self.eval_callbacks: dict[float, list[CallbackBase]] = {}
+        eval_callback_configs = getattr(callback_config, "eval_callbacks", None)
+        if eval_callback_configs:
+            base_kwargs = dict(kwargs)
+            for target_factor in self.target_factors:
+                prefix = f"ema={target_factor}"
+                child_kwargs = {
+                    **base_kwargs,
+                    "log_writer": PrefixedLogWriter(inner=kwargs["log_writer"], prefix=prefix),
+                }
+                self.eval_callbacks[target_factor] = Factory().create_list(eval_callback_configs, **child_kwargs)
+
+    def get_children(self) -> list[CallbackBase]:
+        """Flat list of child eval callbacks (across all ``target_factors``).
+
+        Exposed to the trainer so nested ``PeriodicDataIteratorCallback`` instances have their samplers
+        registered on the shared data loader. The EMA callback remains responsible for dispatching lifecycle
+        hooks to its children.
+        """
+        return [cb for cbs in self.eval_callbacks.values() for cb in cbs]
 
     def _load_ema_checkpoint(self, ema_path, cur_model, model_path, target_factor):
         """Load EMA state from a checkpoint file."""
@@ -111,17 +156,20 @@ class EmaCallback(PeriodicCallback):
                     self._init_ema_from_model(cur_model, model_path, target_factor)
         self._was_resumed = True
 
-    def before_training(self, **_) -> None:
-        if not is_rank0():
-            return
-        if self._was_resumed:
-            return
-        for model_path in self.model_paths:
-            cur_model = select_with_path(obj=self.model, path=model_path)
-            if not isinstance(cur_model, torch.nn.Module):
-                raise ValueError(f"Path {model_path} on model {self.model} did not resolve to a torch.nn.Module")
-            for target_factor in self.target_factors:
-                self._init_ema_from_model(cur_model, model_path, target_factor)
+    def before_training(self, **kwargs) -> None:
+        if is_rank0() and not self._was_resumed:
+            for model_path in self.model_paths:
+                cur_model = select_with_path(obj=self.model, path=model_path)
+                if not isinstance(cur_model, torch.nn.Module):
+                    raise ValueError(f"Path {model_path} on model {self.model} did not resolve to a torch.nn.Module")
+                for target_factor in self.target_factors:
+                    self._init_ema_from_model(cur_model, model_path, target_factor)
+
+        # Forward to children on all ranks (without swapping: children may initialize dataset readers,
+        # samplers, etc., against the live model).
+        for children in self.eval_callbacks.values():
+            for child in children:
+                child.before_training(**kwargs)
 
     def apply_ema(self, cur_model, model_path, target_factor):
         """fused in-place implementation"""
@@ -148,6 +196,72 @@ class EmaCallback(PeriodicCallback):
 
             for name, buffer in cur_model.named_buffers():
                 self.buffers[model_path][name].copy_(buffer)
+
+    @contextmanager
+    def _swapped_weights(self, target_factor: float) -> Iterator[None]:
+        """Temporarily replace live model params/buffers with EMA values for ``target_factor``.
+
+        EMA state is only maintained on rank 0 (see :meth:`track_after_update_step`). On non-rank-0 ranks
+        the local live weights are used as the broadcast destination, and rank 0 broadcasts its EMA-loaded
+        params/buffers to every rank so all ranks run evaluation against the same EMA weights.
+
+        The live weights are always restored on exit, even if the inner block raises. Iterates over all
+        configured ``model_paths``.
+        """
+        snapshots: list[tuple[torch.nn.Module, list[torch.Tensor], list[torch.Tensor], str | None]] = []
+        for model_path in self.model_paths:
+            cur_model = select_with_path(obj=self.model, path=model_path)
+            if not isinstance(cur_model, torch.nn.Module):
+                raise ValueError(f"Path {model_path} on model {self.model} did not resolve to a torch.nn.Module")
+            live_params = [p.detach().clone() for p in cur_model.parameters()]
+            live_buffers = [b.detach().clone() for b in cur_model.buffers()]
+            snapshots.append((cur_model, live_params, live_buffers, model_path))
+
+        try:
+            for cur_model, _live_params, _live_buffers, model_path in snapshots:
+                if is_rank0():
+                    key = (model_path, target_factor)
+                    for name, param in cur_model.named_parameters():
+                        param.data.copy_(self.parameters[key][name])
+                    for name, buffer in cur_model.named_buffers():
+                        buffer.data.copy_(self.buffers[model_path][name])
+                if is_distributed():
+                    for param in cur_model.parameters():
+                        dist.broadcast(param.data, src=0)
+                    for buffer in cur_model.buffers():
+                        dist.broadcast(buffer.data, src=0)
+            yield
+        finally:
+            for cur_model, live_params, live_buffers, _model_path in snapshots:
+                for param, snap in zip(cur_model.parameters(), live_params, strict=True):
+                    param.data.copy_(snap)
+                for buffer, snap in zip(cur_model.buffers(), live_buffers, strict=True):
+                    buffer.data.copy_(snap)
+
+    def _dispatch_to_children(self, hook: str, *, update_counter: UpdateCounter, **kwargs: Any) -> None:
+        """Call ``hook`` on every child, wrapped in the EMA weight swap for its target_factor."""
+        if not self.eval_callbacks:
+            return
+        for target_factor, children in self.eval_callbacks.items():
+            with self._swapped_weights(target_factor):
+                for child in children:
+                    getattr(child, hook)(update_counter=update_counter, **kwargs)
+
+    def after_epoch(self, update_counter: UpdateCounter, **kwargs) -> None:
+        # Own periodic save (EMA-cadence gated).
+        super().after_epoch(update_counter=update_counter, **kwargs)
+        # Children run under EMA weights; each child self-gates on its own schedule.
+        self._dispatch_to_children("after_epoch", update_counter=update_counter, **kwargs)
+
+    def after_update(self, update_counter: UpdateCounter, **kwargs) -> None:
+        super().after_update(update_counter=update_counter, **kwargs)
+        self._dispatch_to_children("after_update", update_counter=update_counter, **kwargs)
+
+    def at_eval(self, update_counter: UpdateCounter, **kwargs) -> None:
+        # ``super().at_eval`` calls ``periodic_callback(interval_type="eval")`` which short-circuits for
+        # this callback (no EMA save during eval). Still call it for consistency / future hooks.
+        super().at_eval(update_counter=update_counter, **kwargs)
+        self._dispatch_to_children("at_eval", update_counter=update_counter, **kwargs)
 
     def _save(self, training_iteration: str | TrainingIteration, model: ModelBase) -> None:
         if not is_rank0():
@@ -188,6 +302,12 @@ class EmaCallback(PeriodicCallback):
         checkpoint = update_counter.cur_iteration
         self._save(checkpoint, model=self.model)
 
-    def after_training(self, **_) -> None:
+    def after_training(self, **kwargs) -> None:
         if self.save_last_weights:
             self._save(training_iteration="last", model=self.model)
+
+        # Forward to children on all ranks (without swapping: children may finalize trackers, flush state,
+        # etc., and should not observe EMA-swapped weights after training).
+        for children in self.eval_callbacks.values():
+            for child in children:
+                child.after_training(**kwargs)

--- a/src/noether/core/callbacks/periodic.py
+++ b/src/noether/core/callbacks/periodic.py
@@ -172,11 +172,6 @@ class PeriodicCallback(CallbackBase):
         self.every_n_samples = callback_config.every_n_samples
         self.batch_size = callback_config.batch_size
 
-        if not (type(self).after_update == PeriodicCallback.after_update):
-            raise AssertionError("Children shouldn't override 'after_update'")
-        if not (type(self).after_epoch == PeriodicCallback.after_epoch):
-            raise AssertionError("Children shouldn't override 'after_epoch'")
-
     def __str__(self):
         return f"{type(self).__name__}({self.get_interval_string_verbose()})"
 

--- a/src/noether/core/schemas/callbacks.py
+++ b/src/noether/core/schemas/callbacks.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, ClassVar, Literal, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from noether.core.schemas.lib import _RegistryBase
+from noether.core.schemas.lib import Discriminated, _RegistryBase
 
 
 class CallBackBaseConfig(_RegistryBase):
@@ -128,6 +128,14 @@ class EmaCallbackConfig(CallBackBaseConfig):
     """Save the weights of the model when training is over (i.e., at the end of training, save the EMA weights)."""
     save_latest_weights: bool = Field(False)
     """Save the latest EMA weights. Note that the latest weights are always overwritten on the next invocation of this callback."""
+    eval_callbacks: list[Annotated[Any, Discriminated(CallBackBaseConfig)]] | None = Field(None)
+    """Optional nested periodic callbacks to run against EMA weights. Each child retains its own schedule
+    (``every_n_epochs`` etc.); the EMA callback swaps its stored EMA parameters into the live model around
+    eval-time hooks (``after_epoch``, ``after_update``, ``at_eval``) and restores the live weights on exit.
+    Children are dispatched once per ``target_factor`` and their metric keys are automatically prefixed with
+    ``ema=<factor>/`` to avoid collisions with live-model metrics. Note: ``before_training`` and
+    ``after_training`` are forwarded without swapping, so EMA initialization and the final save see live
+    weights."""
 
 
 class OnlineLossCallbackConfig(CallBackBaseConfig):

--- a/src/noether/core/writers/__init__.py
+++ b/src/noether/core/writers/__init__.py
@@ -2,8 +2,10 @@
 
 from .checkpoint_writer import CheckpointWriter
 from .log_writer import LogWriter
+from .prefixed_log_writer import PrefixedLogWriter
 
 __all__ = [
     "CheckpointWriter",
     "LogWriter",
+    "PrefixedLogWriter",
 ]

--- a/src/noether/core/writers/prefixed_log_writer.py
+++ b/src/noether/core/writers/prefixed_log_writer.py
@@ -1,0 +1,53 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import torch
+
+from noether.core.writers.log_writer import LogWriter
+
+
+class PrefixedLogWriter:
+    """Proxy over :class:`LogWriter` that prepends a prefix to every logged key.
+
+    Used by composite callbacks (e.g. :class:`~noether.core.callbacks.checkpoint.ema.EmaCallback`) that run
+    child evaluation callbacks under alternate model weights, so that the child's metric keys don't collide
+    with the live-model metrics. All non-logging methods (``flush``, ``__enter__``/``__exit__``, etc.) are
+    delegated to the wrapped writer so the underlying cache/history stay consistent.
+
+    Args:
+        inner: The underlying :class:`LogWriter` to delegate to.
+        prefix: Prefix to prepend to every key (trailing slashes are stripped).
+    """
+
+    def __init__(self, inner: LogWriter, prefix: str) -> None:
+        self._inner = inner
+        self._prefix = prefix.rstrip("/")
+
+    def _prefixed(self, key: str) -> str:
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def add_scalar(
+        self,
+        key: str,
+        value: torch.Tensor | np.generic | float,
+        logger: logging.Logger | None = None,
+        format_str: str | None = None,
+    ) -> None:
+        """Forward to the underlying writer with the key prefixed."""
+        self._inner.add_scalar(self._prefixed(key), value, logger=logger, format_str=format_str)
+
+    def add_nonscalar(self, key: str, value: Any) -> None:
+        """Forward to the underlying writer with the key prefixed."""
+        self._inner.add_nonscalar(self._prefixed(key), value)
+
+    def get_all_metric_values(self, key: str) -> list[float]:
+        """Look up values under the prefixed key."""
+        return self._inner.get_all_metric_values(self._prefixed(key))
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)

--- a/src/noether/training/trainers/base.py
+++ b/src/noether/training/trainers/base.py
@@ -47,6 +47,21 @@ if TYPE_CHECKING:  # import only for type checking to avoid circular imports
     from noether.core.models import ModelBase
 
 
+def _iter_iterator_descendants(callback: CallbackBase) -> Iterator[PeriodicDataIteratorCallback]:
+    """Yield every ``PeriodicDataIteratorCallback`` reachable via ``get_children()``."""
+    for child in callback.get_children():
+        if isinstance(child, PeriodicDataIteratorCallback):
+            yield child
+        yield from _iter_iterator_descendants(child)
+
+
+def _needs_iterator_args(callback: CallbackBase) -> bool:
+    """True if ``callback`` itself or any descendant iterates a dataset and needs ``data_iter``."""
+    if isinstance(callback, PeriodicDataIteratorCallback):
+        return True
+    return any(True for _ in _iter_iterator_descendants(callback))
+
+
 class TrainingContextFilter(logging.Filter):
     def __init__(self, update_counter: UpdateCounter):
         super().__init__()
@@ -618,9 +633,11 @@ class BaseTrainer:
         """Train the model."""
 
         self.callbacks = self.get_all_callbacks(model)
-        iterator_callbacks = [
-            callback for callback in self.callbacks if isinstance(callback, PeriodicDataIteratorCallback)
-        ]
+        iterator_callbacks: list[PeriodicDataIteratorCallback] = []
+        for callback in self.callbacks:
+            if isinstance(callback, PeriodicDataIteratorCallback):
+                iterator_callbacks.append(callback)
+            iterator_callbacks.extend(_iter_iterator_descendants(callback))
 
         model = self._prepare_model(model)
         dist_model = self.wrap_model(model).to(model.device)
@@ -718,16 +735,17 @@ class BaseTrainer:
         early_exit = False
         first_error = None
         for callback in periodic_callbacks:
+            needs_iter_args = _needs_iterator_args(callback)
             try:
                 if end_of_epoch:
                     callback.after_epoch(
                         update_counter=self.update_counter,
-                        **(iterator_callback_args if isinstance(callback, PeriodicDataIteratorCallback) else {}),
+                        **(iterator_callback_args if needs_iter_args else {}),
                     )
                 else:
                     callback.after_update(
                         update_counter=self.update_counter,
-                        **(iterator_callback_args if isinstance(callback, PeriodicDataIteratorCallback) else {}),
+                        **(iterator_callback_args if needs_iter_args else {}),
                     )
             except EarlyStopIteration:
                 self.logger.info(f"Callback {callback} requested early stop of training")
@@ -1067,7 +1085,11 @@ class BaseTrainer:
         callbacks = self.get_user_callbacks(model, evaluation=True)
         model = self._prepare_model(model)
         dist_model = self.wrap_model(model).to(model.device).eval()
-        iterator_callbacks = [callback for callback in callbacks if isinstance(callback, PeriodicDataIteratorCallback)]
+        iterator_callbacks: list[PeriodicDataIteratorCallback] = []
+        for callback in callbacks:
+            if isinstance(callback, PeriodicDataIteratorCallback):
+                iterator_callbacks.append(callback)
+            iterator_callbacks.extend(_iter_iterator_descendants(callback))
         batch_size, _, _ = self._prepare_batch_size()
 
         data_loader = self.get_data_loader(
@@ -1085,7 +1107,7 @@ class BaseTrainer:
                     data_iter=map(BaseTrainer.drop_metadata, data_iter),
                     batch_size=batch_size,
                 )
-                if isinstance(callback, PeriodicDataIteratorCallback)
+                if _needs_iterator_args(callback)
                 else {}
             )
             callback.at_eval(self.update_counter, **iterator_callback_args)

--- a/tests/unit/noether/core/callbacks/checkpoint/test_ema.py
+++ b/tests/unit/noether/core/callbacks/checkpoint/test_ema.py
@@ -225,6 +225,85 @@ class TestEmaCallback:
 
         callback_deps["checkpoint_writer"].save_model_checkpoint.assert_not_called()
 
+    def test_eval_callbacks_see_ema_weights_and_live_is_restored(self, monkeypatch, callback_deps, base_config):
+        """``after_epoch`` forwards to children under swapped EMA weights, then restores the live model.
+
+        Also verifies that before_training forwards to children without swapping (so child init sees live
+        weights), that each child's writer is a PrefixedLogWriter namespaced by target_factor, and that
+        arbitrary kwargs passed by the trainer (e.g. ``data_iter``, ``trainer_model``) flow through to the
+        child.
+        """
+        monkeypatch.setattr(_MODULE_PATH + ".is_rank0", lambda: True)
+        monkeypatch.setattr(_MODULE_PATH + ".is_distributed", lambda: False)
+        monkeypatch.setattr(_MODULE_PATH + ".select_with_path", lambda *, obj, path: obj)
+
+        model = _TinyModel()
+        with torch.no_grad():
+            model.linear.weight.fill_(1.0)
+        base_config["target_factors"] = [0.9]
+
+        # Child records the weights it sees in each hook.
+        observed: dict[str, torch.Tensor] = {}
+
+        def record(hook_name: str):
+            def _cb(**_):
+                observed[hook_name] = model.linear.weight.detach().clone()
+
+            return _cb
+
+        child = Mock()
+        child.before_training.side_effect = record("before_training")
+        child.after_epoch.side_effect = record("after_epoch")
+        child.after_training.side_effect = record("after_training")
+
+        # Mock the Factory so ``eval_callbacks`` instantiates our stub instead of requiring a resolvable
+        # kind path. We capture the child_kwargs to assert the PrefixedLogWriter is installed.
+        captured_kwargs: dict = {}
+
+        def fake_create_list(_configs, **child_kwargs):
+            captured_kwargs.update(child_kwargs)
+            return [child]
+
+        fake_factory = Mock()
+        fake_factory.create_list.side_effect = fake_create_list
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]  # sentinel; Factory is mocked
+
+        cb = EmaCallback(callback_config=SimpleNamespace(**base_config), model=model, **callback_deps)
+
+        # Child's log_writer is a PrefixedLogWriter scoped to this target_factor.
+        from noether.core.writers import PrefixedLogWriter
+
+        assert isinstance(captured_kwargs["log_writer"], PrefixedLogWriter)
+        assert captured_kwargs["log_writer"]._prefix == "ema=0.9"
+
+        # Initialize EMA from live model (weight=1.0 by default init), then diverge live vs. EMA.
+        cb.before_training(extra_kwarg="forwarded")
+        child.before_training.assert_called_once()
+        assert child.before_training.call_args.kwargs["extra_kwarg"] == "forwarded"
+
+        with torch.no_grad():
+            model.linear.weight.fill_(5.0)
+            model.buf.fill_(2.0)
+            cb.parameters[(None, 0.9)]["linear.weight"].fill_(7.0)
+            cb.buffers[None]["buf"].fill_(3.0)
+
+        # Dispatch eval-time hook; child should observe EMA (=7.0), and the live model must be restored.
+        update_counter = SimpleNamespace(cur_iteration=SimpleNamespace(epoch=None, update=None, sample=None))
+        cb.after_epoch(update_counter=update_counter, trainer_model="dist_model")
+
+        assert torch.allclose(observed["after_epoch"], torch.full_like(observed["after_epoch"], 7.0))
+        assert torch.allclose(model.linear.weight, torch.full_like(model.linear.weight, 5.0))
+        assert torch.allclose(model.buf, torch.full_like(model.buf, 2.0))
+
+        # before_training must not swap: child should have seen the live weights at that point (=1.0).
+        assert torch.allclose(observed["before_training"], torch.ones_like(observed["before_training"]))
+
+        # after_training also doesn't swap.
+        cb.after_training()
+        assert torch.allclose(observed["after_training"], torch.full_like(observed["after_training"], 5.0))
+
     def test_apply_ema_modifies_in_place(self, monkeypatch, callback_deps, base_config):
         monkeypatch.setattr(_MODULE_PATH + ".is_rank0", lambda: True)
         monkeypatch.setattr(_MODULE_PATH + ".select_with_path", lambda *, obj, path: obj)

--- a/tests/unit/noether/core/trainer/test_trainer_callbacks.py
+++ b/tests/unit/noether/core/trainer/test_trainer_callbacks.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from noether.core.callbacks import PeriodicCallback, PeriodicDataIteratorCallback
 from noether.core.models.model import Model
 from noether.core.schemas import DatasetBaseConfig
-from noether.core.schemas.callbacks import PeriodicDataIteratorCallbackConfig
+from noether.core.schemas.callbacks import CallBackBaseConfig, PeriodicDataIteratorCallbackConfig
 from noether.core.schemas.trainers import BaseTrainerConfig
 from noether.data.base.dataset import Dataset
 from noether.data.container import DataContainer
@@ -82,6 +82,31 @@ class DummyIteratorCallback(PeriodicDataIteratorCallback):
 
     def process_results(self, results, **_):
         pass
+
+
+class NestedCompositeCallback(PeriodicCallback):
+    """Minimal composite callback: owns children via ``get_children`` and forwards eval-time hooks.
+
+    Stands in for any composite (e.g. ``EmaCallback`` with ``eval_callbacks``) to exercise the trainer's
+    child-flattening and iterator-args routing without pulling in EMA-specific logic.
+    """
+
+    def __init__(self, *args, children=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._children = children or []
+
+    def get_children(self):
+        return self._children
+
+    def after_epoch(self, update_counter, **kwargs):
+        super().after_epoch(update_counter=update_counter, **kwargs)
+        for child in self._children:
+            child.after_epoch(update_counter=update_counter, **kwargs)
+
+    def after_update(self, update_counter, **kwargs):
+        super().after_update(update_counter=update_counter, **kwargs)
+        for child in self._children:
+            child.after_update(update_counter=update_counter, **kwargs)
 
 
 @pytest.mark.filterwarnings("ignore:Batch contains additional keys")
@@ -246,3 +271,87 @@ def test_periodic_iterator_callback_with_gradient_accumulation():
     assert len(callback.received_batches) == num_samples_test
     for i in range(num_samples_test):
         assert callback.received_batches[i]["id"].item() == 100 + i
+
+
+@pytest.mark.filterwarnings("ignore:Batch contains additional keys")
+def test_nested_iterator_callback_receives_batches_through_composite_parent():
+    """Iterator children owned by a composite parent still get their batches.
+
+    Verifies that the trainer (a) flattens ``get_children()`` when building ``iterator_callbacks`` so the
+    nested callback's sampler_config is registered on the shared data loader, and (b) routes
+    ``iterator_callback_args`` (including ``data_iter``) to the parent because it has an iterator
+    descendant, so the parent can forward the args to its child.
+    """
+    num_samples_train, num_samples_test, num_epochs = 3, 2, 2
+    train_dataset = DummyDataset(size=num_samples_train)
+    test_dataset = DummyDataset(size=num_samples_test)
+    data_container = DataContainer(datasets={"train": train_dataset, "test": test_dataset})
+
+    trainer = DummyTrainer(
+        config=BaseTrainerConfig(
+            kind="base",
+            max_epochs=num_epochs,
+            effective_batch_size=1,
+            callbacks=[],
+            forward_properties=["x"],
+            target_properties=["y"],
+        ),
+        data_container=data_container,
+        device="cpu",
+        tracker=None,
+        path_provider=None,
+    )
+
+    # Interleave train + test batches the way the real data loader would.
+    batches = []
+    for epoch in range(num_epochs):
+        for i in range(num_samples_train):
+            batches.append(
+                {"x": torch.randn(1, 10), "y": torch.randint(0, 2, (1,)), "id": torch.tensor([epoch * 100 + i])}
+            )
+        for i in range(num_samples_test):
+            batches.append(
+                {"x": torch.randn(1, 10), "y": torch.randint(0, 2, (1,)), "id": torch.tensor([(epoch + 10) * 100 + i])}
+            )
+    trainer.get_data_loader = Mock(return_value=iter(batches))
+
+    model = DummyModel()
+    callback_deps = dict(
+        trainer=trainer,
+        model=model,
+        data_container=data_container,
+        tracker=Mock(),
+        log_writer=Mock(flush=Mock(), finish=Mock()),
+        checkpoint_writer=Mock(),
+        metric_property_provider=Mock(),
+    )
+    child = DummyIteratorCallback(
+        callback_config=PeriodicDataIteratorCallbackConfig.model_validate(dict(every_n_epochs=1, dataset_key="train")),
+        **callback_deps,
+    )
+    # Parent itself has no data dependency; it only exists to own the child and demonstrate that nesting
+    # does not break iterator wiring.
+    parent = NestedCompositeCallback(
+        callback_config=CallBackBaseConfig.model_validate(dict(every_n_epochs=1)),
+        children=[child],
+        **callback_deps,
+    )
+
+    # Only the parent is registered with the trainer; the child is reachable via ``get_children()``.
+    trainer.get_all_callbacks = lambda _: [parent]
+
+    # Sanity-check that the trainer would discover the child via the same helper it uses internally.
+    from noether.training.trainers.base import _iter_iterator_descendants, _needs_iterator_args
+
+    assert list(_iter_iterator_descendants(parent)) == [child]
+    assert _needs_iterator_args(parent) is True
+
+    trainer.train(model)
+
+    # Child received the right batches even though it was never registered directly as a top-level
+    # callback — exactly the batches the interleaved loader produced for the test dataset.
+    assert len(child.received_batches) == num_samples_test * num_epochs
+    for epoch in range(num_epochs):
+        for i in range(num_samples_test):
+            batch = child.received_batches[epoch * num_samples_test + i]
+            assert batch["id"].item() == (epoch + 10) * 100 + i

--- a/tests/unit/noether/training/test_base_trainer.py
+++ b/tests/unit/noether/training/test_base_trainer.py
@@ -1482,12 +1482,15 @@ class TestSkipRemainingBatches:
 class TestEval:
     def test_eval_calls_at_eval_on_periodic_callbacks(self):
         """eval() calls at_eval on each PeriodicCallback."""
-        from noether.core.callbacks import PeriodicCallback
+        from noether.core.callbacks import CallbackBase, PeriodicCallback
 
         trainer = _make_trainer()
 
         cb_periodic = MagicMock(spec=PeriodicCallback)
-        cb_non_periodic = MagicMock(spec=[])  # not a PeriodicCallback
+        cb_periodic.get_children.return_value = []
+        # not a PeriodicCallback, but still a CallbackBase so get_children() is available
+        cb_non_periodic = MagicMock(spec=CallbackBase)
+        cb_non_periodic.get_children.return_value = []
 
         with (
             patch.object(trainer, "get_user_callbacks", return_value=[cb_periodic, cb_non_periodic]),


### PR DESCRIPTION
Adding support for evaluating against EMA weights during training via a new `eval_callbacks` field
on `EmaCallback`. Previously EMA weights were only saved to disk and had to be evaluated in a
separate run via `PreviousRunInitializer(model_info="ema=0.9999")`.

`EmaCallback` now optionally owns a list of nested periodic callbacks. On each eval-time hook
(`after_epoch` / `after_update` / `at_eval`) it snapshots the live params/buffers, copies the
EMA values into the live model (broadcasting from rank 0 under DDP), dispatches the children,
and restores the live weights. `before_training` / `after_training` are forwarded without
swapping so EMA init and the final save see live weights. Children are instantiated once per
`target_factor` and their logged metric keys are auto-prefixed with `ema=<factor>/` (via a
thin `PrefixedLogWriter` proxy) to avoid collisions with live-model metrics.

The wiring is generic: `CallbackBase.get_children()` exposes nested callbacks to the trainer, the same mechanism can back future composite callbacks
(SWA, teacher-model eval, etc.) without further trainer changes.

## Example

```yaml
- kind: noether.core.callbacks.EmaCallback
  every_n_epochs: 10
  target_factors: [0.9999]
  save_latest_weights: true
  eval_callbacks:
    - kind: noether.training.callbacks.OfflineLossCallback
      every_n_epochs: 1
      dataset_key: val
    # logs as ``ema=0.9999/loss/val/total``
