### PR TITLE
feat: Pyhon API for noether-eval

### DIFF
--- a/src/noether/core/configs/hyperparameters.py
+++ b/src/noether/core/configs/hyperparameters.py
@@ -7,22 +7,46 @@ from typing import Any
 import yaml
 from pydantic import BaseModel
 
+from noether.core.factory import class_constructor_from_class_path
 from noether.core.schemas.lib import _RegistryBase
 from noether.core.schemas.schema import ConfigSchema
 
 _logger = logging.getLogger(__name__)
 
 
+def _union_discriminator_name(field_info: Any) -> str | None:
+    """Return the discriminator field name if ``field_info`` is a Pydantic
+    discriminated-Union field (``Field(discriminator="kind")``), else ``None``.
+
+    Pydantic stores the discriminator name on ``FieldInfo.discriminator`` and,
+    when the discriminator was supplied via ``Annotated[..., Discriminator(...)]``,
+    inside ``FieldInfo.metadata``. We check both.
+    """
+    name = getattr(field_info, "discriminator", None)
+    if isinstance(name, str):
+        return name
+    for entry in getattr(field_info, "metadata", []) or []:
+        if hasattr(entry, "discriminator") and isinstance(entry.discriminator, str):
+            return entry.discriminator
+    return None
+
+
 def _inject_discriminator_fields(model: Any, dumped: Any) -> None:
     """Re-add discriminator fields (e.g. ``kind``) onto ``dumped`` for every
-    ``_RegistryBase`` instance in ``model`` whose discriminator was stripped
-    by ``model_dump(exclude_unset=True)``.
+    discriminated config in ``model`` whose discriminator was stripped by
+    ``model_dump(exclude_unset=True)``.
 
-    Discriminator fields default to a literal class value, so they're "unset"
-    when constructed in Python without an explicit ``kind=...`` argument and
-    therefore disappear from the dump — but they're required to re-validate
-    the discriminated union on reload (e.g. when ``noether-eval`` reads
-    ``hp_resolved.yaml`` back).
+    Covers two discriminator styles:
+
+    * :class:`_RegistryBase` subclasses with a class-level ``_type_field``
+      (noether's ``Discriminated`` registry — e.g. ``CallBackBaseConfig.kind``).
+    * Plain ``BaseModel`` variants of a Pydantic ``Union`` with
+      ``Field(discriminator=...)`` — the discriminator value (typically a
+      ``Literal`` with a default like ``FlowMatchingConfig.kind = "flow_matching"``)
+      is stripped by ``exclude_unset=True`` and breaks union re-validation on
+      reload. Detected by inspecting the parent field's ``discriminator``
+      metadata so unrelated ``Literal`` enums (e.g. ``accelerator``) aren't
+      forced into every dump.
 
     Mutates ``dumped`` in place; recurses through nested models, lists, and
     dicts so the entire tree is patched.
@@ -35,9 +59,20 @@ def _inject_discriminator_fields(model: Any, dumped: Any) -> None:
                 dumped[type_field] = value
 
     if isinstance(model, BaseModel) and isinstance(dumped, dict):
-        for field_name in type(model).model_fields:
-            if field_name in dumped:
-                _inject_discriminator_fields(getattr(model, field_name), dumped[field_name])
+        for field_name, field_info in type(model).model_fields.items():
+            if field_name not in dumped:
+                continue
+            child_model = getattr(model, field_name)
+            child_dumped = dumped[field_name]
+            # Pydantic Union with discriminator: ensure the discriminator
+            # value survives even when the variant's ``Literal`` field was
+            # stripped by ``exclude_unset=True``.
+            disc_name = _union_discriminator_name(field_info)
+            if disc_name and isinstance(child_dumped, dict) and disc_name not in child_dumped:
+                disc_value = getattr(child_model, disc_name, None)
+                if disc_value is not None:
+                    child_dumped[disc_name] = disc_value
+            _inject_discriminator_fields(child_model, child_dumped)
     elif isinstance(model, list) and isinstance(dumped, list):
         for child_model, child_dumped in zip(model, dumped, strict=False):
             _inject_discriminator_fields(child_model, child_dumped)
@@ -63,12 +98,51 @@ class Hyperparameters:
         """
 
         with open(out_file_uri, "w") as f:
