### PR TITLE
fix: allow disabling bias when using conditioning via modulation

### DIFF
--- a/src/noether/modeling/models/ab_upt.py
+++ b/src/noether/modeling/models/ab_upt.py
@@ -173,6 +173,7 @@ class AnchoredBranchedUPT(nn.Module):
                     input_dim=spec.feature_dim.total_dim,
                     hidden_dim=self.hidden_dim,
                     output_dim=self.hidden_dim,
+                    bias=config.transformer_block_config.bias,
                 ),
             )
 

--- a/src/noether/modeling/modules/blocks/perceiver.py
+++ b/src/noether/modeling/modules/blocks/perceiver.py
@@ -34,7 +34,6 @@ class PerceiverBlock(nn.Module):
             self.modulation = None
             elementwise_affine = True
         else:
-            assert config.bias
             self._kv_dim = config.kv_dim or config.hidden_dim
             if config.modulation_linear_projection_config is not None:
                 self.modulation = LinearProjection(config=config.modulation_linear_projection_config)  # type: ignore[arg-type]

--- a/src/noether/modeling/modules/blocks/transformer.py
+++ b/src/noether/modeling/modules/blocks/transformer.py
@@ -34,7 +34,6 @@ class TransformerBlock(nn.Module):
             self.modulation = None
             elementwise_affine = True
         else:
-            assert config.bias
             if config.modulation_linear_projection_config is None:
                 raise ValueError("modulation_linear_projection_config must be provided if condition_dim is not None.")
 


### PR DESCRIPTION
We should still be able to disable bias terms when using global conditioning, currently this isn't possible because we assert confi.bias. 

Howver, the modulation should work fine even without bias terms.

Additonally we weren't passing bias config to input feature projection