### PR TITLE
feat: use QK norm in attention

### DIFF
--- a/src/noether/core/schemas/modules/attention.py
+++ b/src/noether/core/schemas/modules/attention.py
@@ -44,6 +44,9 @@ class AttentionConfig(BaseModel):
     head_dim: int | None = Field(None)
     """Dimensionality of each attention head."""
 
+    qk_norm: bool = Field(False)
+    """Whether to apply layer normalization to the query and key features before computing attention scores."""
+
     @model_validator(mode="after")
     def validate_hidden_dim_and_num_heads(self):
         if self.hidden_dim % self.num_heads != 0:

--- a/src/noether/modeling/modules/attention/anchor_attention/mixed.py
+++ b/src/noether/modeling/modules/attention/anchor_attention/mixed.py
@@ -142,6 +142,7 @@ class MixedAttention(DotProductAttention):
             q, k, v = einops.rearrange(
                 qkv, "bs s (three nh hd) -> three bs nh s hd", three=3, nh=self.num_heads
             ).unbind(0)
+            q, k = self.q_norm(q), self.k_norm(k)
             output, k_dict, v_dict = self._attend(
                 q,
                 k,

--- a/src/noether/modeling/modules/attention/dot_product.py
+++ b/src/noether/modeling/modules/attention/dot_product.py
@@ -42,6 +42,12 @@ class DotProductAttention(nn.Module):
         self.k = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
         self.v = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
         self.proj = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
+        if config.qk_norm:
+            self.q_norm: nn.Module = nn.RMSNorm(self.head_dim)
+            self.k_norm: nn.Module = nn.RMSNorm(self.head_dim)
+        else:
+            self.q_norm = nn.Identity()
+            self.k_norm = nn.Identity()
         apply_init_method(self, self.proj.weight, self.init_weights)
 
     def forward(
@@ -72,6 +78,7 @@ class DotProductAttention(nn.Module):
             num_heads=self.num_heads,
             head_dim=self.head_dim,
         ).unbind(0)
+        q, k = self.q_norm(q), self.k_norm(k)
 
         if self.use_rope:
             assert freqs is not None

--- a/src/noether/modeling/modules/attention/perceiver.py
+++ b/src/noether/modeling/modules/attention/perceiver.py
@@ -44,6 +44,12 @@ class PerceiverAttention(nn.Module):
         self.proj = nn.Linear(config.hidden_dim, config.hidden_dim, bias=config.bias)
         self.dropout = config.dropout
         self.proj_dropout = nn.Dropout(config.dropout)
+        if config.qk_norm:
+            self.q_norm: nn.Module = nn.RMSNorm(self.head_dim)
+            self.k_norm: nn.Module = nn.RMSNorm(self.head_dim)
+        else:
+            self.q_norm = nn.Identity()
+            self.k_norm = nn.Identity()
 
         apply_init_method(self, self.proj.weight, self.init_weights)
 
@@ -75,11 +81,13 @@ class PerceiverAttention(nn.Module):
         """
         # Project query
         q = self.q(q)
-        q = einops.rearrange(
-            q,
-            "bs seqlen_q (num_heads head_dim) -> bs num_heads seqlen_q head_dim",
-            num_heads=self.num_heads,
-            head_dim=self.head_dim,
+        q = self.q_norm(
+            einops.rearrange(
+                q,
+                "bs seqlen_q (num_heads head_dim) -> bs num_heads seqlen_q head_dim",
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+            )
         )
 
         if kv_cache is not None:
@@ -102,6 +110,7 @@ class PerceiverAttention(nn.Module):
                 num_heads=self.num_heads,
                 head_dim=self.head_dim,
             ).unbind(0)
+            k = self.k_norm(k)
 
             if self.use_rope:
                 assert k_freqs is not None

--- a/src/noether/modeling/modules/untied.py
+++ b/src/noether/modeling/modules/untied.py
@@ -320,6 +320,12 @@ class UntiedMixedAttention(MixedAttention):
         self.k = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
         self.v = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
         self.proj = UntiedLinear(config.projection_config)  # type: ignore[arg-type,assignment]
+        if config.qk_norm:
+            self.q_norm: nn.Module = nn.RMSNorm(self.head_dim)
+            self.k_norm: nn.Module = nn.RMSNorm(self.head_dim)
+        else:
+            self.q_norm = nn.Identity()
+            self.k_norm = nn.Identity()
 
     def forward(  # type: ignore[override]
         self,
@@ -357,8 +363,8 @@ class UntiedMixedAttention(MixedAttention):
         input_specs = [s for s in token_specs if s.size is not None]
         self._validate_inputs(x, input_specs, attention_patterns, key_padding_mask, freqs)
 
-        q = einops.rearrange(self.q(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
-        k = einops.rearrange(self.k(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
+        q = self.q_norm(einops.rearrange(self.q(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads))
+        k = self.k_norm(einops.rearrange(self.k(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads))
         v = einops.rearrange(self.v(x, token_specs), "bs s (nh hd) -> bs nh s hd", nh=self.num_heads)
 
         output, _, _ = self._attend(
@@ -443,11 +449,13 @@ class UntiedPerceiverAttention(PerceiverAttention):
         """
         # Per-type Q projection.
         q = self.q(q, token_specs)
-        q = einops.rearrange(
-            q,
-            "bs seqlen_q (num_heads head_dim) -> bs num_heads seqlen_q head_dim",
-            num_heads=self.num_heads,
-            head_dim=self.head_dim,
+        q = self.q_norm(
+            einops.rearrange(
+                q,
+                "bs seqlen_q (num_heads head_dim) -> bs num_heads seqlen_q head_dim",
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+            )
         )
 
         if kv_cache is not None:
@@ -468,6 +476,7 @@ class UntiedPerceiverAttention(PerceiverAttention):
                 num_heads=self.num_heads,
                 head_dim=self.head_dim,
             ).unbind(0)
+            k = self.k_norm(k)
 
             if self.use_rope:
                 assert k_freqs is not None


### PR DESCRIPTION
QK norm can help stabilise attention logits and thus helps for low precision training stability

Sanity check that on final metrics this doesn't change the numbers:
<img width="1234" height="365" alt="image" src="https://github.com/user-attachments/assets/b68e07ea-9a1c-4690-93ad-73a25e329b6d" />