-            config_dict = stage_hyperparameters.model_dump(exclude_unset=True, exclude_computed_fields=True)
+            # ``serialize_as_any=True`` preserves subclass-specific fields when
+            # the schema annotates a polymorphic field as the base class
+            # (e.g. ``trainer.callbacks: list[CallBackBaseConfig]``) — without
+            # it, Pydantic strips fields like ``OfflineLossCallbackConfig.dataset_key``
+            # from the dump because they don't exist on the annotated base, and
+            # the saved YAML fails to re-validate.
+            config_dict = stage_hyperparameters.model_dump(
+                exclude_unset=True, exclude_computed_fields=True, serialize_as_any=True
+            )
             _inject_discriminator_fields(stage_hyperparameters, config_dict)
             config_dict["config_schema_kind"] = stage_hyperparameters.config_schema_kind
             yaml.dump(config_dict, f, sort_keys=False)
 
         _logger.info(f"Dumped resolved hyperparameters to {out_file_uri}")
+
+    @staticmethod
+    def load_resolved(file_uri: str | Path) -> ConfigSchema:
+        """Inverse of :meth:`save_resolved` — load a previously-saved resolved config.
+
+        Reads the YAML with ``yaml.full_load`` (preserves ``!!python/tuple``
+        tags emitted for tuple-typed fields like dataset statistics), resolves
+        the ``config_schema_kind`` marker written by ``save_resolved`` to the
+        concrete :class:`ConfigSchema` subclass, and validates the rest of
+        the dict through Pydantic.
+
+        Args:
+            file_uri: Path to the YAML file produced by ``save_resolved``
+                (typically ``<run_dir>/hp_resolved.yaml``).
+
+        Returns:
+            The validated config schema instance.
+
+        Raises:
+            FileNotFoundError: if ``file_uri`` doesn't exist.
+            pydantic.ValidationError: if the file is missing required fields
+                or the config schema's validators reject it.
+        """
+        path = Path(file_uri)
+        if not path.exists():
+            raise FileNotFoundError(f"resolved hyperparameters file not found: {path}")
+        with open(path) as f:
+            config_dict = yaml.full_load(f)
+        schema_kind = config_dict.pop("config_schema_kind", None)
+        schema_cls: type[ConfigSchema] = class_constructor_from_class_path(schema_kind) if schema_kind else ConfigSchema  # type: ignore
+        return schema_cls(**config_dict)
 
     @staticmethod
     def log(stage_hyperparameters: BaseModel) -> None:

--- a/src/noether/inference/__init__.py
+++ b/src/noether/inference/__init__.py
@@ -1,5 +1,7 @@
 #  Copyright © 2025 Emmi AI GmbH. All rights reserved.
 
+from noether.inference.evaluate import evaluate
 from noether.inference.run import Run
+from noether.inference.runners.inference_runner import InferenceRunner
 
-__all__ = ["Run"]
+__all__ = ["InferenceRunner", "Run", "evaluate"]

