### PR TITLE
feat: Add RMS QK Norm

### DIFF
--- a/src/noether/modeling/modules/attention/dot_product.py
+++ b/src/noether/modeling/modules/attention/dot_product.py
@@ -42,6 +42,7 @@ class DotProductAttention(nn.Module):
         self.k = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
         self.v = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
         self.proj = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
+        self.qk_norm = nn.RMSNorm(self.head_dim, elementwise_affine=True, eps=1e-6)
         apply_init_method(self, self.proj.weight, self.init_weights)
 
     def forward(
@@ -72,6 +73,9 @@ class DotProductAttention(nn.Module):
             num_heads=self.num_heads,
             head_dim=self.head_dim,
         ).unbind(0)
+
+        q = self.qk_norm(q)
+        k = self.qk_norm(k)
 
         if self.use_rope:
             assert freqs is not None


### PR DESCRIPTION
Adds RMS QK norm in `DotProductAttention`

Magic numbers from tests need to be updated after merging https://github.com/Emmi-AI/noether/pull/213 , since the combined change of RMS norm plus WK norm will affect these again.