### PR TITLE
chore: Change RoPE params for drivaerml

### DIFF
--- a/recipes/aero_cfd/configs/dataset_normalizers/caeml_dataset_normalizers.yaml
+++ b/recipes/aero_cfd/configs/dataset_normalizers/caeml_dataset_normalizers.yaml
@@ -4,7 +4,7 @@ surface_position:
   stat_keys:
     min: raw_pos_min
     max: raw_pos_max
-  scale: 1000
+  scale: 100000
 surface_pressure:
   kind: noether.data.preprocessors.normalizers.FieldNormalizer
   strategy: mean_std
@@ -17,7 +17,7 @@ volume_position:
   stat_keys:
     min: raw_pos_min
     max: raw_pos_max
-  scale: 1000
+  scale: 100000
 volume_vorticity:
   kind: noether.data.preprocessors.normalizers.FieldNormalizer
   strategy: mean_std

--- a/recipes/aero_cfd/configs/experiment/drivaerml/ab_upt.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/ab_upt.yaml
@@ -34,6 +34,8 @@ model:
     - self
     - cross
     - self
+  transformer_block_config:
+    max_wavelength: 40_000
     
 sample_size_property: surface_anchor_position
 chunk_size: ${pipeline.num_surface_anchor_points}

--- a/recipes/aero_cfd/configs/experiment/drivaerml/ab_upt_muon_lion.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/ab_upt_muon_lion.yaml
@@ -34,6 +34,8 @@ model:
     - self
     - cross
     - self
+  transformer_block_config:
+    max_wavelength: 40_000
 
 optimizer:
   lr: 0.01

--- a/recipes/aero_cfd/configs/experiment/drivaerml/transformer.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/transformer.yaml
@@ -13,6 +13,10 @@ inference_pipeline:
   num_surface_points: 1000000000
   num_volume_points: 1000000000
 
+model:
+  transformer_block_config:
+    max_wavelength: 40_000
+
 sample_size_property: surface_position
 chunk_size: ${pipeline.num_surface_points}
 chunk_properties:

--- a/recipes/aero_cfd/configs/experiment/drivaerml/transolver.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/transolver.yaml
@@ -15,3 +15,8 @@ chunk_size: ${pipeline.num_surface_points}
 chunk_properties:
   - surface_position
   - volume_position
+
+model:
+  transformer_block_config:
+    max_wavelength: 40_000
+    

--- a/recipes/aero_cfd/configs/experiment/drivaerml/upt.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/upt.yaml
@@ -13,6 +13,9 @@ trainer:
 model:
   supernode_pooling_config:
     radius: 0.25
+  transformer_block_config:
+    max_wavelength: 40_000
+    
     
 pipeline:
   num_supernodes: 16384

--- a/recipes/aero_cfd/configs/slurm/slurm_config.yaml
+++ b/recipes/aero_cfd/configs/slurm/slurm_config.yaml
@@ -1,11 +1,11 @@
-name: shapenet_experiment
+name: ${name}
 slurm_partition: compute
 nodes: 1
 tasks_per_node: 1
 cpus_per_task: 28
 gpus_per_node: 1
 mem_gb: 128
-folder: /home/%u/logs/shapenet_car
+folder: /home/%u/logs/${name}
 slurm_setup:
   - source .venv/bin/activate
 slurm_additional_parameters:

--- a/recipes/aero_cfd/configs/train_caeml.yaml
+++ b/recipes/aero_cfd/configs/train_caeml.yaml
@@ -6,6 +6,7 @@ excluded_properties:
   - surface_sdf
   - volume_normals
   - surface_normals
+  - surface_area
 defaults:
   - data_specs: caeml
   - dataset_normalizers: caeml_dataset_normalizers

--- a/src/noether/core/schemas/models/ab_upt.py
+++ b/src/noether/core/schemas/models/ab_upt.py
@@ -86,6 +86,7 @@ class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin)
             hidden_dim=self.transformer_block_config.hidden_dim // self.transformer_block_config.num_heads,
             input_dim=self.data_specs.position_dim,
             implementation="complex",
+            max_wavelength=self.transformer_block_config.max_wavelength,
         )
 
     @computed_field