--- a/src/noether/inference/evaluate.py
+++ b/src/noether/inference/evaluate.py
@@ -1,0 +1,134 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Programmatic eval API — Python-side equivalent of ``noether-eval``.
+
+The CLI does its work in :mod:`noether.inference.cli.main_inference`: it
+loads ``<run_dir>/hp_resolved.yaml`` as the Hydra base config, injects
+``resume_*`` overrides, and dispatches through :class:`InferenceRunner`. This
+module exposes the same flow as a normal function so Python callers (e.g.
+notebooks, sweep scripts) don't have to shell out.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from noether.core.configs.hyperparameters import Hyperparameters
+from noether.core.schemas.callbacks import CallBackBaseConfig
+from noether.core.schemas.schema import ConfigSchema
+from noether.inference.runners.inference_runner import InferenceRunner
+
+logger = logging.getLogger(__name__)
+
+
+def _set_resume_from_run_dir(config: ConfigSchema, run_dir: Path) -> None:
+    """Wire ``resume_*`` and ``run_id``/``stage_name`` so eval reads the
+    training checkpoint and writes alongside the source run.
+
+    Mirrors :func:`noether.inference.cli.main_inference._inject_hp_resolved_into_argv`:
+    if the saved config carries an explicit ``run_id`` use it; otherwise infer
+    it from ``run_dir``'s name (or its parent's, if ``stage_name`` is set).
+    """
+    saved_stage_name = config.stage_name or ""
+    inferred_run_id = run_dir.parent.name if saved_stage_name else run_dir.name
+    source_run_id = config.run_id or inferred_run_id
+
+    config.run_id = source_run_id
+    config.stage_name = saved_stage_name
+    config.resume_run_id = source_run_id
+    config.resume_stage_name = saved_stage_name
+    if config.output_path:
+        # Pin the source root so a later ``output_path`` override doesn't
+        # redirect checkpoint lookup away from the training run.
+        config.resume_output_path = Path(config.output_path)
+
+
+def evaluate(
+    run_dir: str | Path,
+    *,
+    resume_checkpoint: str = "latest",
+    stage_name: str | None = None,
+    callbacks: list[CallBackBaseConfig] | None = None,
+    device: str = "cuda",
+    disable_tracker: bool = False,
+) -> None:
+    """Run evaluation against a training run directory.
+
+    Programmatic equivalent of::
+
+        noether-eval run_dir=<run_dir> resume_checkpoint=<...> ...
+
+    Loads ``<run_dir>/hp_resolved.yaml`` via :meth:`Hyperparameters.load_resolved`,
+    wires the ``resume_*`` fields so checkpoints are read from the training
+    run, optionally replaces the trainer callback list, and dispatches through
+    :meth:`InferenceRunner.main` (single-process, no Hydra/CLI involvement).
+
+    Args:
+        run_dir: Training run output directory — the one that contains
+            ``hp_resolved.yaml``. Typically ``<output_path>/<run_id>[/<stage_name>]``.
+        resume_checkpoint: Checkpoint tag to load. Examples: ``"latest"``,
+            ``"best_model.<metric>"``, ``"E100"`` (epoch 100), ``"U2500"``
+            (update 2500), ``"S40000"`` (sample 40000).
+        stage_name: Optional sub-stage name for *this* eval run's outputs.
+            Logs / wandb / saved metrics land under
+            ``<run_dir>/<stage_name>/``, separate from the training outputs.
+            Leave ``None`` to write alongside the training run.
+        callbacks: If provided, replaces ``config.trainer.callbacks`` for the
+            eval run. Pass the exact callbacks that should execute (e.g. a
+            single sampling/rollout callback) — nothing from the training
+            config's callback list is kept.
+        device: Device string passed to the trainer (default ``"cuda"``).
+            For multi-GPU eval use the ``noether-eval`` CLI; this function
+            is single-process.
+        disable_tracker: If ``True``, drop the saved tracker config so eval
+            doesn't create a new wandb run.
+
+    Raises:
+        FileNotFoundError: if ``run_dir`` doesn't contain ``hp_resolved.yaml``.
+
+    Example::
+
+        from noether.inference import evaluate
+        from my_recipe.callbacks import SamplingCallbackConfig
+
+        for steps in [1, 2, 4, 8, 16]:
+            evaluate(
+                run_dir="outputs/abupt_diffusion/30035_2026-05-11_spk1e",
+                resume_checkpoint="best_model.loss.test.total",
+                stage_name=f"eval_steps{steps:02d}",
+                callbacks=[SamplingCallbackConfig(every_n_epochs=1, sampling_steps=steps)],
+            )
+    """
+    run_dir = Path(run_dir).resolve()
+    hp_path = run_dir / "hp_resolved.yaml"
+    if not hp_path.exists():
+        raise FileNotFoundError(
+            f"hp_resolved.yaml not found in {run_dir}. run_dir must point at a training run output directory."
+        )
+
+    # Recipe-style runs (kind paths like ``models.foo.Bar``) need the recipe
+    # root on sys.path so discriminated-config dynamic imports resolve. The
+    # CLI does ``sys.path.insert(0, hydra.utils.get_original_cwd())``; here we
+    # add the current working directory for the same effect — callers that
+    # ``cd`` into the recipe before calling ``evaluate`` get it for free.
+    cwd = str(Path.cwd())
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
+    config = Hyperparameters.load_resolved(hp_path)
+    _set_resume_from_run_dir(config, run_dir)
+    config.resume_checkpoint = resume_checkpoint
+
+    if stage_name is not None:
+        config.stage_name = stage_name
+    if disable_tracker:
+        config.tracker = None
+    if callbacks is not None:
+        config.trainer.callbacks = callbacks
+
+    logger.info(
+        f"evaluating run_id={config.run_id!r} stage_name={config.stage_name!r} resume_checkpoint={resume_checkpoint!r}"
+    )
+    InferenceRunner.main(device=device, config=config)

