### PR TITLE
test: add integration tests based on existing recipes

### DIFF
--- a/.github/workflows/weekly-integration-tests.yml
+++ b/.github/workflows/weekly-integration-tests.yml
@@ -51,69 +51,48 @@ jobs:
 
       - name: Notify codeowners on failure
         if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const { owner, repo } = context.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const title = 'Weekly integration tests are failing';
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # MENTIONS may include team handles in @org/team form.
+          ASSIGNEES: 'Ndles,MauritsBleeker,HennerM,kinggongzilla'
+          MENTIONS: '@Ndles @MauritsBleeker @HennerM @kinggongzilla'
+          TITLE: 'Weekly integration tests are failing'
+          LABEL: 'integration-test-failure'
+        run: |
+          set -euo pipefail
 
-            // Parse the wildcard owners from .github/CODEOWNERS so the list stays in one place.
-            // Match either @user or @org/team. The team form must be kept as
-            // a single token (e.g. ``myorg/platform-team``) for both notification
-            // and routing.
-            const handleRe = /@([A-Za-z0-9-]+(?:\/[A-Za-z0-9_-]+)?)/g;
-            const codeowners = fs.readFileSync('.github/CODEOWNERS', 'utf8')
-              .split('\n')
-              .map(l => l.trim())
-              .filter(l => l && !l.startsWith('#') && l.startsWith('*'))
-              .flatMap(l => Array.from(l.matchAll(handleRe), m => m[1]));
+          BODY=$(cat <<EOF
+          The weekly scheduled integration test run failed.
 
-            // Split: GitHub's issue ``assignees`` field rejects teams (and any
-            // login that isn't a collaborator with push access). Mentions in
-            // the body work for both forms.
-            const individuals = codeowners.filter(h => !h.includes('/'));
-            const teams = codeowners.filter(h => h.includes('/'));
+          **Run:** $RUN_URL
+          **Commit:** \`${{ github.sha }}\`
+          **Triggered by:** ${{ github.event_name }}
 
-            const mentions = codeowners.map(h => `@${h}`).join(' ') || '_no codeowners parsed_';
-            const body = [
-              `The weekly scheduled integration test run failed.`,
-              ``,
-              `**Run:** ${runUrl}`,
-              `**Commit:** \`${context.sha}\``,
-              `**Triggered by:** ${context.eventName}`,
-              ``,
-              `${mentions} — please investigate.`,
-              ``,
-              `<sub>This issue is auto-managed by \`.github/workflows/weekly-integration-tests.yml\`. ` +
-              `If a tracking issue with this title is already open, the workflow comments on it instead of opening a new one.</sub>`,
-            ].join('\n');
+          $MENTIONS — please investigate.
 
