### PR TITLE
ci: create a PR instead of directly push of the version update for uv lock file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,16 @@ jobs:
         with:
           packages-dir: dist/
 
-      - name: Commit bumped pyproject.toml and uv.lock back to main
+      - name: Create Pull Request with version bump
         if: steps.calver.outputs.version
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml uv.lock
-          git commit -m "chore(release): ${{ steps.calver.outputs.version }} [skip ci]"
-          git push origin HEAD:${{ github.ref_name }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(release): ${{ steps.calver.outputs.version }} [skip ci]"
+          title: "chore(release): Version ${{ steps.calver.outputs.version }}"
+          body: "Update version to ${{ steps.calver.outputs.version }} and sync lockfile."
+          branch: "chore/release-${{ steps.calver.outputs.version }}"
+          base: "${{ github.ref_name }}"
+          add-paths: |
+            pyproject.toml
+            uv.lock


### PR DESCRIPTION
Direct push to main branch is declined due to branch protection rules. see [link](https://github.com/Emmi-AI/noether/actions/runs/25101830253/job/73552792827)

Therefore we change the approach to create a PR so we can test and see the effect of the change before it goes into main