### PR TITLE
feat: add support for input features to ABUPT

### DIFF
--- a/recipes/aero_cfd/configs/model/ab_upt.yaml
+++ b/recipes/aero_cfd/configs/model/ab_upt.yaml
@@ -30,4 +30,7 @@ forward_properties:
   - geometry_batch_idx
   - surface_anchor_position
   - volume_anchor_position
+  # Following properties are only used if `use_physics_features` is true
+  - surface_anchor_features
+  - volume_anchor_features
 data_specs: ${data_specs}

--- a/recipes/aero_cfd/configs/model/upt.yaml
+++ b/recipes/aero_cfd/configs/model/upt.yaml
@@ -23,7 +23,6 @@ forward_properties:
   - surface_position_batch_idx
   - surface_position_supernode_idx
   - surface_position
-  - surface_features
   - surface_query_position
   - surface_query_features
   - volume_query_position

--- a/recipes/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
+++ b/recipes/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
@@ -318,16 +318,20 @@ class AeroMultistagePipeline(MultiStagePipeline):
         )
         sample_processors = [
             PointSamplingSampleProcessor(
-                items=self.volume_sampling_items,
-                num_points=self.num_volume_points,
-                seed=self.seed,
-            ),
-            PointSamplingSampleProcessor(
                 items=self.surface_sampling_items,
                 num_points=self.num_surface_points,
                 seed=self.seed,
             ),
         ]
