### PR TITLE
fix: add missing use_surface_position_as_input field to AeroCFDPipelineConfig

### DIFF
--- a/recipes/aero_cfd/src/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
+++ b/recipes/aero_cfd/src/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
@@ -51,6 +51,10 @@ class AeroCFDPipelineConfig(PipelineConfig):
     """Number of volume anchor points to sample for AB-UPT."""
     num_surface_anchor_points: int | None = 0
     """Number of surface anchor points to sample for AB-UPT."""
+    use_surface_position_as_input: bool = False
+    """Whether to pass ``surface_position`` through as a model input. Required only when a downstream
+    callback (e.g. the showcase eval pipeline) needs it; off by default since variable-sized point clouds
+    break batch collation when ``batch_size > 1``."""
     seed: int | None = None
     """Random seed for sampling processes."""
     data_specs: ModelDataSpecs


### PR DESCRIPTION
A minor regression from #210: the pipeline class reads this attribute but the config schema was never updated, so pydantic silently dropped the kwarg from `evaluate(...)` and AeroMultistagePipeline.__init__ raised AttributeError. Default False matches the pre-PR behavior; the showcase eval path that needs it sets it explicitly.  