### PR TITLE
feat: add configs for cross-attention in untied domain decoders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ instance/
 docs/_build/
 docs/build/
 docs/source/_generated/
+# temp-generated API docs from autoapi
+docs/source/autoapi
 _build/
 
 # PyBuilder

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -25,6 +25,7 @@ Customizing Training
 * :doc:`training/implement_a_custom_trainer`: Tailoring the training loop for specific research or production needs.
 * :doc:`training/use_callbacks`: Extending the framework with custom training callbacks.
 * :doc:`training/development_cli`: How to develop individual components using Noether's CLI tools.
+* :doc:`training/configuring_ab_upt`: Composing physics blocks and per-domain decoders for AB-UPT.
 
 Inference & Evaluation
 ----------------------
@@ -50,5 +51,6 @@ Inference & Evaluation
    training/launch_job
    training/how_to_initialize
    training/development_cli
+   training/configuring_ab_upt
 
    inference/how_to_run_evaluation_on_trained_models

--- a/docs/source/guides/training/configuring_ab_upt.rst
+++ b/docs/source/guides/training/configuring_ab_upt.rst
@@ -1,0 +1,183 @@
+Configuring AB-UPT
+==================
+
+This guide walks through how to configure
+:py:class:`~noether.modeling.models.ab_upt.AnchoredBranchedUPT` via
+:py:class:`~noether.core.schemas.models.AnchorBranchedUPTConfig`. It is structured around
+the three stages of the model — the geometry encoder, the physics trunk, and the
+per-domain decoder — and references the YAML configs shipped with the ``aero_cfd`` and
+``heat_transfer`` recipes for concrete examples.
+
+For background on the model itself, see the
+`AB-UPT paper <https://arxiv.org/abs/2502.09692>`_ and :doc:`/noether/model_zoo`.
+
+
+At a glance
+-----------
+
+A minimal AB-UPT YAML config looks like this (from
+:source:`recipes/heat_transfer/configs/model/ab_upt.yaml <../../../../recipes/heat_transfer/configs/model/ab_upt.yaml>`):
+
+.. literalinclude:: ../../../../recipes/heat_transfer/configs/model/ab_upt.yaml
+   :language: yaml
+
+The key parameters are:
+
+- ``hidden_dim`` — shared across the geometry encoder, physics trunk, and decoder.
+  Auto-injected into ``transformer_block_config`` and ``supernode_pooling_config`` via
+  :doc:`/reference/config_inheritance`, so you only set it once.
+- ``transformer_block_config`` — attention head count, MLP expansion, RoPE settings.
+  AB-UPT requires ``use_rope: true``.
+- ``supernode_pooling_config`` — geometry encoder front-end. Only required if
+  ``physics_blocks`` contains a ``perceiver`` block.
+- ``physics_blocks`` — ordered list of block types (see below).
+- ``num_domain_decoder_blocks`` — per-domain self-attention head depth.
+- ``data_specs`` — defines the domains and their input/output fields. Drives the
+  per-domain decoder projections automatically via the ``domain_decoder_configs``
+  computed field.
+
+
+Stage 1: the geometry encoder
+-----------------------------
+
+The geometry encoder is **only instantiated when the physics trunk contains a
+``perceiver`` block** and ``supernode_pooling_config`` is set. It runs a
+:py:class:`~noether.modeling.modules.encoders.SupernodePooling` encoder over the
+geometry mesh, followed by ``geometry_depth`` standard transformer blocks.
+
+In the heat-transfer config above, ``geometry_depth: 1`` and a single ``perceiver``
+block in ``physics_blocks`` is enough to attend to the geometry encoding once at the
+start of the trunk.
+
+Skip the geometry branch entirely by:
+
+- Removing all ``perceiver`` / ``perceiver_untied`` entries from ``physics_blocks``, **or**
+- Leaving ``supernode_pooling_config`` unset.
+
+In that case, the model operates purely on per-domain anchor positions.
+
+
+Stage 2: the physics trunk (``physics_blocks``)
+-----------------------------------------------
+
+``physics_blocks`` is the ordered list of attention blocks applied to the concatenated
+per-domain anchor tokens. Each entry is one of:
+
+.. list-table::
+   :widths: 18 12 70
+   :header-rows: 1
+
+   * - Block
+     - Weights
+     - Description
+   * - ``self``
+     - shared
+     - Self-attention **within each domain branch** independently. Token mixing does
+       not cross domain boundaries.
+   * - ``cross``
+     - shared
+     - Cross-attention from each domain to all **other** domains' anchors. Lets
+       domains exchange information.
+   * - ``joint``
+     - shared
+     - Full self-attention over **all** anchors from **all** domains jointly.
+   * - ``perceiver``
+     - shared
+     - Cross-attention from anchors to the geometry encoding. Requires the geometry
+       branch.
+   * - ``self_untied`` / ``cross_untied`` / ``joint_untied`` / ``perceiver_untied``
+     - **per-domain**
+     - Same attention pattern as the un-suffixed variant, but with **separate weights
+       for each domain** (wrapped in ``UntiedTransformerBlock`` /
+       ``UntiedPerceiverBlock``).
+
+.. note::
+
+   ``shared`` is a deprecated alias for ``self``; it still works but emits a
+   ``DeprecationWarning`` and will be removed in a future release.
+
+Choosing tied vs. untied
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the ``_untied`` variants when domains have **substantially different statistics**
+(e.g. surface vs. volume in CFD) and you have enough data to fit per-domain weights.
+Tied (shared) blocks are smaller and regularize across domains; untied blocks have
+more capacity per domain at the cost of parameters.
+
+Concrete patterns
+~~~~~~~~~~~~~~~~~
+
+**Aerodynamics (two domains, surface + volume)** — from
+:source:`recipes/aero_cfd/configs/model/ab_upt.yaml <../../../../recipes/aero_cfd/configs/model/ab_upt.yaml>`:
+
+.. literalinclude:: ../../../../recipes/aero_cfd/configs/model/ab_upt.yaml
+   :language: yaml
+   :lines: 12-22
+
+A single ``perceiver`` block reads geometry once, then the trunk alternates
+``self`` (in-domain mixing) with ``cross`` (cross-domain exchange) for four cycles,
+ending in a ``self`` block.
+
+**Heat transfer (single volume domain)** — from
+:source:`recipes/heat_transfer/configs/model/ab_upt.yaml <../../../../recipes/heat_transfer/configs/model/ab_upt.yaml>`:
+
+.. literalinclude:: ../../../../recipes/heat_transfer/configs/model/ab_upt.yaml
+   :language: yaml
+   :lines: 12-18
+
+With only one domain, ``cross`` and ``joint`` are equivalent to ``self``, so the
+trunk is a stack of ``perceiver`` + ``self`` blocks.
+
+
+Stage 3: optional per-domain decoder
+------------------------------------
+
+After the physics trunk, ``num_domain_decoder_blocks`` optionally adds **untied self-attention
+blocks per domain** (no weight sharing across domains), then a linear projection to
+that domain's output fields. This is semantically equivalent to adding the same number of
+``self_untied`` blocks to the end of the trunk for each domain. The only difference is,
+that the decoder block depth can be set per-domain.
+The output fields and their slicing are derived from
+``data_specs.domains[name].output_dims``.
+
+.. code-block:: yaml
+
+   num_domain_decoder_blocks:
+     surface: 2
+     volume: 2
+
+Set per-domain depths to ``0`` (or omit the entry) to skip the decoder block stack
+and project directly from the trunk output. The output projection itself is always
+present.
+
+
+Other knobs
+-----------
+
+- ``init_weights`` — weight initialization mode for linear layers; defaults to
+  ``"truncnormal002"``.
+- ``drop_path_rate`` — stochastic depth rate; defaults to ``0.0``.
+- ``data_specs.conditioning_dims`` — when set, the total conditioning dimension is
+  pushed into ``transformer_block_config.condition_dim`` and used by the
+  conditioning path of every transformer/perceiver block. The heat-transfer recipe
+  uses this to condition on simulation parameters.
+
+
+Putting it all together
+-----------------------
+
+End-to-end training configs (model + dataset + pipeline + trainer + callbacks) for
+both recipes:
+
+- Aerodynamics: `recipes/aero_cfd/configs/
+  <https://github.com/Emmi-AI/noether/tree/main/recipes/aero_cfd/configs>`_ —
+  see ``train_*.yaml`` for per-dataset entry points and
+  ``experiment/<dataset>/ab_upt.yaml`` for AB-UPT-specific overrides.
+- Heat transfer: `recipes/heat_transfer/configs/
+  <https://github.com/Emmi-AI/noether/tree/main/recipes/heat_transfer/configs>`_ —
+  start from ``train_simshift_heatsink.yaml`` and the
+  ``+experiment/simshift_heatsink=ab_upt`` override.
+
+Both recipes are wired up to the ``noether-train`` CLI; see
+:doc:`/guides/working_with_cli` and :doc:`/guides/training/launch_job` for how to run
+them locally or on SLURM.