+        if self.num_volume_points > 0:
+            sample_processors.append(
+                PointSamplingSampleProcessor(
+                    items=self.volume_sampling_items,
+                    num_points=self.num_volume_points,
+                    seed=self.seed,
+                ),
+            )
+
         if self.has_query_points and not self.sample_query_points:
             # we use the same sampling items for the query points as for the surface and volume points
             sample_processors.extend(
@@ -437,48 +441,70 @@ class AeroMultistagePipeline(MultiStagePipeline):
 
     def _get_anchor_point_sampling_sample_processor(self) -> list[SampleProcessor]:
         """Get the anchor point sampling sample processor."""
-        if self.num_volume_anchor_points > 0 and self.num_surface_anchor_points > 0:
-            # make sure defa
-            self.default_collator_items += [
-                "surface_anchor_position",
-                "volume_anchor_position",
-            ]
-            return [
-                DuplicateKeysSampleProcessor(key_map={"surface_position": "geometry_position"}),
-                PointSamplingSampleProcessor(
-                    items={"geometry_position"},
-                    num_points=self.num_geometry_points,
-                    seed=None if self.seed is None else self.seed + 1,
-                ),
-                SupernodeSamplingSampleProcessor(
-                    item="geometry_position",
-                    num_supernodes=self.num_geometry_supernodes,
-                    supernode_idx_key="geometry_supernode_idx",
-                    seed=None if self.seed is None else self.seed + 2,
-                ),
-                # subsample surface data
-                AnchorPointSamplingSampleProcessor(
-                    items={"surface_position"} | set(self.surface_targets),
-                    num_points=self.num_surface_anchor_points,
-                    keep_queries=self.use_query_positions,
-                    to_prefix_and_postfix=_split_by_underscore,
-                    to_prefix_midfix_postfix=_split_three_or_none,
-                    seed=None if self.seed is None else self.seed + 3,
-                ),
-                # subsample volume data
-                AnchorPointSamplingSampleProcessor(
-                    items={"volume_position"} | set(self.volume_targets),
-                    num_points=self.num_volume_anchor_points,
-                    keep_queries=self.use_query_positions,
-                    to_prefix_and_postfix=_split_by_underscore,
-                    to_prefix_midfix_postfix=_split_three_or_none,
-                    seed=None if self.seed is None else self.seed + 4,
-                ),
-                RenameKeysSampleProcessor(key_map={DataKeys.as_anchor(key): key for key in self.volume_targets}),
-                RenameKeysSampleProcessor(key_map={DataKeys.as_anchor(key): key for key in self.surface_targets}),
-            ]
-
-        else:
+        if self.num_volume_anchor_points == 0 or self.num_surface_anchor_points == 0:
             raise ValueError(
                 "Anchor point sampling requires both num_volume_anchor_points and num_surface_anchor_points to be greater than 0."
             )
+        # make sure default collator items are set
+        self.default_collator_items += [
+            "surface_anchor_position",
+            "volume_anchor_position",
+        ]
+        processors = [
+            DuplicateKeysSampleProcessor(key_map={"surface_position": "geometry_position"}),
+            PointSamplingSampleProcessor(
+                items={"geometry_position"},
+                num_points=self.num_geometry_points,
+                seed=None if self.seed is None else self.seed + 1,
+            ),
+            SupernodeSamplingSampleProcessor(
+                item="geometry_position",
+                num_supernodes=self.num_geometry_supernodes,
+                supernode_idx_key="geometry_supernode_idx",
+                seed=None if self.seed is None else self.seed + 2,
+            ),
+            # subsample surface data
+            AnchorPointSamplingSampleProcessor(
+                items={"surface_position"}
+                | set(self.surface_targets)
+                | (self.surface_features if self.use_physics_features else set()),
+                num_points=self.num_surface_anchor_points,
+                keep_queries=self.use_query_positions,
+                to_prefix_and_postfix=_split_by_underscore,
+                to_prefix_midfix_postfix=_split_three_or_none,
+                seed=None if self.seed is None else self.seed + 3,
+            ),
+            # subsample volume data
+            AnchorPointSamplingSampleProcessor(
+                items={"volume_position"}
+                | set(self.volume_targets)
+                | (self.volume_features if self.use_physics_features else set()),
+                num_points=self.num_volume_anchor_points,
+                keep_queries=self.use_query_positions,
+                to_prefix_and_postfix=_split_by_underscore,
+                to_prefix_midfix_postfix=_split_three_or_none,
+                seed=None if self.seed is None else self.seed + 4,
+            ),
+            RenameKeysSampleProcessor(key_map={DataKeys.as_anchor(key): key for key in self.volume_targets}),
+            RenameKeysSampleProcessor(key_map={DataKeys.as_anchor(key): key for key in self.surface_targets}),
+        ]
+        if self.use_physics_features:
+            processors.extend(
+                [
+                    ConcatTensorSampleProcessor(
+                        items=[DataKeys.as_anchor(key) for key in self.volume_features],
+                        target_key="volume_anchor_features",
+                        dim=1,
+                    ),
+                    ConcatTensorSampleProcessor(
+                        items=[DataKeys.as_anchor(key) for key in self.surface_features],
+                        target_key="surface_anchor_features",
+                        dim=1,
+                    ),
+                ]
+            )
+            self.default_collator_items += [
+                "volume_anchor_features",
+                "surface_anchor_features",
+            ]
+        return processors

--- a/src/noether/core/schemas/dataset.py
+++ b/src/noether/core/schemas/dataset.py
@@ -236,7 +236,7 @@ class ModelDataSpecs(BaseModel):
     """Available conditioning features and their dimensions."""
     domains: dict[str, DomainDataSpec] = Field(default_factory=dict)
     """Per-domain data specifications keyed by domain name."""
-    use_physics_features: bool = False
+    use_physics_features: bool = True
     """Whether physics features are used as input."""
 
     @property
@@ -260,3 +260,10 @@ class ModelDataSpecs(BaseModel):
             if spec.feature_dim:
                 features |= set(spec.feature_dim.keys())
         return features
+
+    @model_validator(mode="after")
+    def remove_feature_fields(self):
+        if not self.use_physics_features:
+            for spec in self.domains.values():
+                spec.feature_dim = None
+        return self

--- a/src/noether/modeling/models/ab_upt.py
+++ b/src/noether/modeling/models/ab_upt.py
@@ -16,6 +16,7 @@ ModelKVCache = dict[str, list[LayerCache]]  # {branch_name: [LayerCache, ...]}
 
 from noether.core.schemas.models import AnchorBranchedUPTConfig
 from noether.core.schemas.modules.attention import TokenSpec
+from noether.core.schemas.modules.mlp import MLPConfig
 from noether.modeling.modules.attention.anchor_attention import (
     CrossAnchorAttention,
     JointAnchorAttention,
@@ -120,6 +121,27 @@ class AnchoredBranchedUPT(nn.Module):
             self.encoder = SupernodePooling(config=config.supernode_pooling_config)  # type: ignore[arg-type]
             self.geometry_blocks = nn.ModuleList(
                 [TransformerBlock(config=config.transformer_block_config) for _ in range(config.geometry_depth)],
+            )
+
+        # Per-domain physics-feature projections (e.g. noisy fields for diffusion).
+        # Driven by ``data_specs.domains[name].feature_dim``: when a domain
+        # declares input feature dims, the backbone builds an MLP that projects
+        # ``domain_anchor_features[name]`` and/or ``domain_query_features[name]``
+        # to ``hidden_dim`` and adds them to the corresponding position
+        # embeddings inside ``physics_blocks_forward``. Sides without features
+        # are zero-padded.
+        self.domain_feature_projs: nn.ModuleDict | None = None
+        for name, spec in config.data_specs.domains.items():
+            if spec.feature_dim is None or spec.feature_dim.total_dim == 0:
+                continue
+            if self.domain_feature_projs is None:
+                self.domain_feature_projs = nn.ModuleDict()
+            self.domain_feature_projs[name] = MLP(
+                config=MLPConfig(
+                    input_dim=spec.feature_dim.total_dim,
+                    hidden_dim=self.hidden_dim,
+                    output_dim=self.hidden_dim,
+                ),
             )
 
         # per-domain decoder blocks (separate weights per domain)
@@ -254,9 +276,90 @@ class AnchoredBranchedUPT(nn.Module):
             )
         return geometry_encoding
 
+    def _build_domain_segment(
+        self,
+        name: str,
+        anchor_position: torch.Tensor | None,
+        query_position: torch.Tensor | None,
+        anchor_feature: torch.Tensor | None,
+        query_feature: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build the physics-block input segment and combined positions for a single domain.
+
+        Concatenates ``[anchor | query]`` along the token dim. Each segment is
+        ``bias(pos_embed(pos)) + (proj(features) or 0)``; the returned position
+        is the concatenation of anchor and query positions in token order.
+        """
+        if anchor_position is None and query_position is None:
+            raise ValueError(f"domain {name!r} has neither anchor nor query positions")
+
+        proj: torch.nn.Module | None = (
+            self.domain_feature_projs[name] if self.domain_feature_projs and name in self.domain_feature_projs else None
+        )
+
+        def _segment(pos: torch.Tensor, feat: torch.Tensor | None) -> torch.Tensor:
+            if pos.ndim != 3:
+                raise ValueError(f"Position tensor for domain '{name}' must be 3-dimensional, got {pos.ndim}.")
+            seg: torch.Tensor = self.domain_biases[name](self.pos_embed(pos))
+            if proj is not None and feat is not None:
+                seg = seg + proj(feat)
+            return seg
+
+        seg_parts: list[torch.Tensor] = []
+        pos_parts: list[torch.Tensor] = []
+        if anchor_position is not None:
+            seg_parts.append(_segment(anchor_position, anchor_feature))
+            pos_parts.append(anchor_position)
+        if query_position is not None:
+            seg_parts.append(_segment(query_position, query_feature))
+            pos_parts.append(query_position)
+
+        segment = torch.cat(seg_parts, dim=1) if len(seg_parts) > 1 else seg_parts[0]
+        position = torch.cat(pos_parts, dim=1) if len(pos_parts) > 1 else pos_parts[0]
+        return segment, position
+
+    def build_physics_input(
+        self,
+        domain_anchor_positions: dict[str, torch.Tensor] | None = None,
+        domain_query_positions: dict[str, torch.Tensor] | None = None,
+        domain_anchor_features: dict[str, torch.Tensor] | None = None,
+        domain_query_features: dict[str, torch.Tensor] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Build the physics-block input tensor and combined per-domain positions.
+
+        Each per-domain segment is ``[anchors | queries]`` with positional
+        biases plus projected features (when ``data_specs.domains[name].feature_dim``
+        was set on the config). Domains are concatenated in ``self.domain_names``
+        order.
+
+        Returns:
+            Tuple of (x_physics, physics_positions). ``x_physics`` has shape
+            ``(B, total_tokens, hidden_dim)``. ``physics_positions`` maps each
+            domain name to its concatenated ``[anchors | queries]`` positions
+            and can be passed directly to :meth:`create_rope_frequencies`.
+        """
+        domain_anchor_positions = domain_anchor_positions or {}
+        domain_query_positions = domain_query_positions or {}
+        domain_anchor_features = domain_anchor_features or {}
+        domain_query_features = domain_query_features or {}
+
+        segments: list[torch.Tensor] = []
+        physics_positions: dict[str, torch.Tensor] = {}
+        for name in self.domain_names:
+            segment, position = self._build_domain_segment(
+                name,
+                anchor_position=domain_anchor_positions.get(name),
+                query_position=domain_query_positions.get(name),
+                anchor_feature=domain_anchor_features.get(name),
+                query_feature=domain_query_features.get(name),
+            )
+            segments.append(segment)
+            physics_positions[name] = position
+        return torch.cat(segments, dim=1), physics_positions
+
     def physics_blocks_forward(
         self,
-        domain_positions_all: dict[str, torch.Tensor],
+        x_physics: torch.Tensor,
         geometry_encoding: torch.Tensor | None,
         physics_token_specs: list[TokenSpec],
         physics_attn_kwargs: dict[str, Any],
@@ -264,26 +367,12 @@ class AnchoredBranchedUPT(nn.Module):
         condition: torch.Tensor | None,
         kv_cache: ModelKVCache | None = None,
     ) -> tuple[torch.Tensor, list[LayerCache]]:
-        """Forward pass through the physics blocks of the model."""
+        """Run the physics-block stack on a pre-built input tensor."""
         physics_cache = kv_cache.get("physics", []) if kv_cache else []
         assert len(physics_cache) in (0, len(self.physics_blocks)), (
             f"physics_cache length ({len(physics_cache)}) must match number of physics blocks ({len(self.physics_blocks)})"
         )
 
-        # Per-domain position embedding + bias, then concatenate in domain order
-        # Preallocate tensor for per-domain position embedding + bias, then fill in domain order
-        batch_size = next(iter(domain_positions_all.values())).size(0)
-        total_tokens = sum(domain_positions_all[name].size(1) for name in self.domain_names)
-        x_physics = torch.empty(batch_size, total_tokens, self.hidden_dim, device=next(self.parameters()).device)
-        start = 0
-        for name in self.domain_names:
-            pos = domain_positions_all[name]
-            if pos.ndim != 3:
-                raise ValueError(f"Position tensor for domain '{name}' must be 3-dimensional, got {pos.ndim}.")
-            emb = self.domain_biases[name](self.pos_embed(pos))
-            end = start + emb.size(1)
-            x_physics[:, start:end, :] = emb
-            start = end
         new_physics_cache: list[LayerCache] = []
         for i, block in enumerate(self.physics_blocks):
             if isinstance(block, TransformerBlock | UntiedTransformerBlock):
@@ -365,7 +454,6 @@ class AnchoredBranchedUPT(nn.Module):
         decoder_attn_kwargs: dict[str, dict[str, Any]],
         condition: torch.Tensor | None,
         kv_cache: ModelKVCache | None = None,
-        domain_positions_all: dict[str, torch.Tensor] | None = None,
     ) -> tuple[dict[str, Tensor], dict[str, list[LayerCache]]]:
         """Forward pass through the per-domain decoder blocks.
 
@@ -380,10 +468,10 @@ class AnchoredBranchedUPT(nn.Module):
         for name in self.domain_names:
             x_domain = domain_tensors[name]
 
-            # Validate sizes
-            if domain_positions_all is not None and name in domain_positions_all:
-                assert x_domain.size(1) == domain_positions_all[name].size(1), (
-                    f"{name} tensor size does not match {name} position size."
+            expected_size = sum(spec.size for spec in per_domain_token_specs[name] if spec.size is not None)
+            if x_domain.size(1) != expected_size:
+                raise ValueError(
+                    f"{name} tensor size ({x_domain.size(1)}) does not match expected size ({expected_size})."
                 )
 
             preds, new_cache = self._decode_domain(
@@ -402,17 +490,23 @@ class AnchoredBranchedUPT(nn.Module):
 
     def create_rope_frequencies(
         self,
-        domain_positions_all: dict[str, torch.Tensor],
+        physics_positions: dict[str, torch.Tensor],
         geometry_position: torch.Tensor | None = None,
         geometry_supernode_idx: torch.Tensor | None = None,
     ) -> tuple[dict[str, Any], dict[str, dict[str, Any]], dict[str, Any], dict[str, Any]]:
         """Create RoPE frequencies for all relevant positions.
 
+        Args:
+            physics_positions: Per-domain combined ``[anchors | queries]``
+                positions, as returned by :meth:`build_physics_input`.
+            geometry_position: Geometry mesh coordinates (optional).
+            geometry_supernode_idx: Geometry supernode indices (optional).
+
         Returns:
             Tuple of (geometry_attn_kwargs, decoder_attn_kwargs, physics_perceiver_attn_kwargs, physics_attn_kwargs).
             decoder_attn_kwargs is keyed by domain name.
         """
-        first_pos = next(iter(domain_positions_all.values()))
+        first_pos = next(iter(physics_positions.values()))
         batch_size = first_pos.size(0)
 
         geometry_attn_kwargs: dict[str, Any] = {}
@@ -427,7 +521,7 @@ class AnchoredBranchedUPT(nn.Module):
             physics_perceiver_attn_kwargs["k_freqs"] = geometry_rope
 
         # Per-domain rope + concatenated physics rope
-        domain_rope = {name: self.rope(domain_positions_all[name]) for name in self.domain_names}
+        domain_rope = {name: self.rope(physics_positions[name]) for name in self.domain_names}
         rope_all = torch.cat([domain_rope[name] for name in self.domain_names], dim=1)
 
         physics_perceiver_attn_kwargs["q_freqs"] = rope_all
@@ -446,7 +540,9 @@ class AnchoredBranchedUPT(nn.Module):
         # domain positions
         domain_anchor_positions: dict[str, Tensor] | None = None,
         domain_query_positions: dict[str, Tensor] | None = None,
-        domain_features: dict[str, Tensor] | None = None,
+        # domain features (per-token inputs in addition to positions)
+        domain_anchor_features: dict[str, Tensor] | None = None,
+        domain_query_features: dict[str, Tensor] | None = None,
         conditioning_inputs: dict[str, Tensor] | None = None,
         # KV cache
         kv_cache: ModelKVCache | None = None,
@@ -470,6 +566,8 @@ class AnchoredBranchedUPT(nn.Module):
             geometry_batch_idx: Batch indices for the geometry points.
             domain_anchor_positions: Per-domain anchor positions, e.g. ``{"surface": (B, N, D), "volume": (B, M, D)}``.
             domain_query_positions: Per-domain query positions (optional).
+            domain_anchor_features: Per-domain anchor input features (optional), matching the shape of ``domain_anchor_positions``.
+            domain_query_features: Per-domain query input features (optional), matching the shape of ``domain_query_positions``.
             conditioning_inputs: Conditioning tensors, e.g. ``{"geometry_design_parameters": (B, D)}``.
             kv_cache: KV cache from a previous forward call.
 
@@ -510,30 +608,18 @@ class AnchoredBranchedUPT(nn.Module):
             use_cached_kv=use_cached_kv,
         )
 
-        # Combine anchor + query positions per domain (or just queries when using cached KV)
-        domain_positions_all: dict[str, torch.Tensor] = {}
-        for name in self.domain_names:
-            anchor = domain_anchor_positions.get(name)
-            query = domain_query_positions.get(name)
-            if anchor is not None and query is not None:
-                domain_positions_all[name] = torch.cat([anchor, query], dim=1)
-            elif anchor is not None:
-                domain_positions_all[name] = anchor
-            elif query is not None:
-                domain_positions_all[name] = query
-            else:
-                # Empty placeholder — infer shape from any available tensor
-                ref = (
-                    next(iter(domain_anchor_positions.values()))
-                    if domain_anchor_positions
-                    else next(iter(domain_query_positions.values()))
-                )
-                domain_positions_all[name] = ref[:, :0]
+        # Physics blocks: build the per-domain input tensor, then run the block stack.
+        x_physics, physics_positions = self.build_physics_input(
+            domain_anchor_positions=domain_anchor_positions,
+            domain_query_positions=domain_query_positions,
+            domain_anchor_features=domain_anchor_features,
+            domain_query_features=domain_query_features,
+        )
 
         # RoPE frequencies
         geometry_attn_kwargs, decoder_attn_kwargs, physics_perceiver_attn_kwargs, physics_attn_kwargs = (
             self.create_rope_frequencies(
-                domain_positions_all=domain_positions_all,
+                physics_positions=physics_positions,
                 geometry_position=geometry_position,
                 geometry_supernode_idx=geometry_supernode_idx,
             )
@@ -555,7 +641,7 @@ class AnchoredBranchedUPT(nn.Module):
 
         # Physics blocks
         x_physics, new_physics_cache = self.physics_blocks_forward(
-            domain_positions_all=domain_positions_all,
+            x_physics=x_physics,
             geometry_encoding=geometry_encoding,
             physics_token_specs=physics_token_specs,
             physics_attn_kwargs=physics_attn_kwargs,
@@ -572,7 +658,6 @@ class AnchoredBranchedUPT(nn.Module):
             decoder_attn_kwargs=decoder_attn_kwargs,
             condition=condition,
             kv_cache=kv_cache,
-            domain_positions_all=domain_positions_all,
         )
 
         # Slice predictions into named fields

--- a/src/noether/modeling/models/aerodynamics.py
+++ b/src/noether/modeling/models/aerodynamics.py
@@ -314,8 +314,8 @@ class AeroUPT(Model):
         surface_position: torch.Tensor,
         surface_query_position: torch.Tensor,
         volume_query_position: torch.Tensor,
-        surface_features: torch.Tensor | None = None,
-        volume_features: torch.Tensor | None = None,
+        surface_query_features: torch.Tensor | None = None,
+        volume_query_features: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor]:
         num_surface = surface_query_position.shape[1]
         query_position = torch.cat([surface_query_position, volume_query_position], dim=1)
@@ -344,10 +344,10 @@ class AeroUPT(Model):
 
         if self.use_physics_features:
             parts: list[torch.Tensor] = []
-            if surface_features is not None and hasattr(self, "project_surface_features"):
-                parts.append(self.project_surface_features(surface_features))
-            if volume_features is not None and hasattr(self, "project_volume_features"):
-                parts.append(self.project_volume_features(volume_features))
+            if surface_query_features is not None and hasattr(self, "project_surface_features"):
+                parts.append(self.project_surface_features(surface_query_features))
+            if volume_query_features is not None and hasattr(self, "project_volume_features"):
+                parts.append(self.project_volume_features(volume_query_features))
             if parts:
                 queries = queries + torch.cat(parts, dim=1)
 
@@ -380,12 +380,18 @@ class AeroABUPT(Model):
         domain_anchor_positions: dict[str, torch.Tensor] = {}
         domain_query_positions: dict[str, torch.Tensor] = {}
         conditioning_inputs: dict[str, torch.Tensor] = {}
+        domain_anchor_features: dict[str, torch.Tensor] = {}
+        domain_query_features: dict[str, torch.Tensor] = {}
 
         for name in self._domain_names:
             if f"{name}_anchor_position" in kwargs:
                 domain_anchor_positions[name] = kwargs[f"{name}_anchor_position"]
             if f"query_{name}_position" in kwargs:
                 domain_query_positions[name] = kwargs[f"query_{name}_position"]
+            if f"{name}_anchor_features" in kwargs:
+                domain_anchor_features[name] = kwargs[f"{name}_anchor_features"]
+            if f"{name}_query_features" in kwargs:
+                domain_query_features[name] = kwargs[f"{name}_query_features"]
 
         for key in self._conditioning_keys:
             if key in kwargs:
@@ -398,5 +404,7 @@ class AeroABUPT(Model):
             domain_anchor_positions=domain_anchor_positions or None,
             domain_query_positions=domain_query_positions or None,
             conditioning_inputs=conditioning_inputs or None,
+            domain_anchor_features=domain_anchor_features or None,
+            domain_query_features=domain_query_features or None,
         )
         return predictions  # type: ignore[no-any-return]

--- a/tests/unit/noether/modeling/models/test_ab_upt.py
+++ b/tests/unit/noether/modeling/models/test_ab_upt.py
@@ -725,3 +725,274 @@ class TestMixedTiedAndUntiedBlocks:
 
         assert predictions["surface_pressure"].shape == (batch_size, 8, 1)
         assert predictions["volume_velocity"].shape == (batch_size, 6, 3)
+
+
+@pytest.fixture
+def partial_feature_config():
+    """Config where only one domain (``surface``) declares ``feature_dim``."""
+    data_specs = ModelDataSpecs(
+        position_dim=3,
+        domains={
+            "surface": DomainDataSpec(
+                output_dims=FieldDimSpec({"pressure": 1}),
+                feature_dim=FieldDimSpec({"area": 1}),
+            ),
+            "volume": DomainDataSpec(
+                output_dims=FieldDimSpec({"velocity": 3}),
+            ),
+        },
+    )
+    tf_config = TransformerBlockConfig(
+        hidden_dim=32,
+        num_heads=4,
+        mlp_expansion_factor=2.0,
+        use_bias=True,
+        use_rope=True,
+        dropout=0.0,
+    )
+    pool_config = SupernodePoolingConfig(hidden_dim=32, input_dim=3, radius=0.1, k=None)
+
+    return AnchorBranchedUPTConfig(
+        kind="AnchoredBranchedUPT",
+        name="ab_upt_partial_feat",
+        hidden_dim=32,
+        geometry_depth=1,
+        physics_blocks=["perceiver", "self"],
+        num_domain_decoder_blocks={"surface": 1, "volume": 1},
+        transformer_block_config=tf_config,
+        supernode_pooling_config=pool_config,
+        init_weights="truncnormal002",
+        data_specs=data_specs,
+    )
+
+
+@pytest.fixture
+def partial_feature_model(partial_feature_config):
+    with (
+        patch(_MODULE_PATH + ".RopeFrequency", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".SupernodePooling", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".TransformerBlock", new=FakeTransformerBlock),
+        patch(_MODULE_PATH + ".ContinuousSincosEmbed", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".MLP", new=FakeGenericModule),
+        patch(_MODULE_PATH + ".PerceiverBlock", new=FakePerceiverBlock),
+        patch(_MODULE_PATH + ".LinearProjection", new=FakeGenericModule),
+    ):
+        model = AnchoredBranchedUPT(config=partial_feature_config)
+        for name in model.domain_names:
+            model.domain_decoder_projections[name] = nn.Linear(
+                32, partial_feature_config.data_specs.domains[name].output_dims.total_dim
+            )
+        yield model
+
+
+class TestAnchoredBranchedUPTFeatures:
+    """Tests for per-domain anchor/query input features.
+
+    Per-domain feature MLPs are built only when
+    ``data_specs.domains[name].feature_dim`` is set; the projected features
+    are added to the position-bias output inside ``build_physics_input``.
+    These tests cover the wiring (which projections get built), forward
+    shapes when features are passed, and that features actually contribute
+    to the physics input.
+    """
+
+    def test_feature_projs_built_for_each_configured_domain(self, model):
+        """Both surface and volume declare ``feature_dim`` → projections built for both."""
+        assert model.domain_feature_projs is not None
+        assert set(model.domain_feature_projs.keys()) == {"surface", "volume"}
+
+    def test_feature_projs_none_when_no_domain_has_feature_dim(self, three_domain_model):
+        """No domain declares ``feature_dim`` → ``domain_feature_projs`` stays ``None``."""
+        assert three_domain_model.domain_feature_projs is None
+
+    def test_feature_projs_only_for_configured_domains(self, partial_feature_model):
+        """Only ``surface`` declares ``feature_dim`` → only ``surface`` gets a projection."""
+        assert partial_feature_model.domain_feature_projs is not None
+        assert "surface" in partial_feature_model.domain_feature_projs
+        assert "volume" not in partial_feature_model.domain_feature_projs
+
+    def test_forward_with_anchor_features(self, model):
+        """Anchor features for every configured domain run end-to-end with correct shapes."""
+        batch_size = 2
+        num_surface, num_volume = 20, 15
+
+        model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 64, 64)
+        model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 64)
+        model.rope.forward = lambda *a, **k: torch.randn(batch_size, 2000, 16)
+
+        predictions, _ = model(
+            geometry_position=torch.randn(50, 3),
+            geometry_supernode_idx=torch.zeros(50, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(50, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, num_surface, 3),
+                "volume": torch.randn(batch_size, num_volume, 3),
+            },
+            domain_anchor_features={
+                "surface": torch.randn(batch_size, num_surface, 1),  # area
+                "volume": torch.randn(batch_size, num_volume, 1),  # sdf
+            },
+        )
+
+        assert predictions["surface_pressure"].shape == (batch_size, num_surface, 1)
+        assert predictions["volume_velocity"].shape == (batch_size, num_volume, 3)
+
+    def test_forward_with_anchor_and_query_features(self, model):
+        """Anchor and query features coexist; query side emerges under ``query_*`` keys."""
+        batch_size = 1
+
+        model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 64, 64)
+        model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 64)
+        model.rope.forward = lambda *a, **k: torch.randn(batch_size, 2000, 16)
+
+        predictions, _ = model(
+            geometry_position=torch.randn(10, 3),
+            geometry_supernode_idx=torch.zeros(10, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(10, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, 10, 3),
+                "volume": torch.randn(batch_size, 8, 3),
+            },
+            domain_query_positions={
+                "surface": torch.randn(batch_size, 5, 3),
+            },
+            domain_anchor_features={
+                "surface": torch.randn(batch_size, 10, 1),
+                "volume": torch.randn(batch_size, 8, 1),
+            },
+            domain_query_features={
+                "surface": torch.randn(batch_size, 5, 1),
+            },
+        )
+
+        assert predictions["surface_pressure"].shape == (batch_size, 10, 1)
+        assert predictions["volume_velocity"].shape == (batch_size, 8, 3)
+        assert predictions["query_surface_pressure"].shape == (batch_size, 5, 1)
+
+    def test_forward_with_query_features_only(self, model):
+        """Query-only features (no anchor features supplied) still flow through."""
+        batch_size = 1
+        model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 64, 64)
+        model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 64)
+        model.rope.forward = lambda *a, **k: torch.randn(batch_size, 2000, 16)
+
+        predictions, _ = model(
+            geometry_position=torch.randn(10, 3),
+            geometry_supernode_idx=torch.zeros(10, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(10, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, 10, 3),
+                "volume": torch.randn(batch_size, 8, 3),
+            },
+            domain_query_positions={
+                "surface": torch.randn(batch_size, 5, 3),
+            },
+            domain_query_features={
+                "surface": torch.randn(batch_size, 5, 1),
+            },
+        )
+
+        assert predictions["query_surface_pressure"].shape == (batch_size, 5, 1)
+
+    def test_features_contribute_to_physics_input(self, model):
+        """Anchor features actually contribute to ``x_physics`` — output differs with vs. without."""
+        batch_size = 1
+        # Force pos_embed to a constant so the only source of variation is the feature path.
+        model.pos_embed.forward = lambda x, *a, **k: torch.zeros(x.shape[0], x.shape[1], 64)
+
+        anchor_pos = {
+            "surface": torch.randn(batch_size, 4, 3),
+            "volume": torch.randn(batch_size, 3, 3),
+        }
+        anchor_feat = {
+            "surface": torch.ones(batch_size, 4, 1),
+            "volume": torch.ones(batch_size, 3, 1),
+        }
+
+        x_no_feat, _ = model.build_physics_input(domain_anchor_positions=anchor_pos)
+        x_with_feat, _ = model.build_physics_input(
+            domain_anchor_positions=anchor_pos,
+            domain_anchor_features=anchor_feat,
+        )
+
+        assert x_no_feat.shape == x_with_feat.shape
+        assert not torch.allclose(x_no_feat, x_with_feat)
+
+    def test_query_features_contribute_to_physics_input(self, model):
+        """Query features change the query segment of ``x_physics`` independently of anchors."""
+        batch_size = 1
+        model.pos_embed.forward = lambda x, *a, **k: torch.zeros(x.shape[0], x.shape[1], 64)
+
+        anchor_pos = {
+            "surface": torch.randn(batch_size, 4, 3),
+            "volume": torch.randn(batch_size, 3, 3),
+        }
+        query_pos = {"surface": torch.randn(batch_size, 2, 3)}
+        query_feat = {"surface": torch.ones(batch_size, 2, 1)}
+
+        x_no_query_feat, _ = model.build_physics_input(
+            domain_anchor_positions=anchor_pos,
+            domain_query_positions=query_pos,
+        )
+        x_with_query_feat, _ = model.build_physics_input(
+            domain_anchor_positions=anchor_pos,
+            domain_query_positions=query_pos,
+            domain_query_features=query_feat,
+        )
+
+        assert x_no_query_feat.shape == x_with_query_feat.shape
+        # Anchor segment for surface is the first 4 tokens — must remain unchanged.
+        assert torch.allclose(x_no_query_feat[:, :4], x_with_query_feat[:, :4])
+        # Query segment for surface (tokens 4:6) must differ.
+        assert not torch.allclose(x_no_query_feat[:, 4:6], x_with_query_feat[:, 4:6])
+
+    def test_features_silently_ignored_without_projection(self, three_domain_model):
+        """Features supplied for domains without ``feature_dim`` are dropped, not raised."""
+        batch_size = 1
+        three_domain_model.encoder.forward = lambda *a, **k: torch.randn(batch_size, 64, 64)
+        three_domain_model.pos_embed.forward = lambda x, *a, **k: torch.randn(x.shape[0], x.shape[1], 64)
+        three_domain_model.rope.forward = lambda *a, **k: torch.randn(batch_size, 2000, 16)
+
+        predictions, _ = three_domain_model(
+            geometry_position=torch.randn(10, 3),
+            geometry_supernode_idx=torch.zeros(10, dtype=torch.long),
+            geometry_batch_idx=torch.zeros(10, dtype=torch.long),
+            domain_anchor_positions={
+                "surface": torch.randn(batch_size, 10, 3),
+                "volume": torch.randn(batch_size, 8, 3),
+                "wake": torch.randn(batch_size, 6, 3),
+            },
+            domain_anchor_features={
+                "surface": torch.randn(batch_size, 10, 1),
+                "volume": torch.randn(batch_size, 8, 1),
+                "wake": torch.randn(batch_size, 6, 1),
+            },
+        )
+
+        assert predictions["surface_pressure"].shape == (batch_size, 10, 1)
+        assert predictions["wake_turbulence"].shape == (batch_size, 6, 2)
+
+    def test_features_applied_only_for_configured_domain(self, partial_feature_model):
+        """Mixed config: surface features change ``x_physics`` but volume features are ignored."""
+        batch_size = 1
+        partial_feature_model.pos_embed.forward = lambda x, *a, **k: torch.zeros(x.shape[0], x.shape[1], 32)
+
+        anchor_pos = {
+            "surface": torch.randn(batch_size, 4, 3),
+            "volume": torch.randn(batch_size, 3, 3),
+        }
+
+        x_baseline, _ = partial_feature_model.build_physics_input(domain_anchor_positions=anchor_pos)
+        x_volume_feat, _ = partial_feature_model.build_physics_input(
+            domain_anchor_positions=anchor_pos,
+            domain_anchor_features={"volume": torch.ones(batch_size, 3, 1)},
+        )
+        x_surface_feat, _ = partial_feature_model.build_physics_input(
+            domain_anchor_positions=anchor_pos,
+            domain_anchor_features={"surface": torch.ones(batch_size, 4, 1)},
+        )
+
+        # Volume has no projection → its features are dropped, output matches baseline.
+        assert torch.allclose(x_baseline, x_volume_feat)
+        # Surface has a projection → its features change the output.
+        assert not torch.allclose(x_baseline, x_surface_feat)


### PR DESCRIPTION
ABUPT's forward currently has a unused `domain_features` argument, which means it doesn't support providing features to the model, even though from the signature it looks like it does.

I am replacing the domain_features with domain_{anchor,query}_features, to mirror the domain_{anchor,query}_position arguments. These are then projected with a MLP and added to the position embeddings if available. 
I also adjusted the aero_cfd recipe to supply these the input features accordingly in the multistage pipeline. 

The interface assumes that features are provided as normalized per-point concatentated vectors which are then projected inside the model. It is debatable whether it should be responsibility of the caller to project these to model_dim instead. We don't really have a consistent approach, for UPT and Transformer this is done in the aerodynamics wrapper.