### PR TITLE
fix: catch OOM in slurm submission

### DIFF
--- a/recipes/aero_cfd/configs/slurm/slurm_config.yaml
+++ b/recipes/aero_cfd/configs/slurm/slurm_config.yaml
@@ -4,7 +4,7 @@ nodes: 1
 tasks_per_node: 1
 cpus_per_task: 28
 gpus_per_node: 1
-mem_gb: 64
+mem_gb: 128
 folder: /home/%u/logs/shapenet_car
 slurm_setup:
   - source .venv/bin/activate

--- a/src/noether/core/callbacks/periodic.py
+++ b/src/noether/core/callbacks/periodic.py
@@ -677,7 +677,12 @@ class PeriodicDataIteratorCallback(PeriodicCallback, metaclass=ABCMeta):
         # iterate
         data_times = []
         results = []
-        pbar_ctor = NoopTqdm if not sys.stdout.isatty() or not is_rank0() else tqdm
+        pbar_ctor: type[tqdm | NoopTqdm] = tqdm
+        if not sys.stdout.isatty() or not is_rank0():
+            self.logger.info(
+                f"{self} is iterating over {local_dataset_len} samples ({num_batches} batches) from {self.dataset_key}"
+            )
+            pbar_ctor = NoopTqdm
         for _ in pbar_ctor(iterable=range(num_batches), desc=f"{self} on {self.dataset_key}", unit="b"):
             with Stopwatch() as data_sw:
                 batch = next(data_iter)

--- a/src/noether/training/cli/submit_job.py
+++ b/src/noether/training/cli/submit_job.py
@@ -256,29 +256,71 @@ def _validate_all_combos(config_path: Path, combos: list[list[str]]) -> SlurmCon
     return first_slurm
 
 
-def _build_train_command(config_path: Path, combo: list[str]) -> list[str]:
-    """Build the ``noether-train`` invocation for one sweep combination."""
-    return ["uv", "run", "noether-train", "--hp", str(config_path), *combo]
+def _train_entrypoint(config_path: str, overrides: list[str], cwd: str) -> None:
+    """In-process training entrypoint executed by the submitit worker.
+
+    Replaces the previous ``submitit.helpers.CommandFunction`` approach (shelling
+    out via ``subprocess.Popen``). With the subprocess approach, a SLURM cgroup
+    OOM kill targets the largest memory consumer (the trainer or one of its
+    multiprocessing children); the submitit wrapper survives, sits in
+    ``copy_process_streams`` reading broken pipes, and ignores any SIGTERM SLURM
+    sends to clean up (see ``submitit.core.job_environment.SignalHandler.bypass``)
+    — so the step lingers until walltime. Running training in-process means the
+    wrapper dies with the trainer, ``srun`` exits, and the step ends.
+
+    ``main_train.main`` is invoked (rather than ``HydraRunner().run`` directly) so
+    that ``@hydra.main`` populates ``HydraConfig`` — ``HydraRunner.derive_run_name``
+    reads ``HydraConfig.get().overrides.task`` to append the sweep suffix to the
+    run name.
+
+    Args:
+        config_path: Absolute path to the training config yaml.
+        overrides: Hydra-style overrides for this sweep combination.
+        cwd: Working directory at submission time. Restored so user code referenced
+            via ``config_schema_kind`` is importable.
+    """
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+    os.chdir(cwd)
+
+    sys.argv = [sys.argv[0], "--hp", config_path, *overrides]
+
+    # Imported lazily: ``main_train`` calls ``setup_hydra()`` at import time, which
+    # inspects ``sys.argv`` — so argv must be set up first.
+    from noether.training.cli.main_train import main as train_main
+
+    train_main()
 
 
-def _print_dry_run(folder: str, params: dict[str, Any], commands: list[list[str]]) -> None:
+def _format_task_preview(config_path: Path, combo: list[str]) -> str:
+    """Render a one-line preview of the (in-process) training invocation."""
+    return f"noether-train --hp {config_path} {' '.join(combo)}".rstrip()
+
+
+def _print_dry_run(folder: str, params: dict[str, Any], previews: list[str]) -> None:
     print("[dry-run] submitit AutoExecutor configuration:")
     print(f"  folder: {folder}")
     for key, value in params.items():
         print(f"  {key}: {value}")