--- a/recipes/aero_cfd/configs/experiment/drivaerml/ab_upt_decoder_xattn.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaerml/ab_upt_decoder_xattn.yaml
@@ -1,0 +1,56 @@
+# @package _global_
+defaults:
+  - override /model: ab_upt
+  - override /tracker: development_tracker
+  - override /optimizer: muon
+
+name: drivaerml-ab-upt-muon-lion
+
+pipeline:
+    num_geometry_points: 65536
+    num_geometry_supernodes: 16384
+    num_surface_anchor_points: 16384
+    num_volume_anchor_points: 16384
+
+inference_pipeline:
+  num_geometry_points: 65536
+  num_geometry_supernodes: 16384
+  num_surface_anchor_points: 1000000000
+  num_volume_anchor_points: 1000000000
+
+trainer:
+  precision: float16
+
+model:
+  supernode_pooling_config:
+    radius: 0.25
+  # don't use decoder_blocks, we use untied cross and self attention blocks instead
+  num_domain_decoder_blocks: null
+  physics_blocks:
+    - perceiver
+    - self
+    - cross
+    - self
+    - cross
+    - self
+    - cross_untied
+    - self_untied
+    - self_untied
+    - cross_untied
+    - self_untied
+    - self_untied
+  transformer_block_config:
+    max_wavelength: 40_000
+
+optimizer:
+  lr: 0.01
+  secondary:
+    kind: noether.core.optimizer.Lion
+    lr: 5.0e-5
+    weight_decay: 0.05
+
+sample_size_property: surface_anchor_position
+chunk_size: ${pipeline.num_surface_anchor_points}
+chunk_properties:
+  - surface_anchor_position
+  - volume_anchor_position

