### PR TITLE
ci: fix mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
       entry: uv run mypy --show-traceback
       language: system
       types: [python]
-      # Only check files in src/noether, exclude template files due to placeholders
-      files: ^src/noether/
-      exclude: template_files/
+      pass_filenames: false
+      require_serial: true
       args: []

--- a/src/noether/io/diskcache/lru_cache.py
+++ b/src/noether/io/diskcache/lru_cache.py
@@ -196,7 +196,7 @@ class LRUCacheFileSystem(CachingFileSystem):
 
         def _strip_protocol(path):
             # acts as a method, since each instance has a difference target
-            return self.fs._strip_protocol(type(self)._strip_protocol(path))
+            return self.fs._strip_protocol(type(self)._strip_protocol(path))  # type: ignore
 
         self._strip_protocol = _strip_protocol
 


### PR DESCRIPTION
mypy enabled a sqlite cache in 1.20 https://github.com/python/mypy/issues/21136, which does not play nicely with concurrent execution of mypy. pre-commit spawns a process per file, which then triggers `OperationalError: database is locked`. 

We can avoid running parallel processes by using the `pass_filenames` and `requires_serial` pre-commit arguments. This should ensure only one mypy is running at a time.