--- a/tests/unit/noether/core/configs/test_hyperparameters.py
+++ b/tests/unit/noether/core/configs/test_hyperparameters.py
@@ -4,11 +4,11 @@ import logging
 import os
 from collections import OrderedDict
 from pathlib import Path
-from typing import ClassVar
+from typing import Annotated, ClassVar, Literal, Union
 
 import pytest
 import yaml
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel, Field, RootModel
 
 from noether.core.configs.hyperparameters import Hyperparameters, _inject_discriminator_fields
 from noether.core.schemas.lib import _RegistryBase
@@ -48,12 +48,49 @@ class _RegistryStub(_RegistryBase):
     value: int = 0
 
 
+class _RegistryStubWithExtras(_RegistryStub):
+    """Subclass with extra fields — used to verify polymorphic-dump preserves
+    subclass-specific fields when the parent annotates a base-class slot."""
+
+    extra: str = "subclass-only"
+
+
 class _NestedModel(BaseModel):
     """Wraps a registry config + a list/dict of registry configs to exercise recursion."""
 
     pipeline: _RegistryStub
     callbacks: list[_RegistryStub] = []
     by_key: dict[str, _RegistryStub] = {}
+
+
+class _UnionVariantA(BaseModel):
+    """Variant ``A`` of a Pydantic discriminated Union — ``kind`` is a Literal
+    with a default, so ``exclude_unset=True`` strips it and reload fails
+    without injection."""
+
+    kind: Literal["a"] = "a"
+    value_a: int = 0
+
+
+class _UnionVariantB(BaseModel):
+    kind: Literal["b"] = "b"
+    value_b: int = 0
+
+
+_AnyUnion = Annotated[Union[_UnionVariantA, _UnionVariantB], Field(discriminator="kind")]
+
+
+class _UnionParent(BaseModel):
+    """Parent that holds a Pydantic discriminated Union by field."""
+
+    item: _AnyUnion = Field(default_factory=_UnionVariantA)
+
+
+class _LiteralEnumModel(BaseModel):
+    """Parent with a plain ``Literal`` enum field — *not* a Union discriminator.
+    These must not be force-injected by the discriminator patcher."""
+
+    accelerator: Literal["cpu", "gpu", "mps"] = "gpu"
 
 
 class TestInjectDiscriminatorFields:
@@ -112,6 +149,40 @@ class TestInjectDiscriminatorFields:
         assert dumped["by_key"]["a"]["kind"] == "registry_stub.default"
         assert dumped["by_key"]["b"]["kind"] == "b_kind"
 
+    def test_injects_pydantic_union_discriminator(self):
+        """Union variants identify themselves via a ``Literal[...]`` field with
+        a default (e.g. ``FlowMatchingConfig.kind = "flow_matching"``).
+        ``exclude_unset=True`` strips it and the dumped dict fails to
+        re-validate the union — the patcher must inject it from the live
+        instance using the parent field's ``discriminator`` metadata."""
+        model = _UnionParent(item=_UnionVariantA(value_a=7))
+        dumped = model.model_dump(exclude_unset=True)
+
+        assert "kind" not in dumped["item"]  # baseline: stripped by exclude_unset
+
+        _inject_discriminator_fields(model, dumped)
+
+        assert dumped["item"]["kind"] == "a"
+
+        # Round-trip the patched dump back through the model — without the
+        # injected discriminator this would raise a ``union_tag_not_found``.
+        reloaded = _UnionParent.model_validate(dumped)
+        assert isinstance(reloaded.item, _UnionVariantA)
+        assert reloaded.item.value_a == 7
+
+    def test_does_not_inject_plain_literal_enum(self):
+        """Plain ``Literal`` enum fields (e.g. ``accelerator: Literal["cpu","gpu","mps"]``)
+        are *not* Union discriminators — the patcher must leave them alone so
+        ``exclude_unset=True`` semantics are preserved for unrelated enums."""
+        model = _LiteralEnumModel()  # accelerator uses default ("gpu")
+        dumped = model.model_dump(exclude_unset=True)
+
+        assert "accelerator" not in dumped  # baseline: default-only fields are stripped
+
+        _inject_discriminator_fields(model, dumped)
+
+        assert "accelerator" not in dumped  # still stripped — not a discriminator
+
 
 class TestHyperparameters:
     """Tests for the Hyperparameters utility class."""