--- a/recipes/aero_cfd/configs/experiment/shapenet/ab_upt_decoder_xattn.yaml
+++ b/recipes/aero_cfd/configs/experiment/shapenet/ab_upt_decoder_xattn.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+defaults:
+  - override /model: ab_upt  
+  - override /tracker: development_tracker
+  - override /optimizer: lion
+
+name: shapenet-car-ab-upt
+
+model:
+  supernode_pooling_config:
+    radius: 9
+   
+  num_domain_decoder_blocks:
+    surface: 0
+    volume: 0
+
+  physics_blocks:
+    - perceiver
+    - self
+    - cross
+    - self
+    - cross
+    - self
+    - cross
+    - self
+    - cross
+    - self
+    - cross_untied
+    - self_untied
+pipeline:
+    num_geometry_points: 3586
+    num_geometry_supernodes: 3586
+    num_surface_anchor_points: 3586
+    num_volume_anchor_points: 4096
+
+trainer:
+  precision: float16

--- a/src/noether/core/schemas/models/ab_upt.py
+++ b/src/noether/core/schemas/models/ab_upt.py
@@ -21,6 +21,43 @@ from .base import ModelBaseConfig
 
 
 class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin):
+    """Configuration for the Anchored Branched UPT (AB-UPT) model.
+
+    AB-UPT is built from three configurable stages:
+
+    1. **Geometry encoder** (optional): a :class:`SupernodePooling` encoder followed by
+       ``geometry_depth`` standard transformer blocks. Only instantiated when at least
+       one ``perceiver`` / ``perceiver_untied`` block is present in ``physics_blocks``
+       and ``supernode_pooling_config`` is provided.
+    2. **Physics trunk**: a stack of blocks listed in ``physics_blocks`` operating on
+       per-domain anchor (and optionally query) tokens. The block string controls the
+       attention pattern and weight sharing — see ``physics_blocks`` below.
+    3. **Per-domain decoder** (optional): ``num_domain_decoder_blocks[name]``
+       self-attention blocks with **untied weights per domain**, followed by a linear
+       projection to that domain's output fields.
+
+    ``hidden_dim`` is a shared field — it is auto-injected into
+    ``transformer_block_config`` and ``supernode_pooling_config`` via
+    :class:`InjectSharedFieldFromParentMixin`, so it only needs to be set once at the top
+    level. See :doc:`/reference/config_inheritance`.
+
+    Configuration guide
+    -------------------
+
+    See :doc:`/guides/training/configuring_ab_upt` for a step-by-step walkthrough of how
+    to compose physics blocks, choose between tied and ``_untied`` variants, and wire up
+    the per-domain decoder.
+
+    Concrete examples (YAML):
+
+    - Aerodynamics (multi-domain, surface + volume):
+      `recipes/aero_cfd/configs/model/ab_upt.yaml
+      <https://github.com/Emmi-AI/noether/blob/main/recipes/aero_cfd/configs/model/ab_upt.yaml>`_
+    - Heat transfer (single-domain, volume only with parameter conditioning):
+      `recipes/heat_transfer/configs/model/ab_upt.yaml
+      <https://github.com/Emmi-AI/noether/blob/main/recipes/heat_transfer/configs/model/ab_upt.yaml>`_
+    """
+
     kind: str | None = "noether.core.schemas.models.AnchorBranchedUPTConfig"
 
     model_config = ConfigDict(extra="forbid")