-            // Reuse a single tracking issue to avoid spam when failures persist for multiple weeks.
-            const existing = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}"`,
-            });
+          <sub>Auto-managed by \`.github/workflows/weekly-integration-tests.yml\`. Subsequent failures comment on this issue rather than opening a new one.</sub>
+          EOF
+          )
 
-            if (existing.data.total_count > 0) {
-              const issue_number = existing.data.items[0].number;
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-              core.info(`Commented on existing tracking issue #${issue_number}`);
-              return;
-            }
+          # Find an existing open tracking issue by label + exact title:
+          NUM=$(gh issue list \
+            --state open --label "$LABEL" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" \
+            | head -n1)
 
-            // Try to open with assignees; fall back to no assignees if the API
-            // rejects the list (e.g. an individual without push access). The
-            // mentions in the body still notify everyone either way.
-            const issuePayload = { owner, repo, title, body, labels: ['integration-test-failure'] };
-            try {
-              const created = await github.rest.issues.create({
-                ...issuePayload,
-                assignees: individuals,
-              });
-              core.info(`Opened tracking issue #${created.data.number} (assignees: ${individuals.join(', ') || 'none'}; teams mentioned: ${teams.join(', ') || 'none'})`);
-            } catch (err) {
-              core.warning(`issues.create with assignees failed (${err.status} ${err.message}); retrying without assignees`);
-              const created = await github.rest.issues.create(issuePayload);
-              core.info(`Opened tracking issue #${created.data.number} without assignees`);
-            }
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body "$BODY"
+            echo "Commented on existing tracking issue #$NUM"
+          else
+            # Try with assignees; if the API rejects the list (e.g. a stale
+            # CODEOWNER without push access) fall back to no assignees so the
+            # body mentions still route notifications.
+            if ! gh issue create \
+                --title "$TITLE" --body "$BODY" \
+                --label "$LABEL" --assignee "$ASSIGNEES"; then
+              echo "::warning::issue create with assignees failed; retrying without assignees"
+              gh issue create --title "$TITLE" --body "$BODY" --label "$LABEL"
+            fi
+          fi

--- a/.github/workflows/weekly-integration-tests.yml
+++ b/.github/workflows/weekly-integration-tests.yml
@@ -1,0 +1,119 @@
+name: weekly-integration-tests
+
+on:
+  schedule:
+    # 05:00 UTC every Monday — i.e. 06:00 CET (winter) / 07:00 CEST (summer).
+    # GitHub cron is fixed UTC and does not observe DST, so the local-time slot
+    # shifts by an hour twice a year. The job typically completes in well under
+    # 30 minutes, so failure notifications still land before the start of the
+    # work day in either season.
+    - cron: '0 5 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write   # needed to open / comment on the tracking issue on failure
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup uv (with cache)
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run integration tests (CPU only)
+        id: pytest
+        run: |
+          uv run --no-sync pytest \
+            -m "integration and not gpu" \
+            --junitxml=pytest-integration.xml \
+            -v
+
+      - name: Upload junit on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-integration
+          path: pytest-integration.xml
+
+      - name: Notify codeowners on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = 'Weekly integration tests are failing';
+
+            // Parse the wildcard owners from .github/CODEOWNERS so the list stays in one place.
+            // Match either @user or @org/team. The team form must be kept as
+            // a single token (e.g. ``myorg/platform-team``) for both notification
+            // and routing.
+            const handleRe = /@([A-Za-z0-9-]+(?:\/[A-Za-z0-9_-]+)?)/g;
+            const codeowners = fs.readFileSync('.github/CODEOWNERS', 'utf8')
+              .split('\n')
+              .map(l => l.trim())
+              .filter(l => l && !l.startsWith('#') && l.startsWith('*'))
+              .flatMap(l => Array.from(l.matchAll(handleRe), m => m[1]));
+
+            // Split: GitHub's issue ``assignees`` field rejects teams (and any
+            // login that isn't a collaborator with push access). Mentions in
+            // the body work for both forms.
+            const individuals = codeowners.filter(h => !h.includes('/'));
+            const teams = codeowners.filter(h => h.includes('/'));
+
+            const mentions = codeowners.map(h => `@${h}`).join(' ') || '_no codeowners parsed_';
+            const body = [
+              `The weekly scheduled integration test run failed.`,
+              ``,
+              `**Run:** ${runUrl}`,
+              `**Commit:** \`${context.sha}\``,
+              `**Triggered by:** ${context.eventName}`,
+              ``,
+              `${mentions} — please investigate.`,
+              ``,
+              `<sub>This issue is auto-managed by \`.github/workflows/weekly-integration-tests.yml\`. ` +
+              `If a tracking issue with this title is already open, the workflow comments on it instead of opening a new one.</sub>`,
+            ].join('\n');
+
+            // Reuse a single tracking issue to avoid spam when failures persist for multiple weeks.
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}"`,
+            });
+
+            if (existing.data.total_count > 0) {
+              const issue_number = existing.data.items[0].number;
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              core.info(`Commented on existing tracking issue #${issue_number}`);
+              return;
+            }
+
+            // Try to open with assignees; fall back to no assignees if the API
+            // rejects the list (e.g. an individual without push access). The
+            // mentions in the body still notify everyone either way.
+            const issuePayload = { owner, repo, title, body, labels: ['integration-test-failure'] };
+            try {
+              const created = await github.rest.issues.create({
+                ...issuePayload,
+                assignees: individuals,
+              });
+              core.info(`Opened tracking issue #${created.data.number} (assignees: ${individuals.join(', ') || 'none'}; teams mentioned: ${teams.join(', ') || 'none'})`);
+            } catch (err) {
+              core.warning(`issues.create with assignees failed (${err.status} ${err.message}); retrying without assignees`);
+              const created = await github.rest.issues.create(issuePayload);
+              core.info(`Opened tracking issue #${created.data.number} without assignees`);
+            }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,10 +172,11 @@ module = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = [".", "src"]
-addopts = ["--import-mode=importlib", "-m", "not benchmark"]
+addopts = ["--import-mode=importlib", "-m", "not benchmark and not integration"]
 markers = [
     "benchmark: micro-benchmarks; excluded from default runs",
     "gpu: requires CUDA; tests use this marker to opt into the GPU-only suite",
+    "integration: end-to-end pipeline tests; auto-applied to anything under tests/integration/",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,10 @@ module = [
 testpaths = ["tests"]
 pythonpath = [".", "src"]
 addopts = ["--import-mode=importlib", "-m", "not benchmark"]
+markers = [
+    "benchmark: micro-benchmarks; excluded from default runs",
+    "gpu: requires CUDA; tests use this marker to opt into the GPU-only suite",
+]
 
 
 [tool.ruff]

--- a/recipes/aero_cfd/configs/experiment/drivaerml/upt.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/upt.yaml
@@ -13,7 +13,7 @@ trainer:
 model:
   supernode_pooling_config:
     radius: 0.25
-  transformer_block_config:
+  approximator_config:
     max_wavelength: 40_000
     
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,16 +75,30 @@ def _stabilize_benchmark_environment() -> Iterator[None]:
             subprocess.run(["nvidia-smi", "--reset-gpu-clocks"], capture_output=True, timeout=5, check=False)
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Inject ``_stabilize_benchmark_environment`` into every ``@pytest.mark.benchmark`` test.
+_INTEGRATION_DIR = "tests/integration/"
 
-    Prepending the fixture to ``fixturenames`` ensures it is resolved before any
-    function-scoped fixtures (including ``cache_flush``) that the benchmark relies on.
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Per-item collection tweaks.
+
+    1. Inject ``_stabilize_benchmark_environment`` into every
+       ``@pytest.mark.benchmark`` test (prepending it ensures it is resolved
+       before any function-scoped fixtures the benchmark relies on).
+    2. Auto-apply ``@pytest.mark.integration`` to anything collected from
+       ``tests/integration/`` so the suite can be filtered as
+       ``pytest -m "not integration"`` (or run in isolation as
+       ``pytest -m integration``) without per-file boilerplate.
     """
+    rootpath = config.rootpath
     for item in items:
-        if item.get_closest_marker("benchmark") is None:
+        if item.get_closest_marker("benchmark") is not None:
+            fixturenames = getattr(item, "fixturenames", None)
+            if fixturenames is not None and "_stabilize_benchmark_environment" not in fixturenames:
+                fixturenames.insert(0, "_stabilize_benchmark_environment")
+
+        try:
+            rel = item.path.relative_to(rootpath).as_posix()
+        except ValueError:
             continue
-        fixturenames = getattr(item, "fixturenames", None)
-        if fixturenames is None or "_stabilize_benchmark_environment" in fixturenames:
-            continue
-        fixturenames.insert(0, "_stabilize_benchmark_environment")
+        if rel.startswith(_INTEGRATION_DIR) and item.get_closest_marker("integration") is None:
+            item.add_marker(pytest.mark.integration)

--- a/tests/integration/training_pipelines/__init__.py
+++ b/tests/integration/training_pipelines/__init__.py
@@ -1,0 +1,1 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.

--- a/tests/integration/training_pipelines/conftest.py
+++ b/tests/integration/training_pipelines/conftest.py
@@ -1,0 +1,68 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import torch
+from hydra.core.global_hydra import GlobalHydra
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RECIPES_DIR = _REPO_ROOT / "recipes"
+
+# Top-level package names exposed by recipes. When a recipe directory goes onto sys.path these names take over;
+# we flush them on swap so a previous recipe's cached module does not shadow the new one.
+_AERO_CFD_TOP_LEVEL = ("pipeline", "trainers", "callbacks", "model", "showcase")
+_HEAT_TRANSFER_TOP_LEVEL = ("pipeline", "callbacks", "model")
+
+
+def _ensure_path(path: Path) -> None:
+    p = str(path)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+_ensure_path(_RECIPES_DIR)
+
+
+@pytest.fixture
+def device() -> str:
+    """Return ``"cuda"`` if available, otherwise ``"cpu"``."""
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+@pytest.fixture
+def accelerator(device: str) -> str:
+    """The noether accelerator string (``"gpu"`` or ``"cpu"``)."""
+    return "gpu" if device == "cuda" else "cpu"
+
+
+@pytest.fixture(autouse=True)
+def _clear_hydra() -> Iterator[None]:
+    """Clear Hydra's global state before and after each test."""
+    GlobalHydra.instance().clear()
+    yield
+    GlobalHydra.instance().clear()
+
+
+def _put_recipe_on_path(monkeypatch: pytest.MonkeyPatch, recipe_dir: Path, top_level_names: tuple[str, ...]) -> None:
+    monkeypatch.syspath_prepend(str(recipe_dir))
+    # Drop cached top-level modules from any previously activated recipe so the next ``import pipeline`` (etc.)
+    # re-resolves against the new sys.path.
+    for name in top_level_names:
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def aero_cfd_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activate ``recipes/aero_cfd/`` for top-level imports used in YAML kinds."""
+    _put_recipe_on_path(monkeypatch, _RECIPES_DIR / "aero_cfd", _AERO_CFD_TOP_LEVEL)
+
+
+@pytest.fixture
+def heat_transfer_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activate ``recipes/heat_transfer/`` for top-level imports used in YAML kinds."""
+    _put_recipe_on_path(monkeypatch, _RECIPES_DIR / "heat_transfer", _HEAT_TRANSFER_TOP_LEVEL)

--- a/tests/integration/training_pipelines/fixtures/__init__.py
+++ b/tests/integration/training_pipelines/fixtures/__init__.py
@@ -1,0 +1,1 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.

--- a/tests/integration/training_pipelines/fixtures/helpers.py
+++ b/tests/integration/training_pipelines/fixtures/helpers.py
@@ -1,0 +1,112 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from hydra import compose, initialize_config_dir
+
+from noether.core.factory import class_constructor_from_class_path
+from noether.core.schemas.schema import ConfigSchema
+from noether.training.runners import HydraRunner
+
+from .overrides import apply_test_overrides, to_runner_dict
+
+
+def make_run_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    """Create ``tmp_path/out`` and ``tmp_path/data`` and return both."""
+    output_path = tmp_path / "out"
+    dataset_root = tmp_path / "data"
+    output_path.mkdir()
+    dataset_root.mkdir()
+    return output_path, dataset_root
+
+
+def instantiate_schema(runner_dict: dict[str, Any]) -> ConfigSchema:
+    """Build a ``ConfigSchema`` (or recipe-defined subclass) from a resolved Hydra dict."""
+    schema_kind = runner_dict.get("config_schema_kind")
+    schema_cls: type[ConfigSchema] = class_constructor_from_class_path(schema_kind) if schema_kind else ConfigSchema
+    return schema_cls(**runner_dict)
+
+
+def compose_recipe_config(
+    *,
+    configs_dir: str,
+    config_name: str,
+    overrides: list[str],
+    stub_kind: str,
+    accelerator: str,
+    output_path: Path,
+    dataset_root: Path,
+    extra: dict[str, Any] | None = None,
+) -> ConfigSchema:
+    """Compose a recipe YAML, apply test caps, and return a validated ``ConfigSchema``.
+
+    Tests that need to inspect the composed config before training (for assertions
+    or further patching) should use this rather than ``run_hydra_recipe`` directly.
+    """
+    with initialize_config_dir(version_base=None, config_dir=configs_dir, job_name="test"):
+        cfg = compose(config_name=config_name, overrides=[*overrides, "tracker=disabled"])
+
+    apply_test_overrides(
+        cfg,
+        accelerator=accelerator,
+        output_path=output_path,
+        dataset_root=dataset_root,
+        stub_dataset_kind=stub_kind,
+        extra=extra,
+    )
+    return instantiate_schema(to_runner_dict(cfg))
+
+
+def floating_state_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    """Snapshot all floating-point parameters on CPU.
+
+    ``HydraRunner.setup_experiment`` returns a CPU model; ``trainer.train`` moves
+    it to ``self.device``. Snapshotting on CPU keeps the post-train comparison
+    device-agnostic.
+    """
+    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+
+
+def assert_any_param_changed(model: torch.nn.Module, before_state: dict[str, torch.Tensor], *, label: str) -> None:
+    after = model.state_dict()
+    changed = any(not torch.equal(before_state[k], after[k].detach().cpu()) for k in before_state)
+    assert changed, f"no parameter changed during {label} training"
+
+
+def train_and_assert_weights_changed(config: ConfigSchema, *, device: str, label: str) -> None:
+    """Set up trainer/model from a fully-built config, train one step, assert weights moved."""
+    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config)
+    before = floating_state_cpu(model)
+    trainer.train(model)
+    assert_any_param_changed(model, before, label=label)
+
+
+def run_hydra_recipe(
+    *,
+    configs_dir: str,
+    config_name: str,
+    overrides: list[str],
+    stub_kind: str,
+    tmp_path: Path,
+    accelerator: str,
+    device: str,
+    label: str,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """End-to-end: compose recipe → cap → setup_experiment → train → assert."""
+    output_path, dataset_root = make_run_dirs(tmp_path)
+    config = compose_recipe_config(
+        configs_dir=configs_dir,
+        config_name=config_name,
+        overrides=overrides,
+        stub_kind=stub_kind,
+        accelerator=accelerator,
+        output_path=output_path,
+        dataset_root=dataset_root,
+        extra=extra,
+    )
+    train_and_assert_weights_changed(config, device=device, label=label)

--- a/tests/integration/training_pipelines/fixtures/overrides.py
+++ b/tests/integration/training_pipelines/fixtures/overrides.py
@@ -1,0 +1,78 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def apply_test_overrides(
+    cfg: DictConfig,
+    *,
+    accelerator: str,
+    output_path: Path,
+    dataset_root: Path,
+    stub_dataset_kind: str,
+    keep_datasets: tuple[str, ...] = ("train",),
+    extra: dict[str, Any] | None = None,
+) -> DictConfig:
+    """Cap a composed recipe config to a fast, hermetic single-step run.
+
+    Args:
+        cfg: Composed Hydra config (a DictConfig from ``hydra.compose``).
+        accelerator: ``"cpu"`` or ``"gpu"``.
+        output_path: Directory under which the run writes logs/checkpoints. Tests should pass a ``tmp_path``
+            so cleanup is automatic.
+        dataset_root: Directory passed as the dataset root. Stub datasets ignore this for I/O but the pydantic schema
+            requires the path to exist, so tests should pass ``tmp_path``.
+        stub_dataset_kind: Dotted class path of the in-memory stub dataset.
+        keep_datasets: Dataset keys to retain. The default ``("train",)`` drops ``val``/``test``/``test_repeat`` etc.;
+            those splits only exist to feed callbacks, which we disable below.
+        extra: Optional flat mapping of dotted-path → value overrides applied last (e.g.
+            ``{"trainer.max_batch_size": 1}``).
+
+    Returns:
+        The same ``cfg`` with overrides applied in place (for chaining).
+    """
+    OmegaConf.set_struct(cfg, False)
+
+    cfg.dataset_root = str(dataset_root)
+    cfg.dataset_kind = stub_dataset_kind
+
+    cfg.accelerator = accelerator
+    cfg.output_path = str(output_path)
+    cfg.store_code_in_output = False
+    cfg.tracker = None
+    cfg.num_workers = 0
+    cfg.devices = "0" if accelerator == "gpu" else "cpu"
+    # Recipes ship slurm sections for cluster runs; tests don't need them and some recipes use field names that drift
+    # from noether's current SlurmConfig schema. Drop it entirely.
+    cfg.slurm = None
+
+    cfg.trainer.max_epochs = 1
+    cfg.trainer.max_updates = None
+    cfg.trainer.max_samples = None
+    cfg.trainer.effective_batch_size = 1
+    cfg.trainer.callbacks = []
+    cfg.trainer.add_default_callbacks = False
+    cfg.trainer.add_trainer_callbacks = False
+    cfg.trainer.precision = "float32"
+    cfg.trainer.log_every_n_epochs = 1
+
+    cfg.datasets = {k: v for k, v in cfg.datasets.items() if k in keep_datasets}
+
+    if extra:
+        for path, value in extra.items():
+            OmegaConf.update(cfg, path, value, merge=False)
+
+    return cfg
+
+
+def to_runner_dict(cfg: DictConfig) -> dict[str, Any]:
+    """Resolve a DictConfig and convert to the plain dict ``HydraRunner.run`` expects."""
+    container = OmegaConf.to_container(cfg, resolve=True)
+    if not isinstance(container, dict):
+        raise TypeError(f"Expected a dict-like config, got {type(container).__name__}")
+    return container  # type: ignore[return-value]

--- a/tests/integration/training_pipelines/fixtures/synthetic_datasets.py
+++ b/tests/integration/training_pipelines/fixtures/synthetic_datasets.py
@@ -1,0 +1,174 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+import torch
+
+from noether.core.schemas.dataset import StandardDatasetConfig
+from noether.data.datasets.cfd.caeml.drivaerml.dataset import DrivAerMLDataset
+from noether.data.datasets.cfd.shapenet_car.dataset import ShapeNetCarDataset
+from noether.data.datasets.cfd.shapenet_car.filemap import SHAPENET_CAR_FILEMAP
+from noether.data.datasets.cfd.simshift_heatsink.config import SimshiftHeatsinkConfig
+from noether.data.datasets.cfd.simshift_heatsink.dataset import SimshiftHeatsinkDataset
+
+
+def _seeded_randn(*shape: int, seed: int) -> torch.Tensor:
+    gen = torch.Generator().manual_seed(seed)
+    return torch.randn(*shape, generator=gen)
+
+
+def _seeded_unit_vectors(*shape: int, seed: int) -> torch.Tensor:
+    return torch.nn.functional.normalize(_seeded_randn(*shape, seed=seed), dim=-1)
+
+
+def _seeded_positions(n: int, dim: int, *, low: float, high: float, seed: int) -> torch.Tensor:
+    """Uniform points in ``[low, high]^dim``.
+
+    The production ``PositionNormalizer`` rejects values outside the dataset's ``raw_pos_min`` / ``raw_pos_max``
+    bounds, so synthetic positions must stay inside that bbox or the test fails before any forward pass.
+    """
+    gen = torch.Generator().manual_seed(seed)
+    return torch.rand(n, dim, generator=gen) * (high - low) + low
+
+
+class StubShapeNetCarDataset(ShapeNetCarDataset):
+    """In-memory ShapeNetCarDataset that bypasses all disk I/O.
+
+    Returns synthetic tensors sized to satisfy the pipeline's downsampling requirements (``num_surface_points=3586``,
+    ``num_volume_points=4096`` per the ``ShapeNetCarPreset``).
+    """
+
+    NUM_SAMPLES: int = 4
+    NUM_SURFACE_POINTS: int = 4096
+    NUM_VOLUME_POINTS: int = 4096
+    POS_MIN: float = -4.5
+    POS_MAX: float = 6.0
+
+    def __init__(self, dataset_config: StandardDatasetConfig) -> None:
+        super().__init__(dataset_config=dataset_config)
+
+    def _resolve_source_root_path(self) -> None:
+        return
+
+    def _load_design_ids(self) -> None:
+        self.design_ids = [f"stub/{i:04d}" for i in range(self.NUM_SAMPLES)]
+
+    def _load(self, idx: int, filename: str) -> torch.Tensor:
+        n_surf = self.NUM_SURFACE_POINTS
+        n_vol = self.NUM_VOLUME_POINTS
+        seed = (hash((type(self).__name__, idx, filename)) & 0x7FFFFFFF) or 1
+
+        if filename == SHAPENET_CAR_FILEMAP.surface_position:
+            return _seeded_positions(n_surf, 3, low=self.POS_MIN, high=self.POS_MAX, seed=seed)
+        if filename == SHAPENET_CAR_FILEMAP.surface_pressure:
+            return _seeded_randn(n_surf, seed=seed)
+        if filename == SHAPENET_CAR_FILEMAP.surface_normals:
+            return _seeded_unit_vectors(n_surf, 3, seed=seed)
+        if filename == SHAPENET_CAR_FILEMAP.volume_position:
+            return _seeded_positions(n_vol, 3, low=self.POS_MIN, high=self.POS_MAX, seed=seed)
+        if filename == SHAPENET_CAR_FILEMAP.volume_velocity:
+            return _seeded_randn(n_vol, 3, seed=seed)
+        if filename == SHAPENET_CAR_FILEMAP.volume_distance_to_surface:
+            return _seeded_randn(n_vol, seed=seed)
+        if filename == SHAPENET_CAR_FILEMAP.volume_normals:
+            return _seeded_unit_vectors(n_vol, 3, seed=seed)
+        raise KeyError(f"StubShapeNetCarDataset has no synthetic tensor for filename={filename!r}")
+
+
+class StubDrivAerMLDataset(DrivAerMLDataset):
+    """In-memory DrivAerMLDataset that bypasses all disk I/O.
+
+    Sized for the ``DrivAerMLPreset`` pipeline (``num_surface_points=16384``, ``num_volume_points=16384``).
+    """
+
+    NUM_SAMPLES: int = 4
+    NUM_SURFACE_POINTS: int = 16384
+    NUM_VOLUME_POINTS: int = 16384
+    POS_MIN: float = -40.0
+    POS_MAX: float = 80.0
+
+    def __init__(self, dataset_config: StandardDatasetConfig) -> None:
+        super().__init__(dataset_config=dataset_config)
+
+    def _load_design_ids(self) -> None:
+        self.design_ids = [str(i) for i in range(self.NUM_SAMPLES)]
+
+    def _load(self, idx: int, filename: str) -> torch.Tensor:
+        n_surf = self.NUM_SURFACE_POINTS
+        n_vol = self.NUM_VOLUME_POINTS
+        seed = (hash((type(self).__name__, idx, filename)) & 0x7FFFFFFF) or 1
+        fm = self.filemap
+
+        if filename == fm.surface_position:
+            return _seeded_positions(n_surf, 3, low=self.POS_MIN, high=self.POS_MAX, seed=seed)
+        if filename == fm.surface_pressure:
+            return _seeded_randn(n_surf, seed=seed)
+        if filename == fm.surface_friction:
+            return _seeded_randn(n_surf, 3, seed=seed)
+        if filename == fm.surface_normals:
+            return _seeded_unit_vectors(n_surf, 3, seed=seed)
+        if filename == fm.surface_area:
+            return _seeded_randn(n_surf, seed=seed).abs()
+        if filename == fm.volume_position:
+            return _seeded_positions(n_vol, 3, low=self.POS_MIN, high=self.POS_MAX, seed=seed)
+        if filename == fm.volume_pressure:
+            return _seeded_randn(n_vol, seed=seed)
+        if filename == fm.volume_velocity:
+            return _seeded_randn(n_vol, 3, seed=seed)
+        if filename == fm.volume_vorticity:
+            return _seeded_randn(n_vol, 3, seed=seed)
+        raise KeyError(f"StubDrivAerMLDataset has no synthetic tensor for filename={filename!r}")
+
+
+class StubSimshiftHeatsinkDataset(SimshiftHeatsinkDataset):
+    """In-memory SimshiftHeatsinkDataset bypassing HDF5 / HuggingFace download.
+
+    Mirrors the production dataset's ``pre_getitem`` contract: returns a dict
+    with ``position``/``velocity``/``temperature``/``pressure`` per sample. The
+    ``simulation_parameters`` getter is also overridden since it reads from a
+    pandas DataFrame the real ``__init__`` builds.
+    """
+
+    NUM_SAMPLES: int = 4
+    NUM_VOLUME_POINTS: int = 4096
+    NUM_SIM_PARAMS: int = 5
+
+    def __init__(self, dataset_config: SimshiftHeatsinkConfig) -> None:
+        # Fully bypass the real __init__ (HDF5 / HuggingFace download / metadata
+        # CSV). Reproduce the minimum invariants: dataset_config wiring through
+        # the grandparent Dataset.__init__, plus the attributes that getitem_*
+        # methods read.
+        from noether.data.base.dataset import Dataset as _BaseDataset
+
+        _BaseDataset.__init__(self, dataset_config=dataset_config)
+        self._zip_path = None
+        self.source_root = None  # type: ignore[assignment]
+        self.difficulty = getattr(dataset_config, "difficulty", "easy")
+        self.domain = getattr(dataset_config, "domain", "source")
+        self.split = dataset_config.split
+        self._sample_ids = list(range(self.NUM_SAMPLES))
+        self._cond_columns = [f"param_{i}" for i in range(self.NUM_SIM_PARAMS)]
+
+    # Per-axis bbox derived from the production stats.json (volume_position_min /
+    # volume_position_max). Positions outside this box trip the FieldNormalizer's
+    # bounds check.
+    POS_LOW: tuple[float, float, float] = (-0.069, -0.069, 0.001)
+    POS_HIGH: tuple[float, float, float] = (0.069, 0.069, 0.499)
+
+    def _read_h5(self, sample_id: int) -> dict[str, torch.Tensor]:
+        n = self.NUM_VOLUME_POINTS
+        seed = (hash((type(self).__name__, sample_id)) & 0x7FFFFFFF) or 1
+        gen = torch.Generator().manual_seed(seed)
+        low = torch.tensor(self.POS_LOW)
+        high = torch.tensor(self.POS_HIGH)
+        position = torch.rand(n, 3, generator=gen) * (high - low) + low
+        return {
+            "position": position,
+            "velocity": _seeded_randn(n, 3, seed=seed + 1),
+            "temperature": _seeded_randn(n, 1, seed=seed + 2),
+            "pressure": _seeded_randn(n, 1, seed=seed + 3),
+        }
+
+    def getitem_simulation_parameters(self, idx: int) -> torch.Tensor:  # type: ignore[override]
+        seed = (hash((type(self).__name__, idx, "sim_params")) & 0x7FFFFFFF) or 1
+        return _seeded_randn(1, self.NUM_SIM_PARAMS, seed=seed)

--- a/tests/integration/training_pipelines/test_aero_cfd_hydra.py
+++ b/tests/integration/training_pipelines/test_aero_cfd_hydra.py
@@ -1,0 +1,165 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+
+from noether.core.factory import class_constructor_from_class_path
+from noether.core.schemas.schema import ConfigSchema
+from noether.training.runners import HydraRunner
+from tests.integration.training_pipelines.fixtures.overrides import apply_test_overrides, to_runner_dict
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_AERO_CFD_CONFIGS = str(_REPO_ROOT / "recipes" / "aero_cfd" / "configs")
+
+_STUB_SHAPENET = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubShapeNetCarDataset"
+_STUB_DRIVAERML = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubDrivAerMLDataset"
+
+
+def _instantiate_schema(runner_dict: dict) -> ConfigSchema:
+    schema_kind = runner_dict.get("config_schema_kind")
+    schema_cls: type[ConfigSchema] = class_constructor_from_class_path(schema_kind) if schema_kind else ConfigSchema
+    return schema_cls(**runner_dict)
+
+
+def _floating_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {k: v.detach().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+
+
+def _any_changed(before: dict[str, torch.Tensor], after_state: dict) -> bool:
+    return any(not torch.equal(before[k], after_state[k].detach()) for k in before)
+
+
+def _run_recipe(
+    *,
+    config_name: str,
+    experiment_override: str,
+    stub_kind: str,
+    tmp_path: Path,
+    accelerator: str,
+    device: str,
+    extra: dict | None = None,
+) -> tuple[torch.nn.Module, bool]:
+    output_path = tmp_path / "out"
+    dataset_root = tmp_path / "data"
+    output_path.mkdir()
+    dataset_root.mkdir()
+
+    with initialize_config_dir(version_base=None, config_dir=_AERO_CFD_CONFIGS, job_name="test"):
+        cfg = compose(
+            config_name=config_name,
+            overrides=[experiment_override, "tracker=disabled"],
+        )
+
+    apply_test_overrides(
+        cfg,
+        accelerator=accelerator,
+        output_path=output_path,
+        dataset_root=dataset_root,
+        stub_dataset_kind=stub_kind,
+        extra=extra,
+    )
+
+    config_obj = _instantiate_schema(to_runner_dict(cfg))
+    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config_obj)
+
+    before = _floating_state(model)
+    trainer.train(model)
+    changed = _any_changed(before, model.state_dict())
+    return model, changed
+
+
+@pytest.mark.usefixtures("aero_cfd_on_path")
+@pytest.mark.parametrize("model_name", ["transformer", "transolver", "ab_upt", "upt"])
+def test_shapenet_pipeline(model_name: str, tmp_path: Path, accelerator: str, device: str) -> None:
+    """ShapeNet-Car recipe runs end-to-end and updates weights for each model architecture."""
+    _, changed = _run_recipe(
+        config_name="train_shapenet",
+        experiment_override=f"+experiment/shapenet={model_name}",
+        stub_kind=_STUB_SHAPENET,
+        tmp_path=tmp_path,
+        accelerator=accelerator,
+        device=device,
+    )
+    assert changed, f"no parameter changed during shapenet/{model_name} training"
+
+
+@pytest.mark.usefixtures("aero_cfd_on_path")
+@pytest.mark.parametrize("model_name", ["transformer", "transolver", "ab_upt", "upt"])
+def test_drivaerml_pipeline(model_name: str, tmp_path: Path, accelerator: str, device: str) -> None:
+    """DrivAerML recipe runs end-to-end and updates weights for each model architecture."""
+    _, changed = _run_recipe(
+        config_name="train_drivaerml",
+        experiment_override=f"+experiment/drivaerml={model_name}",
+        stub_kind=_STUB_DRIVAERML,
+        tmp_path=tmp_path,
+        accelerator=accelerator,
+        device=device,
+    )
+    assert changed, f"no parameter changed during drivaerml/{model_name} training"
+
+
+# Orthogonal cases — exercised on the cheapest combo (shapenet × transformer)
+# rather than the full grid, since they're testing trainer mechanics rather
+# than recipe wiring.
+
+
+@pytest.mark.usefixtures("aero_cfd_on_path")
+def test_shapenet_with_gradient_accumulation(tmp_path: Path, accelerator: str, device: str) -> None:
+    """Effective batch size > max batch size triggers gradient accumulation."""
+    _, changed = _run_recipe(
+        config_name="train_shapenet",
+        experiment_override="+experiment/shapenet=transformer",
+        stub_kind=_STUB_SHAPENET,
+        tmp_path=tmp_path,
+        accelerator=accelerator,
+        device=device,
+        extra={
+            "trainer.effective_batch_size": 2,
+            "trainer.max_batch_size": 1,
+            "trainer.disable_gradient_accumulation": False,
+        },
+    )
+    assert changed, "no parameter changed when running with gradient accumulation"
+
+
+@pytest.mark.gpu
+def test_shapenet_with_bf16(tmp_path: Path) -> None:
+    """Mixed-precision (bfloat16) training runs end-to-end. GPU only."""
+    if not torch.cuda.is_available():
+        pytest.skip("bfloat16 mixed-precision training requires a CUDA GPU")
+    _, changed = _run_recipe(
+        config_name="train_shapenet",
+        experiment_override="+experiment/shapenet=transformer",
+        stub_kind=_STUB_SHAPENET,
+        tmp_path=tmp_path,
+        accelerator="gpu",
+        device="cuda",
+        extra={"trainer.precision": "bfloat16"},
+    )
+    assert changed, "no parameter changed when running with bfloat16 precision"
+
+
+@pytest.mark.usefixtures("aero_cfd_on_path")
+def test_shapenet_with_default_callbacks(tmp_path: Path, accelerator: str, device: str) -> None:
+    """Trainer wiring still works when default + trainer callbacks are enabled."""
+    # Re-enable the default callbacks the override helper turns off. Keep the
+    # user callback list empty so we don't pull in the production
+    # OfflineLossCallback that needs a 'test' dataset we've dropped.
+    _, changed = _run_recipe(
+        config_name="train_shapenet",
+        experiment_override="+experiment/shapenet=transformer",
+        stub_kind=_STUB_SHAPENET,
+        tmp_path=tmp_path,
+        accelerator=accelerator,
+        device=device,
+        extra={
+            "trainer.add_default_callbacks": True,
+            "trainer.add_trainer_callbacks": True,
+        },
+    )
+    assert changed, "no parameter changed with default callbacks enabled"

--- a/tests/integration/training_pipelines/test_aero_cfd_hydra.py
+++ b/tests/integration/training_pipelines/test_aero_cfd_hydra.py
@@ -27,11 +27,15 @@ def _instantiate_schema(runner_dict: dict) -> ConfigSchema:
 
 
 def _floating_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
-    return {k: v.detach().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+    # Snapshot on CPU: setup_experiment returns a CPU model, but trainer.train
+    # moves it to self.device, so post-train state lives on the accelerator.
+    # Comparing across devices via torch.equal raises; staying on CPU keeps
+    # the assertion device-agnostic.
+    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
 
 
 def _any_changed(before: dict[str, torch.Tensor], after_state: dict) -> bool:
-    return any(not torch.equal(before[k], after_state[k].detach()) for k in before)
+    return any(not torch.equal(before[k], after_state[k].detach().cpu()) for k in before)
 
 
 def _run_recipe(

--- a/tests/integration/training_pipelines/test_aero_cfd_hydra.py
+++ b/tests/integration/training_pipelines/test_aero_cfd_hydra.py
@@ -6,12 +6,8 @@ from pathlib import Path
 
 import pytest
 import torch
-from hydra import compose, initialize_config_dir
 
-from noether.core.factory import class_constructor_from_class_path
-from noether.core.schemas.schema import ConfigSchema
-from noether.training.runners import HydraRunner
-from tests.integration.training_pipelines.fixtures.overrides import apply_test_overrides, to_runner_dict
+from tests.integration.training_pipelines.fixtures.helpers import run_hydra_recipe
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _AERO_CFD_CONFIGS = str(_REPO_ROOT / "recipes" / "aero_cfd" / "configs")
@@ -20,91 +16,36 @@ _STUB_SHAPENET = "tests.integration.training_pipelines.fixtures.synthetic_datase
 _STUB_DRIVAERML = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubDrivAerMLDataset"
 
 
-def _instantiate_schema(runner_dict: dict) -> ConfigSchema:
-    schema_kind = runner_dict.get("config_schema_kind")
-    schema_cls: type[ConfigSchema] = class_constructor_from_class_path(schema_kind) if schema_kind else ConfigSchema
-    return schema_cls(**runner_dict)
-
-
-def _floating_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
-    # Snapshot on CPU: setup_experiment returns a CPU model, but trainer.train
-    # moves it to self.device, so post-train state lives on the accelerator.
-    # Comparing across devices via torch.equal raises; staying on CPU keeps
-    # the assertion device-agnostic.
-    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
-
-
-def _any_changed(before: dict[str, torch.Tensor], after_state: dict) -> bool:
-    return any(not torch.equal(before[k], after_state[k].detach().cpu()) for k in before)
-
-
-def _run_recipe(
-    *,
-    config_name: str,
-    experiment_override: str,
-    stub_kind: str,
-    tmp_path: Path,
-    accelerator: str,
-    device: str,
-    extra: dict | None = None,
-) -> tuple[torch.nn.Module, bool]:
-    output_path = tmp_path / "out"
-    dataset_root = tmp_path / "data"
-    output_path.mkdir()
-    dataset_root.mkdir()
-
-    with initialize_config_dir(version_base=None, config_dir=_AERO_CFD_CONFIGS, job_name="test"):
-        cfg = compose(
-            config_name=config_name,
-            overrides=[experiment_override, "tracker=disabled"],
-        )
-
-    apply_test_overrides(
-        cfg,
-        accelerator=accelerator,
-        output_path=output_path,
-        dataset_root=dataset_root,
-        stub_dataset_kind=stub_kind,
-        extra=extra,
-    )
-
-    config_obj = _instantiate_schema(to_runner_dict(cfg))
-    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config_obj)
-
-    before = _floating_state(model)
-    trainer.train(model)
-    changed = _any_changed(before, model.state_dict())
-    return model, changed
-
-
 @pytest.mark.usefixtures("aero_cfd_on_path")
 @pytest.mark.parametrize("model_name", ["transformer", "transolver", "ab_upt", "upt"])
 def test_shapenet_pipeline(model_name: str, tmp_path: Path, accelerator: str, device: str) -> None:
     """ShapeNet-Car recipe runs end-to-end and updates weights for each model architecture."""
-    _, changed = _run_recipe(
+    run_hydra_recipe(
+        configs_dir=_AERO_CFD_CONFIGS,
         config_name="train_shapenet",
-        experiment_override=f"+experiment/shapenet={model_name}",
+        overrides=[f"+experiment/shapenet={model_name}"],
         stub_kind=_STUB_SHAPENET,
         tmp_path=tmp_path,
         accelerator=accelerator,
         device=device,
+        label=f"shapenet/{model_name}",
     )
-    assert changed, f"no parameter changed during shapenet/{model_name} training"
 
 
 @pytest.mark.usefixtures("aero_cfd_on_path")
 @pytest.mark.parametrize("model_name", ["transformer", "transolver", "ab_upt", "upt"])
 def test_drivaerml_pipeline(model_name: str, tmp_path: Path, accelerator: str, device: str) -> None:
     """DrivAerML recipe runs end-to-end and updates weights for each model architecture."""
-    _, changed = _run_recipe(
+    run_hydra_recipe(
+        configs_dir=_AERO_CFD_CONFIGS,
         config_name="train_drivaerml",
-        experiment_override=f"+experiment/drivaerml={model_name}",
+        overrides=[f"+experiment/drivaerml={model_name}"],
         stub_kind=_STUB_DRIVAERML,
         tmp_path=tmp_path,
         accelerator=accelerator,
         device=device,
+        label=f"drivaerml/{model_name}",
     )
-    assert changed, f"no parameter changed during drivaerml/{model_name} training"
 
 
 # Orthogonal cases — exercised on the cheapest combo (shapenet × transformer)
@@ -115,37 +56,40 @@ def test_drivaerml_pipeline(model_name: str, tmp_path: Path, accelerator: str, d
 @pytest.mark.usefixtures("aero_cfd_on_path")
 def test_shapenet_with_gradient_accumulation(tmp_path: Path, accelerator: str, device: str) -> None:
     """Effective batch size > max batch size triggers gradient accumulation."""
-    _, changed = _run_recipe(
+    run_hydra_recipe(
+        configs_dir=_AERO_CFD_CONFIGS,
         config_name="train_shapenet",
-        experiment_override="+experiment/shapenet=transformer",
+        overrides=["+experiment/shapenet=transformer"],
         stub_kind=_STUB_SHAPENET,
         tmp_path=tmp_path,
         accelerator=accelerator,
         device=device,
+        label="shapenet/transformer+grad_accum",
         extra={
             "trainer.effective_batch_size": 2,
             "trainer.max_batch_size": 1,
             "trainer.disable_gradient_accumulation": False,
         },
     )
-    assert changed, "no parameter changed when running with gradient accumulation"
 
 
 @pytest.mark.gpu
+@pytest.mark.usefixtures("aero_cfd_on_path")
 def test_shapenet_with_bf16(tmp_path: Path) -> None:
     """Mixed-precision (bfloat16) training runs end-to-end. GPU only."""
     if not torch.cuda.is_available():
         pytest.skip("bfloat16 mixed-precision training requires a CUDA GPU")
-    _, changed = _run_recipe(
+    run_hydra_recipe(
+        configs_dir=_AERO_CFD_CONFIGS,
         config_name="train_shapenet",
-        experiment_override="+experiment/shapenet=transformer",
+        overrides=["+experiment/shapenet=transformer"],
         stub_kind=_STUB_SHAPENET,
         tmp_path=tmp_path,
         accelerator="gpu",
         device="cuda",
+        label="shapenet/transformer+bf16",
         extra={"trainer.precision": "bfloat16"},
     )
-    assert changed, "no parameter changed when running with bfloat16 precision"
 
 
 @pytest.mark.usefixtures("aero_cfd_on_path")
@@ -154,16 +98,17 @@ def test_shapenet_with_default_callbacks(tmp_path: Path, accelerator: str, devic
     # Re-enable the default callbacks the override helper turns off. Keep the
     # user callback list empty so we don't pull in the production
     # OfflineLossCallback that needs a 'test' dataset we've dropped.
-    _, changed = _run_recipe(
+    run_hydra_recipe(
+        configs_dir=_AERO_CFD_CONFIGS,
         config_name="train_shapenet",
-        experiment_override="+experiment/shapenet=transformer",
+        overrides=["+experiment/shapenet=transformer"],
         stub_kind=_STUB_SHAPENET,
         tmp_path=tmp_path,
         accelerator=accelerator,
         device=device,
+        label="shapenet/transformer+default_callbacks",
         extra={
             "trainer.add_default_callbacks": True,
             "trainer.add_trainer_callbacks": True,
         },
     )
-    assert changed, "no parameter changed with default callbacks enabled"

--- a/tests/integration/training_pipelines/test_aero_cfd_python_api.py
+++ b/tests/integration/training_pipelines/test_aero_cfd_python_api.py
@@ -68,10 +68,13 @@ def _patch_for_test(config: ConfigSchema, *, extra_excluded_properties: set[str]
 
 def _run_and_assert_weights_changed(config: ConfigSchema, device: str, label: str) -> None:
     trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config)
-    initial = {k: v.detach().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+    # Snapshot on CPU: trainer.train moves the model to self.device, so the
+    # post-train state lives on the accelerator. CPU comparison stays
+    # device-agnostic.
+    initial = {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
     trainer.train(model)
     after = model.state_dict()
-    changed = any(not torch.equal(initial[k], after[k].detach()) for k in initial)
+    changed = any(not torch.equal(initial[k], after[k].detach().cpu()) for k in initial)
     assert changed, f"no parameter changed during python-api {label} training"
 
 

--- a/tests/integration/training_pipelines/test_aero_cfd_python_api.py
+++ b/tests/integration/training_pipelines/test_aero_cfd_python_api.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-import torch
 
 from noether.core.schemas.schema import ConfigSchema
-from noether.training.runners import HydraRunner
+from tests.integration.training_pipelines.fixtures.helpers import (
+    make_run_dirs,
+    train_and_assert_weights_changed,
+)
 from tests.integration.training_pipelines.fixtures.synthetic_datasets import StubShapeNetCarDataset
 
 _TRAINER_KIND = "noether.training.trainers.WeightedLossTrainer"
@@ -66,18 +68,6 @@ def _patch_for_test(config: ConfigSchema, *, extra_excluded_properties: set[str]
         train_ds_cfg.excluded_properties = (train_ds_cfg.excluded_properties or set()) | extra_excluded_properties
 
 
-def _run_and_assert_weights_changed(config: ConfigSchema, device: str, label: str) -> None:
-    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config)
-    # Snapshot on CPU: trainer.train moves the model to self.device, so the
-    # post-train state lives on the accelerator. CPU comparison stays
-    # device-agnostic.
-    initial = {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
-    trainer.train(model)
-    after = model.state_dict()
-    changed = any(not torch.equal(initial[k], after[k].detach().cpu()) for k in initial)
-    assert changed, f"no parameter changed during python-api {label} training"
-
-
 def _build_kwargs(
     *,
     model_kind: str,
@@ -115,10 +105,7 @@ def test_shapenet_python_api_pipeline(
     device: str,
 ) -> None:
     """End-to-end ShapeNetCar run via the preset API."""
-    output_path = tmp_path / "out"
-    dataset_root = tmp_path / "data"
-    output_path.mkdir()
-    dataset_root.mkdir()
+    output_path, dataset_root = make_run_dirs(tmp_path)
 
     config = stubbed_shapenet_preset.build_config(
         include_evaluation=False,
@@ -140,7 +127,7 @@ def test_shapenet_python_api_pipeline(
     # path adds it to excluded_properties). Exclude it here so the test doesn't
     # trip over a recipe inconsistency unrelated to the pipeline.
     _patch_for_test(config, extra_excluded_properties={"surface_area"})
-    _run_and_assert_weights_changed(config, device=device, label=model_kind)
+    train_and_assert_weights_changed(config, device=device, label=f"python-api shapenet/{model_kind}")
 
 
 @pytest.mark.parametrize(
@@ -158,10 +145,7 @@ def test_drivaerml_python_api_pipeline(
     device: str,
 ) -> None:
     """End-to-end DrivAerML run via the preset API."""
-    output_path = tmp_path / "out"
-    dataset_root = tmp_path / "data"
-    output_path.mkdir()
-    dataset_root.mkdir()
+    output_path, dataset_root = make_run_dirs(tmp_path)
 
     config = stubbed_drivaerml_preset.build_config(
         **_build_kwargs(
@@ -176,7 +160,7 @@ def test_drivaerml_python_api_pipeline(
     assert config.datasets["train"].kind.endswith("StubDrivAerMLDataset")
 
     _patch_for_test(config)
-    _run_and_assert_weights_changed(config, device=device, label=model_kind)
+    train_and_assert_weights_changed(config, device=device, label=f"python-api drivaerml/{model_kind}")
 
 
 def test_stub_dataset_class_path_is_importable() -> None:

--- a/tests/integration/training_pipelines/test_aero_cfd_python_api.py
+++ b/tests/integration/training_pipelines/test_aero_cfd_python_api.py
@@ -1,0 +1,186 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+from noether.core.schemas.schema import ConfigSchema
+from noether.training.runners import HydraRunner
+from tests.integration.training_pipelines.fixtures.synthetic_datasets import StubShapeNetCarDataset
+
+_TRAINER_KIND = "noether.training.trainers.WeightedLossTrainer"
+
+_SHAPENET_FIELD_WEIGHTS = {"surface_pressure": 1.0, "volume_velocity": 1.0}
+_DRIVAERML_FIELD_WEIGHTS = {
+    "surface_pressure": 1.0,
+    "surface_friction": 1.0,
+    "volume_pressure": 1.0,
+    "volume_velocity": 1.0,
+    "volume_vorticity": 1.0,
+}
+
+
+@pytest.fixture
+def stubbed_shapenet_preset(aero_cfd_on_path):
+    """Yield a ``ShapeNetCarPreset`` subclass whose ``dataset_kind`` is the stub."""
+    from aero_cfd.presets import ShapeNetCarPreset  # imported under aero_cfd_on_path
+
+    class _StubbedShapeNetCarPreset(ShapeNetCarPreset):
+        dataset_kind = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubShapeNetCarDataset"
+
+    return _StubbedShapeNetCarPreset()
+
+
+@pytest.fixture
+def stubbed_drivaerml_preset(aero_cfd_on_path):
+    """Yield a ``DrivAerMLPreset`` subclass whose ``dataset_kind`` is the stub."""
+    from aero_cfd.presets import DrivAerMLPreset
+
+    class _StubbedDrivAerMLPreset(DrivAerMLPreset):
+        dataset_kind = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubDrivAerMLDataset"
+
+    return _StubbedDrivAerMLPreset()
+
+
+def _patch_for_test(config: ConfigSchema, *, extra_excluded_properties: set[str] | None = None) -> None:
+    """Strip the parts of a preset-built config that don't belong in an in-process test.
+
+    The preset's ``build_config`` falls through to ``standard_callbacks(...)``
+    on an empty ``callbacks_override`` (Python ``[] or default`` quirk), so the
+    only reliable way to disable callbacks is to overwrite the trainer config
+    after the fact.
+    """
+    config.trainer.callbacks = []
+    config.trainer.add_default_callbacks = False
+    config.trainer.add_trainer_callbacks = False
+    config.num_workers = 0
+    config.store_code_in_output = False
+    config.tracker = None
+    config.slurm = None
+    if extra_excluded_properties:
+        train_ds_cfg = config.datasets["train"]
+        train_ds_cfg.excluded_properties = (train_ds_cfg.excluded_properties or set()) | extra_excluded_properties
+
+
+def _run_and_assert_weights_changed(config: ConfigSchema, device: str, label: str) -> None:
+    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config)
+    initial = {k: v.detach().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+    trainer.train(model)
+    after = model.state_dict()
+    changed = any(not torch.equal(initial[k], after[k].detach()) for k in initial)
+    assert changed, f"no parameter changed during python-api {label} training"
+
+
+def _build_kwargs(
+    *,
+    model_kind: str,
+    field_weights: dict[str, float],
+    dataset_root: Path,
+    output_path: Path,
+    accelerator: str,
+) -> dict[str, Any]:
+    return dict(
+        model_kind=model_kind,
+        model_params=dict(hidden_dim=96, depth=2),
+        trainer_kind=_TRAINER_KIND,
+        trainer_params=dict(field_weights=field_weights),
+        dataset_root=str(dataset_root),
+        output_path=str(output_path),
+        accelerator=accelerator,
+        max_epochs=1,
+        batch_size=1,
+        datasets=["train"],
+    )
+
+
+@pytest.mark.parametrize(
+    "model_kind",
+    [
+        "noether.modeling.models.aerodynamics.AeroTransformer",
+        "noether.modeling.models.aerodynamics.AeroTransolver",
+    ],
+)
+def test_shapenet_python_api_pipeline(
+    model_kind: str,
+    stubbed_shapenet_preset,
+    tmp_path: Path,
+    accelerator: str,
+    device: str,
+) -> None:
+    """End-to-end ShapeNetCar run via the preset API."""
+    output_path = tmp_path / "out"
+    dataset_root = tmp_path / "data"
+    output_path.mkdir()
+    dataset_root.mkdir()
+
+    config = stubbed_shapenet_preset.build_config(
+        include_evaluation=False,
+        **_build_kwargs(
+            model_kind=model_kind,
+            field_weights=_SHAPENET_FIELD_WEIGHTS,
+            dataset_root=dataset_root,
+            output_path=output_path,
+            accelerator=accelerator,
+        ),
+    )
+
+    assert config.datasets["train"].kind.endswith("StubShapeNetCarDataset")
+
+    # ShapeNetCarPreset.excluded_properties omits ``surface_area``, but the
+    # SHAPENET_CAR_FILEMAP doesn't define a ``surface_area`` file either — so
+    # ``getitem_surface_area`` calls ``_load(idx, None)`` and the production
+    # code would also fail (it just isn't reached today because the YAML config
+    # path adds it to excluded_properties). Exclude it here so the test doesn't
+    # trip over a recipe inconsistency unrelated to the pipeline.
+    _patch_for_test(config, extra_excluded_properties={"surface_area"})
+    _run_and_assert_weights_changed(config, device=device, label=model_kind)
+
+
+@pytest.mark.parametrize(
+    "model_kind",
+    [
+        "noether.modeling.models.aerodynamics.AeroTransformer",
+        "noether.modeling.models.aerodynamics.AeroTransolver",
+    ],
+)
+def test_drivaerml_python_api_pipeline(
+    model_kind: str,
+    stubbed_drivaerml_preset,
+    tmp_path: Path,
+    accelerator: str,
+    device: str,
+) -> None:
+    """End-to-end DrivAerML run via the preset API."""
+    output_path = tmp_path / "out"
+    dataset_root = tmp_path / "data"
+    output_path.mkdir()
+    dataset_root.mkdir()
+
+    config = stubbed_drivaerml_preset.build_config(
+        **_build_kwargs(
+            model_kind=model_kind,
+            field_weights=_DRIVAERML_FIELD_WEIGHTS,
+            dataset_root=dataset_root,
+            output_path=output_path,
+            accelerator=accelerator,
+        ),
+    )
+
+    assert config.datasets["train"].kind.endswith("StubDrivAerMLDataset")
+
+    _patch_for_test(config)
+    _run_and_assert_weights_changed(config, device=device, label=model_kind)
+
+
+def test_stub_dataset_class_path_is_importable() -> None:
+    """The dotted path embedded in the stubbed preset must remain valid."""
+    from noether.core.factory import class_constructor_from_class_path
+
+    cls = class_constructor_from_class_path(
+        "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubShapeNetCarDataset"
+    )
+    assert cls is StubShapeNetCarDataset

--- a/tests/integration/training_pipelines/test_heat_transfer_hydra.py
+++ b/tests/integration/training_pipelines/test_heat_transfer_hydra.py
@@ -1,0 +1,68 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+
+from noether.core.factory import class_constructor_from_class_path
+from noether.core.schemas.schema import ConfigSchema
+from noether.training.runners import HydraRunner
+from tests.integration.training_pipelines.fixtures.overrides import apply_test_overrides, to_runner_dict
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_HEAT_TRANSFER_CONFIGS = str(_REPO_ROOT / "recipes" / "heat_transfer" / "configs")
+_STUB_HEATSINK = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubSimshiftHeatsinkDataset"
+
+
+def _instantiate_schema(runner_dict: dict) -> ConfigSchema:
+    schema_kind = runner_dict.get("config_schema_kind")
+    schema_cls: type[ConfigSchema] = class_constructor_from_class_path(schema_kind) if schema_kind else ConfigSchema
+    return schema_cls(**runner_dict)
+
+
+def _floating_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {k: v.detach().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+
+
+def _any_changed(before: dict[str, torch.Tensor], after_state: dict) -> bool:
+    return any(not torch.equal(before[k], after_state[k].detach()) for k in before)
+
+
+@pytest.mark.usefixtures("heat_transfer_on_path")
+@pytest.mark.parametrize("experiment_name", ["ab_upt", "transolver"])
+def test_simshift_heatsink_pipeline(experiment_name: str, tmp_path: Path, accelerator: str, device: str) -> None:
+    """SIMSHIFT-Heatsink recipe runs end-to-end and updates weights."""
+    output_path = tmp_path / "out"
+    dataset_root = tmp_path / "data"
+    output_path.mkdir()
+    dataset_root.mkdir()
+
+    with initialize_config_dir(version_base=None, config_dir=_HEAT_TRANSFER_CONFIGS, job_name="test"):
+        cfg = compose(
+            config_name="train_simshift_heatsink",
+            overrides=[
+                f"+experiment/simshift_heatsink={experiment_name}",
+                "tracker=disabled",
+            ],
+        )
+
+    apply_test_overrides(
+        cfg,
+        accelerator=accelerator,
+        output_path=output_path,
+        dataset_root=dataset_root,
+        stub_dataset_kind=_STUB_HEATSINK,
+    )
+
+    config_obj = _instantiate_schema(to_runner_dict(cfg))
+    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config_obj)
+
+    before = _floating_state(model)
+    trainer.train(model)
+    assert _any_changed(before, model.state_dict()), (
+        f"no parameter changed during simshift_heatsink/{experiment_name} training"
+    )

--- a/tests/integration/training_pipelines/test_heat_transfer_hydra.py
+++ b/tests/integration/training_pipelines/test_heat_transfer_hydra.py
@@ -5,67 +5,25 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import torch
-from hydra import compose, initialize_config_dir
 
-from noether.core.factory import class_constructor_from_class_path
-from noether.core.schemas.schema import ConfigSchema
-from noether.training.runners import HydraRunner
-from tests.integration.training_pipelines.fixtures.overrides import apply_test_overrides, to_runner_dict
+from tests.integration.training_pipelines.fixtures.helpers import run_hydra_recipe
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _HEAT_TRANSFER_CONFIGS = str(_REPO_ROOT / "recipes" / "heat_transfer" / "configs")
 _STUB_HEATSINK = "tests.integration.training_pipelines.fixtures.synthetic_datasets.StubSimshiftHeatsinkDataset"
 
 
-def _instantiate_schema(runner_dict: dict) -> ConfigSchema:
-    schema_kind = runner_dict.get("config_schema_kind")
-    schema_cls: type[ConfigSchema] = class_constructor_from_class_path(schema_kind) if schema_kind else ConfigSchema
-    return schema_cls(**runner_dict)
-
-
-def _floating_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
-    # Snapshot on CPU: setup_experiment returns a CPU model, but trainer.train
-    # moves it to self.device, so post-train state lives on the accelerator.
-    # Staying on CPU keeps the comparison device-agnostic.
-    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
-
-
-def _any_changed(before: dict[str, torch.Tensor], after_state: dict) -> bool:
-    return any(not torch.equal(before[k], after_state[k].detach().cpu()) for k in before)
-
-
 @pytest.mark.usefixtures("heat_transfer_on_path")
 @pytest.mark.parametrize("experiment_name", ["ab_upt", "transolver"])
 def test_simshift_heatsink_pipeline(experiment_name: str, tmp_path: Path, accelerator: str, device: str) -> None:
     """SIMSHIFT-Heatsink recipe runs end-to-end and updates weights."""
-    output_path = tmp_path / "out"
-    dataset_root = tmp_path / "data"
-    output_path.mkdir()
-    dataset_root.mkdir()
-
-    with initialize_config_dir(version_base=None, config_dir=_HEAT_TRANSFER_CONFIGS, job_name="test"):
-        cfg = compose(
-            config_name="train_simshift_heatsink",
-            overrides=[
-                f"+experiment/simshift_heatsink={experiment_name}",
-                "tracker=disabled",
-            ],
-        )
-
-    apply_test_overrides(
-        cfg,
+    run_hydra_recipe(
+        configs_dir=_HEAT_TRANSFER_CONFIGS,
+        config_name="train_simshift_heatsink",
+        overrides=[f"+experiment/simshift_heatsink={experiment_name}"],
+        stub_kind=_STUB_HEATSINK,
+        tmp_path=tmp_path,
         accelerator=accelerator,
-        output_path=output_path,
-        dataset_root=dataset_root,
-        stub_dataset_kind=_STUB_HEATSINK,
-    )
-
-    config_obj = _instantiate_schema(to_runner_dict(cfg))
-    trainer, model, _tracker, _mc = HydraRunner.setup_experiment(device=device, config=config_obj)
-
-    before = _floating_state(model)
-    trainer.train(model)
-    assert _any_changed(before, model.state_dict()), (
-        f"no parameter changed during simshift_heatsink/{experiment_name} training"
+        device=device,
+        label=f"simshift_heatsink/{experiment_name}",
     )

--- a/tests/integration/training_pipelines/test_heat_transfer_hydra.py
+++ b/tests/integration/training_pipelines/test_heat_transfer_hydra.py
@@ -25,11 +25,14 @@ def _instantiate_schema(runner_dict: dict) -> ConfigSchema:
 
 
 def _floating_state(model: torch.nn.Module) -> dict[str, torch.Tensor]:
-    return {k: v.detach().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
+    # Snapshot on CPU: setup_experiment returns a CPU model, but trainer.train
+    # moves it to self.device, so post-train state lives on the accelerator.
+    # Staying on CPU keeps the comparison device-agnostic.
+    return {k: v.detach().cpu().clone() for k, v in model.state_dict().items() if v.is_floating_point()}
 
 
 def _any_changed(before: dict[str, torch.Tensor], after_state: dict) -> bool:
-    return any(not torch.equal(before[k], after_state[k].detach()) for k in before)
+    return any(not torch.equal(before[k], after_state[k].detach().cpu()) for k in before)
 
 
 @pytest.mark.usefixtures("heat_transfer_on_path")


### PR DESCRIPTION
This PR adds integration tests based on some of the existing recipes. The goal is to automatically test the pipelines e2e with no need for real datasets. 
Adding real samples can be an option as well - open for a disucssion.