@@ -93,6 +94,7 @@ class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin)
         return ContinuousSincosEmbeddingConfig(
             hidden_dim=self.hidden_dim,
             input_dim=self.data_specs.position_dim,
+            max_wavelength=self.transformer_block_config.max_wavelength,
         )
 
     @computed_field

--- a/src/noether/core/schemas/models/upt.py
+++ b/src/noether/core/schemas/models/upt.py
@@ -61,6 +61,7 @@ class UPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin):
             hidden_dim=self.hidden_dim // self.num_heads,
             input_dim=self.data_specs.position_dim,
             implementation="complex",
+            max_wavelength=self.approximator_config.max_wavelength,
         )
 
     @model_validator(mode="after")
@@ -78,6 +79,7 @@ class UPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin):
         return ContinuousSincosEmbeddingConfig(
             hidden_dim=self.hidden_dim,
             input_dim=self.data_specs.position_dim,
+            max_wavelength=self.approximator_config.max_wavelength,
         )
 
     @model_validator(mode="after")

--- a/src/noether/core/schemas/modules/blocks.py
+++ b/src/noether/core/schemas/modules/blocks.py
@@ -54,6 +54,9 @@ class TransformerBlockConfig(BaseModel):
     use_rope: bool = Field(False)
     """Whether to use Rotary Positional Embeddings (RoPE)."""
 
+    max_wavelength: int | None = Field(10_000)
+    """Theta parameter for the transformer sine/cosine embedding. Default: 10_000"""
+
     attention_arguments: dict = {}
     """Additional arguments for the attention module that are only needed for a specific attention implementation."""
 
@@ -67,6 +70,12 @@ class TransformerBlockConfig(BaseModel):
             if self.mlp_expansion_factor is None:
                 raise ValueError("Either 'mlp_hidden_dim' or 'mlp_expansion_factor' must be provided.")
             self.mlp_hidden_dim = self.hidden_dim * self.mlp_expansion_factor
+        return self
+
+    @model_validator(mode="after")
+    def set_wavelength_for_rope(self):
+        if self.use_rope and self.max_wavelength is None:
+            raise ValueError("max_wavelength must be provided when use_rope is True.")
         return self
 
     @computed_field

--- a/src/noether/inference/cli/main_inference.py
+++ b/src/noether/inference/cli/main_inference.py
@@ -56,10 +56,9 @@ def main(inference_config: DictConfig):
     input_dir = Path(inference_config.input_dir).resolve()
     run_id = inference_config.run_id
     stage_name = inference_config.get("stage_name", "")
-
-    hp_resolved_path = input_dir / run_id / stage_name / "hp_resolved.yaml"
+    hp_resolved_path = input_dir / str(run_id) / stage_name / "hp_resolved.yaml"
     if not hp_resolved_path.exists():
-        raise FileNotFoundError(f"hp_resolved.yaml not found in {input_dir / run_id / stage_name}")
+        raise FileNotFoundError(f"hp_resolved.yaml not found in {input_dir / str(run_id) / stage_name}")
 
     # Load training config as base
     with open(hp_resolved_path) as f:

--- a/src/noether/modeling/models/aerodynamics.py
+++ b/src/noether/modeling/models/aerodynamics.py
@@ -91,7 +91,11 @@ class AeroTransformer(Model):
         self.use_rope = model_config.transformer_block_config.use_rope
 
         self.pos_embed = ContinuousSincosEmbed(
-            config=ContinuousSincosEmbeddingConfig(hidden_dim=hidden_dim, input_dim=position_dim),
+            config=ContinuousSincosEmbeddingConfig(
+                hidden_dim=hidden_dim,
+                input_dim=position_dim,
+                max_wavelength=model_config.transformer_block_config.max_wavelength,
+            ),
         )
 
         if self.use_rope:
@@ -100,6 +104,7 @@ class AeroTransformer(Model):
                     hidden_dim=hidden_dim // model_config.transformer_block_config.num_heads,
                     input_dim=position_dim,
                     implementation="complex",
+                    max_wavelength=model_config.transformer_block_config.max_wavelength,
                 ),
             )
 


### PR DESCRIPTION
Add Rope and SinCos embedding max_wavelength parameter to models to make them configurable and update the aero_cfd recipe for DrivaerML to use a higher scale for position normalization as well as as higher max_wavelength.