@@ -61,7 +98,7 @@ class AnchorBranchedUPTConfig(ModelBaseConfig, InjectSharedFieldFromParentMixin)
 
     Note: "shared" is a deprecated alias for "self" and will be removed in a future release."""
 
-    num_domain_decoder_blocks: dict[str, int]
+    num_domain_decoder_blocks: dict[str, int] = Field(default_factory=dict)
     """Number of final domain-specific decoder blocks with self attention and no weight sharing, e.g. {"surface": 2, "volume": 2}."""
 
     init_weights: InitWeightsMode = Field("truncnormal002")

--- a/src/noether/modeling/models/ab_upt.py
+++ b/src/noether/modeling/models/ab_upt.py
@@ -28,8 +28,18 @@ from noether.modeling.modules.mlp import MLP
 
 
 class AnchoredBranchedUPT(nn.Module):
-    """
-    Implementation of the Anchored Branched UPT model. Including input embedding and output projection, so this is an off-the-shelf model that can be used directly by providing the appropriate input tensors.
+    """Implementation of the Anchored Branched UPT (AB-UPT) model.
+
+    This is an off-the-shelf model — it includes input embedding and output projection,
+    so it can be used directly by providing the appropriate input tensors. See
+    :meth:`forward` for the expected inputs.
+
+    The architecture is fully driven by
+    :class:`~noether.core.schemas.models.AnchorBranchedUPTConfig`: the geometry encoder
+    depth, the ordering and type of physics blocks, and the per-domain decoder depths
+    are all configured there. For a walkthrough of how to assemble a config (and
+    concrete YAML examples from the ``aero_cfd`` and ``heat_transfer`` recipes), see
+    :doc:`/guides/training/configuring_ab_upt`.
     """
 
     def __init__(
@@ -114,8 +124,7 @@ class AnchoredBranchedUPT(nn.Module):
 
         # per-domain decoder blocks (separate weights per domain)
         self.domain_decoder_blocks = nn.ModuleDict()
-        for name in self.domain_names:
-            num_blocks = config.num_domain_decoder_blocks[name]
+        for name, num_blocks in config.num_domain_decoder_blocks.items():
             decoder_block_config = copy.deepcopy(config.transformer_block_config)
             decoder_block_config.attention_constructor = SelfAnchorAttention  # type: ignore[assignment]
             decoder_block_config.attention_arguments = {"branches": (name,)}
@@ -323,15 +332,19 @@ class AnchoredBranchedUPT(nn.Module):
         Returns:
             Tuple of (predictions, new_cache). Predictions is None if x has no tokens.
         """
-        decoder_blocks = cast("nn.ModuleList", self.domain_decoder_blocks[domain_name])
+        new_cache: list[LayerCache] = []
+
+        if x.size(1) == 0:
+            return None, new_cache
+
+        if domain_name not in self.domain_decoder_blocks:
+            decoder_blocks = nn.ModuleList()
+        else:
+            decoder_blocks = cast("nn.ModuleList", self.domain_decoder_blocks[domain_name])
         if cache is not None:
             assert len(cache) in (0, len(decoder_blocks)), (
                 f"{domain_name} cache length ({len(cache)}) must match number of decoder blocks ({len(decoder_blocks)})"
             )
-
-        new_cache: list[LayerCache] = []
-        if x.size(1) == 0:
-            return None, new_cache
 
         for i, block in enumerate(decoder_blocks):
             x, block_cache = block(


### PR DESCRIPTION
Add configs showcasing how to setup untied blocks and replace the per-domain decoders
Accordingly added documentation on how to configure AB-UPT.