### PR TITLE
fix: aero_cfd training with bsz>1

### DIFF
--- a/recipes/aero_cfd/showcase/cli.py
+++ b/recipes/aero_cfd/showcase/cli.py
@@ -9,6 +9,7 @@ from typing import Annotated
 import torch
 import typer
 from rich.console import Console
+
 from showcase.model_configs import (
     ABUPT_MODEL_KIND,
     FIELD_WEIGHTS,
@@ -144,6 +145,7 @@ def train(
     ),
 ) -> None:
     from aero_cfd.callbacks import AeroMetricsCallbackConfig
+
     from noether.core.schemas.callbacks import CheckpointCallbackConfig
     from noether.training.runners import HydraRunner
 
@@ -298,6 +300,7 @@ def evaluate(
     precomputed from the original VTP mesh.
     """
     from aero_cfd.callbacks import AeroMetricsCallbackConfig, QueryInferenceCallbackConfig
+
     from noether.inference.runners.inference_runner import InferenceRunner
 
     run_dir = Path(output_path) / run_id
@@ -339,6 +342,7 @@ def evaluate(
             model_kind=ABUPT_MODEL_KIND,
             num_surface_anchor_points=num_inference_surface_points,
             num_volume_anchor_points=num_inference_volume_points,
+            use_surface_position_as_input=True,
         )
         callback = QueryInferenceCallbackConfig(
             dataset_key=query_key,

--- a/recipes/aero_cfd/src/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
+++ b/recipes/aero_cfd/src/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
@@ -1,5 +1,6 @@
 #  Copyright © 2025 Emmi AI GmbH. All rights reserved.
 
+
 from noether.core.schemas.dataset import ModelDataSpecs, PipelineConfig
 from noether.core.schemas.statistics import AeroStatsSchema
 from noether.data.pipeline import MultiStagePipeline, SampleProcessor
@@ -160,6 +161,7 @@ class AeroMultistagePipeline(MultiStagePipeline):
         )
         self.volume_features = set(volume_spec.feature_dim.keys()) if volume_spec and volume_spec.feature_dim else set()
         self.conditioning_dims = pipeline_config.data_specs.conditioning_dims
+        self.use_surface_position_as_input = pipeline_config.use_surface_position_as_input
 
         self._define_items_keys()
 
@@ -255,7 +257,7 @@ class AeroMultistagePipeline(MultiStagePipeline):
                 DefaultCollator(
                     items=self.default_collator_items,
                     optional_items=["index", "surface_normals", "surface_area"]
-                    + (["surface_position"] if self.use_anchor_points else []),
+                    + (["surface_position"] if self.use_surface_position_as_input else []),
                 )
             ]
         )


### PR DESCRIPTION
For the ABUPT showcase we are passing through the whole `surface_position` tensor from the dataset. When using datasets with variable-sized surface point clouds, this breaks batch collation, when bsz>1, since we can't trivially batch variable sized inputs. Since this is only used for the callback in the showcase we can simply stop passing this data in all other cases to fix the error.