@@ -137,3 +208,65 @@ class TestHyperparameters:
         assert mock_params == loaded
 
         assert f"Dumped resolved hyperparameters to {out_file}" in caplog.text
+
+    def test_load_resolved_round_trip(self, mock_params: MockHyperparameters, tmp_path: Path):
+        """``load_resolved`` is the inverse of ``save_resolved`` — the loaded
+        config compares equal to what was saved."""
+        out_file = tmp_path / "hp.yaml"
+        Hyperparameters.save_resolved(mock_params, out_file)
+
+        loaded = Hyperparameters.load_resolved(out_file)
+
+        assert isinstance(loaded, MockHyperparameters)
+        assert loaded == mock_params
+
+    def test_load_resolved_resolves_config_schema_kind(self, mock_params: MockHyperparameters, tmp_path: Path):
+        """``load_resolved`` returns the concrete ``ConfigSchema`` subclass
+        named by the saved ``config_schema_kind`` field, not the base."""
+        out_file = tmp_path / "hp.yaml"
+        Hyperparameters.save_resolved(mock_params, out_file)
+
+        loaded = Hyperparameters.load_resolved(out_file)
+
+        # The subclass-only ``spec`` field survives — i.e. we got the right class back.
+        assert type(loaded) is MockHyperparameters
+        assert loaded.spec == mock_params.spec
+
+    def test_load_resolved_missing_file(self, tmp_path: Path):
+        """``load_resolved`` raises ``FileNotFoundError`` on a missing path
+        (rather than the less-helpful ``yaml`` parse error)."""
+        with pytest.raises(FileNotFoundError, match="resolved hyperparameters"):
+            Hyperparameters.load_resolved(tmp_path / "does_not_exist.yaml")
+
+    def test_save_resolved_preserves_polymorphic_subclass_fields(self, tmp_path: Path):
+        """When a field is annotated with a base type but holds a subclass
+        instance, ``save_resolved`` must preserve the subclass-specific fields.
+
+        Without ``serialize_as_any=True``, Pydantic walks the *annotated* base
+        type when serializing and silently drops fields that exist only on the
+        subclass — e.g. ``OfflineLossCallbackConfig.dataset_key`` disappears
+        from a ``list[CallBackBaseConfig]`` dump, breaking re-validation.
+        """
+        os.environ["MASTER_PORT"] = "12345"
+
+        class _PolymorphicHP(ConfigSchema):
+            items: list[_RegistryStub] = Field(default_factory=list)
+
+        params = _PolymorphicHP(
+            output_path="/tmp",
+            datasets=dict(),
+            model=dict(name="abc", kind="xyz"),
+            trainer=dict(kind="mock", effective_batch_size=32, callbacks=[], max_epochs=1),
+            items=[_RegistryStubWithExtras(value=1, extra="kept")],
+        )
+
+        out_file = tmp_path / "polymorphic.yaml"
+        Hyperparameters.save_resolved(params, out_file)
+
+        with open(out_file) as f:
+            content = yaml.safe_load(f)
+
+        # The subclass-only ``extra`` field survives the polymorphic dump.
+        assert content["items"][0]["extra"] == "kept"
+        # And the discriminator that ``exclude_unset`` would strip is still there.
+        assert content["items"][0]["kind"] == "registry_stub.default"