-    print(f"[dry-run] Would submit {len(commands)} task(s):")
-    for idx, cmd in enumerate(commands):
-        print(f"  [{idx}] {' '.join(cmd)}")
+    print(f"[dry-run] Would submit {len(previews)} task(s) in-process via main_train.main:")
+    for idx, preview in enumerate(previews):
+        print(f"  [{idx}] {preview}")
 
 
-def _submit(executor: submitit.AutoExecutor, commands: list[list[str]]) -> list[submitit.Job]:
-    """Submit one or more commands. Multiple commands go inside ``executor.batch()``
-    so SLURM sees a single array job."""
-    cmd_fns = [submitit.helpers.CommandFunction(cmd) for cmd in commands]
-    if len(cmd_fns) == 1:
-        return [executor.submit(cmd_fns[0])]
+def _submit(
+    executor: submitit.AutoExecutor,
+    config_path: Path,
+    combos: list[list[str]],
+    cwd: str,
+) -> list[submitit.Job]:
+    """Submit one or more in-process training tasks.
+
+    Multiple combos go inside ``executor.batch()`` so SLURM sees a single array job.
+    """
+    if len(combos) == 1:
+        return [executor.submit(_train_entrypoint, str(config_path), combos[0], cwd)]
     with executor.batch():
-        return [executor.submit(fn) for fn in cmd_fns]
+        return [executor.submit(_train_entrypoint, str(config_path), combo, cwd) for combo in combos]
 
 
 def main() -> None:
@@ -312,15 +354,16 @@ def main() -> None:
 
     slurm_config = _validate_all_combos(config_path, combos)
     folder, params = slurm_config.to_executor_kwargs()
-    commands = [_build_train_command(config_path, combo) for combo in combos]
+    cwd = os.getcwd()
 
     if dry_run:
-        _print_dry_run(folder, params, commands)
+        previews = [_format_task_preview(config_path, combo) for combo in combos]
+        _print_dry_run(folder, params, previews)
         sys.exit(0)
 
     executor = submitit.AutoExecutor(folder=folder)
     executor.update_parameters(**params)
-    jobs = _submit(executor, commands)
+    jobs = _submit(executor, config_path, combos, cwd)
 
     if len(jobs) == 1:
         print(f"Submitted job {jobs[0].job_id}")

