### PR TITLE
chore: auto-set slurm tasks_per_node

### DIFF
--- a/recipes/aero_cfd/configs/slurm/slurm_config.yaml
+++ b/recipes/aero_cfd/configs/slurm/slurm_config.yaml
@@ -1,11 +1,10 @@
-name: ${name}
-slurm_partition: compute
-nodes: 1
-tasks_per_node: 1
 cpus_per_task: 28
+folder: /home/%u/logs/${name}
 gpus_per_node: 1
 mem_gb: 128
-folder: /home/%u/logs/${name}
+name: ${name}
+nodes: 1
+slurm_partition: compute
 slurm_setup:
   - source .venv/bin/activate
 slurm_additional_parameters:

--- a/recipes/heat_transfer/configs/slurm/slurm_config.yaml
+++ b/recipes/heat_transfer/configs/slurm/slurm_config.yaml
@@ -1,9 +1,9 @@
-nodes: 1
 cpus_per_task: 28
-partition: compute
+folder: /home/%u/logs/${project}/%x_%j.out
 gpus_per_node: 1
-ntasks_per_node: 1
-mem: 64GB
-output: /home/%u/logs/${project}/%x_%j.out
-nice: 0
-job_name: ${name}
+mem_gb: 64
+name: ${name}
+nodes: 1
+slurm_partition: compute
+slurm_additional_parameters:
+  nice: 0

--- a/src/noether/core/schemas/slurm.py
+++ b/src/noether/core/schemas/slurm.py
@@ -6,7 +6,7 @@ import getpass
 import re
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 # SLURM patterns that require a running job and cannot be resolved at submission time.
 _UNSUPPORTED_FOLDER_PATTERNS: frozenset[str] = frozenset({"%j", "%J", "%A", "%a", "%N", "%x"})
@@ -107,6 +107,14 @@ class SlurmConfig(BaseModel):
                 f"Invalid gpus_per_node spec: '{value}'. Expected a count or 'type:count' (e.g. '2', 'a100:4')."
             )
         return value
+
+    @model_validator(mode="after")
+    def _set_tasks_per_node_if_gpus_set(self):
+        """If gpus_per_node is set but tasks_per_node isn't, set tasks_per_node = gpus_per_node."""
+        if self.gpus_per_node is not None and self.tasks_per_node is None:
+            gpus = self.gpus_per_node if isinstance(self.gpus_per_node, int) else int(self.gpus_per_node.split(":")[-1])
+            self.tasks_per_node = gpus
+        return self
 
     def to_executor_kwargs(self) -> tuple[str, dict[str, Any]]:
         """Return ``(folder, update_parameters_kwargs)`` for :class:`submitit.AutoExecutor`.


### PR DESCRIPTION
With slurm jobs we want one task per GPU, thus in most cases it's unnecessary to set both gpus_per_node and task_per_node because they should be tied. We can use a model_validator to keep them in sync. We have code that throws an error if they are out-of-sync but this might change in the future so for now it's not a validation error if they are set to different values, happy to debate this.