### PR TITLE
test: fix dataloader test on macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ module = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = [".", "src"]
 addopts = ["--import-mode=importlib", "-m", "not benchmark"]
 
 


### PR DESCRIPTION
tests/integration/noether/data/test_pipeline_determinism.py::test_multistage_pipeline_with_sampling_processors_is_deterministic was failing on macos with

```
ModuleNotFoundError: No module named 'tests'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/markus/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/markus/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/multiprocessing/spawn.py", line 132, in _main
    self = reduction.pickle.load(from_parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'tests
```

The reason is PyTorch dataloader is using `spawn` on macos to start processes which behaves differently to `fork` used on linux. With spawn the PYTHONPATH wasn't set properly, not including `tests` to the path, leading to ModuleNotFoundError. This can be fixed by configuring pytest to add the current working directory "." to the Pythonpath manually