--- a/tests/unit/noether/training/cli/test_submit_job.py
+++ b/tests/unit/noether/training/cli/test_submit_job.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import pickle
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,9 +13,10 @@ from omegaconf import OmegaConf
 
 from noether.core.schemas.slurm import SlurmConfig
 from noether.training.cli.submit_job import (
-    _build_train_command,
     _expand_sweeps,
+    _format_task_preview,
     _parse_argv,
+    _train_entrypoint,
     _validate_all_combos,
     main,
     validate_config,
@@ -180,17 +184,54 @@ class TestValidateAllCombos:
 
 
 # --------------------------------------------------------------------------- #
-# _build_train_command
+# _format_task_preview
 # --------------------------------------------------------------------------- #
-class TestBuildTrainCommand:
-    def test_includes_uv_run_noether_train_and_hp(self):
-        cmd = _build_train_command(Path("/abs/cfg.yaml"), ["a=1", "b=2"])
-        assert cmd == ["uv", "run", "noether-train", "--hp", "/abs/cfg.yaml", "a=1", "b=2"]
+class TestFormatTaskPreview:
+    def test_no_overrides(self):
+        assert _format_task_preview(Path("/abs/cfg.yaml"), []) == "noether-train --hp /abs/cfg.yaml"
+
+    def test_with_overrides(self):
+        assert _format_task_preview(Path("/abs/cfg.yaml"), ["a=1", "b=2"]) == "noether-train --hp /abs/cfg.yaml a=1 b=2"
 
     def test_handles_path_with_spaces(self):
-        # The command is a list (no shell), so spaces in paths require no quoting.
-        cmd = _build_train_command(Path("/my projects/cfg.yaml"), [])
-        assert cmd == ["uv", "run", "noether-train", "--hp", "/my projects/cfg.yaml"]
+        assert _format_task_preview(Path("/my projects/cfg.yaml"), []) == "noether-train --hp /my projects/cfg.yaml"
+
+
+# --------------------------------------------------------------------------- #
+# _train_entrypoint
+# --------------------------------------------------------------------------- #
+class TestTrainEntrypoint:
+    def test_is_picklable(self):
+        # submitit serialises the submitted function to disk for the worker to load.
+        assert pickle.loads(pickle.dumps(_train_entrypoint)) is _train_entrypoint
+
+    def test_sets_up_argv_and_cwd_then_calls_main_train(self, tmp_path: Path, monkeypatch):
+        # main_train calls setup_hydra() at import time, which inspects sys.argv.
+        # _train_entrypoint must therefore set up sys.argv *before* importing main_train.
+        # We assert this by capturing sys.argv at the moment our fake main() is called.
+        captured: dict = {}
+
+        def _record_state():
+            captured["argv"] = list(sys.argv)
+            captured["cwd"] = os.getcwd()
+
+        fake_main_train = MagicMock()
+        fake_main_train.main = MagicMock(side_effect=_record_state)
+        monkeypatch.setitem(sys.modules, "noether.training.cli.main_train", fake_main_train)
+
+        original_cwd = os.getcwd()
+        original_argv = list(sys.argv)
+        try:
+            cfg_path = tmp_path / "cfg.yaml"
+            _train_entrypoint(str(cfg_path), ["a=1", "b=2"], str(tmp_path))
+        finally:
+            os.chdir(original_cwd)
+            sys.argv[:] = original_argv
+
+        fake_main_train.main.assert_called_once_with()
+        assert captured["argv"][1:] == ["--hp", str(cfg_path), "a=1", "b=2"]
+        assert captured["cwd"] == str(tmp_path)
+        assert str(tmp_path) in sys.path
 
 
 # --------------------------------------------------------------------------- #
@@ -213,7 +254,7 @@ class TestMain:
         executor.batch.return_value.__enter__ = MagicMock(return_value=None)
         executor.batch.return_value.__exit__ = MagicMock(return_value=False)
         if mock_jobs is None:
-            executor.submit.side_effect = lambda fn: MagicMock(job_id="42_0")
+            executor.submit.side_effect = lambda *args, **kwargs: MagicMock(job_id="42_0")
         else:
             executor.submit.side_effect = mock_jobs
 
@@ -256,6 +297,12 @@ class TestMain:
         assert params["timeout_min"] == 60
         executor.submit.assert_called_once()
         executor.batch.assert_not_called()  # batch() only used for arrays
+        # submit(_train_entrypoint, str(config_path), overrides, cwd)
+        fn, submitted_path, overrides, cwd = executor.submit.call_args.args
+        assert fn is _train_entrypoint
+        assert submitted_path == str(cfg_path)
+        assert overrides == []
+        assert cwd == os.getcwd()
 
     def test_multirun_uses_batch_and_submits_n_times(self, slurm, cfg_path):
         argv = ["prog", "--hp", str(cfg_path), "-m", "+seed=1,2,3"]
@@ -264,14 +311,12 @@ class TestMain:
 
         executor.batch.assert_called_once()
         assert executor.submit.call_count == 3
-        # Verify each submit got a distinct seed in its CommandFunction args.
-        seeds_seen = set()
+        seeds_seen: set[str] = set()
         for call in executor.submit.call_args_list:
-            cmd_fn = call.args[0]
-            cmd = " ".join(cmd_fn.command)
-            for s in ("+seed=1", "+seed=2", "+seed=3"):
-                if s in cmd:
-                    seeds_seen.add(s)
+            fn, submitted_path, overrides, _cwd = call.args
+            assert fn is _train_entrypoint
+            assert submitted_path == str(cfg_path)
+            seeds_seen.update(o for o in overrides if o.startswith("+seed="))
         assert seeds_seen == {"+seed=1", "+seed=2", "+seed=3"}
 
     def test_dry_run_does_not_construct_executor(self, slurm, cfg_path, capsys):


### PR DESCRIPTION
Run training in-process inside the submitit worker instead of shelling out via `submitit.helpers.CommandFunction` (`uv run noether-train …`).

## Why
When a SLURM cgroup OOM kill fires, it picks the largest memory consumer (the trainer or one of its mp children). With the subprocess approach the submitit wrapper survives, parks in `copy_process_streams` reading broken pipes, and ignores any `SIGTERM` SLURM sends to clean up (submitit installs a signal-bypass handler for `SIGTERM`/`SIGCONT` in `submitit/core/job_environment.py:155-156`). The step then lingers until walltime instead of failing fast.

Running training in-process means the worker dies with the trainer; `srun` exits non-zero and the step ends.

## What changed
- Replaced `_build_train_command` + `CommandFunction` with `_train_entrypoint(config_path, overrides, cwd)` — a top-level (picklable) function.
- The entrypoint sets `sys.argv` to mimic `noether-train --hp <path> <overrides…>` and calls `main_train.main`, so `@hydra.main` still populates `HydraConfig` (load-bearing for `HydraRunner.derive_run_name`'s multirun suffix).
- `_submit` now hands `_train_entrypoint` to `executor.submit` directly (single submission) or inside `executor.batch()` (multirun array).
- Dry-run output reformatted to show the equivalent `noether-train --hp …` invocation under "in-process via main_train.main".

## Test plan
- [x] Module imports cleanly; `_train_entrypoint` pickles (submitit requirement).
- [x] Dry-run output renders for single and multi-combo cases.
- [x] Submit a real OOM-prone job and confirm the step ends promptly on OOM instead of running to walltime.
