### PR TITLE
fix: resume_from_checkpoint for eval callbacks

### DIFF
--- a/src/noether/core/callbacks/checkpoint/ema.py
+++ b/src/noether/core/callbacks/checkpoint/ema.py
@@ -154,6 +154,7 @@ class EmaCallback(PeriodicCallback):
                         "initializing EMA from current model weights"
                     )
                     self._init_ema_from_model(cur_model, model_path, target_factor)
+                logger.debug(f"EMA state for model path '{model_path}' and target_factor={target_factor} initialized")
         self._was_resumed = True
 
     def before_training(self, **kwargs) -> None:

--- a/src/noether/core/initializers/previous_run.py
+++ b/src/noether/core/initializers/previous_run.py
@@ -1,5 +1,6 @@
 #  Copyright © 2025 Emmi AI GmbH. All rights reserved.
 
+from noether.core.callbacks.base import CallbackBase
 from noether.core.initializers import CheckpointInitializer
 from noether.core.models import CompositeModel, Model, ModelBase
 from noether.core.schemas.initializers import PreviousRunInitializerConfig
@@ -105,3 +106,17 @@ class PreviousRunInitializer(CheckpointInitializer):
                 self.init_weights(model=submodel, model_name=f"{model.name}.{submodule_name}")
         else:
             self._init_weights(model=model, model_name=model_name)
+
+    def init_callbacks(self, callbacks: list[CallbackBase], model: ModelBase) -> None:
+        """Initialize the callbacks from the checkpoint.
+
+        Args:
+            callbacks: the callbacks to initialize.
+            model: the model to initialize the callbacks for.
+        """
+
+        for callback in callbacks:
+            callback.resume_from_checkpoint(
+                resumption_paths=self.init_run_path_provider,
+                model=model,
+            )

--- a/src/noether/data/samplers/interleaved_sampler.py
+++ b/src/noether/data/samplers/interleaved_sampler.py
@@ -260,7 +260,7 @@ class InterleavedSampler:
             start_update = updates_per_epoch * config.start_epoch
             start_sample = start_update * config.batch_size
             start_epoch = config.start_epoch
-        elif config.start_update is not None:
+        elif config.start_update is not None and updates_per_epoch > 0:
             start_update = config.start_update
             start_epoch = start_update // updates_per_epoch
             start_sample = start_update * config.batch_size

--- a/src/noether/training/trainers/base.py
+++ b/src/noether/training/trainers/base.py
@@ -1082,11 +1082,11 @@ class BaseTrainer:
     def eval(self, model: ModelBase) -> None:
         """Run evaluation by executing all configured callbacks."""
         self.logger.info("Starting evaluation")
-        callbacks = self.get_user_callbacks(model, evaluation=True)
+        self.callbacks = self.get_user_callbacks(model, evaluation=True)
         model = self._prepare_model(model)
         dist_model = self.wrap_model(model).to(model.device).eval()
         iterator_callbacks: list[PeriodicDataIteratorCallback] = []
-        for callback in callbacks:
+        for callback in self.callbacks:
             if isinstance(callback, PeriodicDataIteratorCallback):
                 iterator_callbacks.append(callback)
             iterator_callbacks.extend(_iter_iterator_descendants(callback))
@@ -1098,7 +1098,7 @@ class BaseTrainer:
         data_iter = iter(data_loader)
 
         with self.log_writer:
-            for callback in callbacks:
+            for callback in self.callbacks:
                 if not isinstance(callback, PeriodicCallback):
                     continue
                 self.logger.info(f"Running periodic callback: {callback}")


### PR DESCRIPTION
The eval entrypoint was not calling `resume_from_checkpoint` for callbacks. This is a problem when trying to use the eval_callbacks feature of the EMA callback. 

Evaluation on a EMA checkpoint can also be done either by setting the resume_initializer to load the model weights straight from the EMA checkpoint. However, this means that the EMA callback throws an error when trying to evaluate because it can't load the EMA weights. Two solutions to fix this

1. Skip `eval` calls for EMA callback
2. Call `resume_from_checkpoint` in the PreviousRunInitializer. This should mostly be a no-op because among the inbuilt callbacks only the EMA callback implements this. 

I decided for (2) because being able to reuse the same callback from training to eval leads to better usability. In the absence of the EMA checkpoint this will output a warning and fall back to use normal model weights for EMA.