--- a/tests/unit/noether/inference/test_evaluate.py
+++ b/tests/unit/noether/inference/test_evaluate.py
@@ -1,0 +1,95 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+import os
+from collections import OrderedDict
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import RootModel
+
+from noether.core.configs.hyperparameters import Hyperparameters
+from noether.core.schemas.callbacks import OnlineLossCallbackConfig
+from noether.core.schemas.schema import ConfigSchema
+from noether.inference.evaluate import evaluate
+
+_INFERENCE_RUNNER_MAIN = "noether.inference.evaluate.InferenceRunner.main"
+
+
+class _DimSpec(RootModel[OrderedDict[str, int]]):
+    pass
+
+
+class _EvalHP(ConfigSchema):
+    """Minimal ConfigSchema subclass with a non-trivial polymorphic field
+    suitable for testing override-path navigation."""
+
+    spec: _DimSpec
+
+
+@pytest.fixture
+def hp_resolved_dir(tmp_path: Path) -> Path:
+    """Create a directory with a saved ``hp_resolved.yaml`` representing a
+    training run that ``evaluate`` can target."""
+    os.environ["MASTER_PORT"] = "12345"
+    params = _EvalHP(
+        output_path=str(tmp_path),
+        run_id="run_abc123",
+        datasets=dict(),
+        model=dict(name="m", kind="k"),
+        trainer=dict(kind="mock", effective_batch_size=4, callbacks=[], max_epochs=1),
+        spec=_DimSpec({"a": 1, "b": 2}),
+    )
+    run_dir = tmp_path / "run_abc123"
+    run_dir.mkdir()
+    Hyperparameters.save_resolved(params, run_dir / "hp_resolved.yaml")
+    return run_dir
+
+
+class TestEvaluate:
+    """``evaluate`` should mirror the ``noether-eval`` CLI: load the saved
+    config, wire ``resume_*`` against the run dir, optionally swap the callback
+    list, and dispatch via ``InferenceRunner.main``."""
+
+    def test_dispatches_to_inference_runner(self, hp_resolved_dir: Path):
+        with patch(_INFERENCE_RUNNER_MAIN) as mock_main:
+            evaluate(hp_resolved_dir, resume_checkpoint="best.metric")
+
+        mock_main.assert_called_once()
+        kwargs = mock_main.call_args.kwargs
+        assert kwargs["device"] == "cuda"
+        config = kwargs["config"]
+        # resume_* points back at the saved training run
+        assert config.resume_run_id == "run_abc123"
+        assert config.resume_checkpoint == "best.metric"
+        assert config.resume_output_path == Path(config.output_path)
+
+    def test_replaces_callbacks(self, hp_resolved_dir: Path):
+        eval_cb = OnlineLossCallbackConfig(every_n_epochs=1)
+        with patch(_INFERENCE_RUNNER_MAIN) as mock_main:
+            evaluate(hp_resolved_dir, callbacks=[eval_cb])
+
+        config = mock_main.call_args.kwargs["config"]
+        assert config.trainer.callbacks == [eval_cb]
+
+    def test_overrides_stage_name_for_eval_outputs(self, hp_resolved_dir: Path):
+        """``stage_name`` parameter routes outputs to a sub-stage while
+        ``resume_stage_name`` keeps pointing at the training-time stage."""
+        with patch(_INFERENCE_RUNNER_MAIN) as mock_main:
+            evaluate(hp_resolved_dir, stage_name="eval_sub")
+
+        config = mock_main.call_args.kwargs["config"]
+        assert config.stage_name == "eval_sub"
+        # The source run's stage_name was empty — resume should still target it.
+        assert config.resume_stage_name == ""
+
+    def test_disable_tracker(self, hp_resolved_dir: Path):
+        with patch(_INFERENCE_RUNNER_MAIN) as mock_main:
+            evaluate(hp_resolved_dir, disable_tracker=True)
+
+        config = mock_main.call_args.kwargs["config"]
+        assert config.tracker is None
+
+    def test_missing_run_dir(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="hp_resolved.yaml"):
+            evaluate(tmp_path / "nope")


### PR DESCRIPTION
Expose a Python function that can be used to programmatically call Noether-eval, for more complex cases or when Python is preferred in driving the eval process, includes fixes for fixing roundtrip loading of serialised hp_params.yaml files, which was broken under certain circumstances. This overlaps slightly with https://github.com/Emmi-AI/noether/pull/217 but has a different goal.