### PR TITLE
chore: reuse callback configs in ema eval

### DIFF
--- a/recipes/aero_cfd/configs/callbacks/training_callbacks_caeml.yaml
+++ b/recipes/aero_cfd/configs/callbacks/training_callbacks_caeml.yaml
@@ -4,7 +4,8 @@
   save_latest_weights: true
   save_latest_optim: true
 # validation loss
-- kind: noether.training.callbacks.OfflineLossCallback
+- &val_loss
+  kind: noether.training.callbacks.OfflineLossCallback
   batch_size: 1
   every_n_epochs: 1
   dataset_key: val
@@ -17,7 +18,8 @@
   every_n_epochs: 1
   dataset_key: val
   forward_properties: ${model.forward_properties}
-- kind: callbacks.AeroMetricsCallback
+- &chunked_test_metrics
+  kind: callbacks.AeroMetricsCallback
   batch_size: 1
   every_n_epochs: ${trainer.max_epochs}
   dataset_key: chunked_test
@@ -36,12 +38,5 @@
   # nested eval callbacks: run validation with EMA weights swapped in. Metric keys are auto-prefixed
   # with ``ema=<factor>/`` (e.g. ``ema=0.9999/loss/val/total``).
   eval_callbacks:
-    - kind: noether.training.callbacks.OfflineLossCallback
-      batch_size: 1
-      every_n_epochs: 1
-      dataset_key: val
-    - kind: callbacks.AeroMetricsCallback
-      batch_size: 1
-      every_n_epochs: ${trainer.max_epochs}
-      dataset_key: chunked_test
-      forward_properties: ${model.forward_properties}
+    - *val_loss
+    - *chunked_test_metrics

--- a/recipes/aero_cfd/configs/callbacks/training_callbacks_shapenet.yaml
+++ b/recipes/aero_cfd/configs/callbacks/training_callbacks_shapenet.yaml
@@ -5,7 +5,8 @@
   save_latest_optim: true
   save_optim: false
 # validation loss
-- kind: noether.training.callbacks.OfflineLossCallback
+- &test_loss
+  kind: noether.training.callbacks.OfflineLossCallback
   batch_size: 1
   every_n_epochs: 1
   dataset_key: test
@@ -18,7 +19,8 @@
   every_n_epochs: 1
   dataset_key: test
   forward_properties: ${model.forward_properties}
-- kind: callbacks.AeroMetricsCallback
+- &test_repeat_metrics
+  kind: callbacks.AeroMetricsCallback
   batch_size: 1
   every_n_epochs: ${trainer.max_epochs}
   dataset_key: test_repeat
@@ -26,18 +28,11 @@
 #ema
 - kind: noether.core.callbacks.EmaCallback
   every_n_epochs: 10
-  save_weights: false 
-  save_last_weights: false 
+  save_weights: false
+  save_last_weights: false
   save_latest_weights: true
   target_factors:
     - 0.9999
   eval_callbacks:
-    - kind: noether.training.callbacks.OfflineLossCallback
-      batch_size: 1
-      every_n_epochs: 1
-      dataset_key: test
-    - kind: callbacks.AeroMetricsCallback
-      batch_size: 1
-      every_n_epochs: ${trainer.max_epochs}
-      dataset_key: test_repeat
-      forward_properties: ${model.forward_properties}
+    - *test_loss
+    - *test_repeat_metrics


### PR DESCRIPTION
I was copying callback definitions to be used for the EMA evaluation callbacks, however I was missing a few properties for the AeroMetricsCallback, specifically the chunking.

It is less error-prone to reference them instead of copying, this also fixes the wrong config.