### PR TITLE
fix: accidental overwrite of run directory

### DIFF
--- a/src/noether/core/providers/path.py
+++ b/src/noether/core/providers/path.py
@@ -21,11 +21,24 @@ class PathProvider:
         debug: If `True`, outputs are stored in a "debug" subfolder.
     """
 
-    def __init__(self, output_root_path: Path, run_id: str, stage_name: str | None = None, debug: bool = False):
+    def __init__(
+        self,
+        output_root_path: Path,
+        run_id: str,
+        stage_name: str | None = None,
+        debug: bool = False,
+        force_overwrite: bool = False,
+    ):
         self.output_root = output_root_path
         self.stage_name = stage_name
         self.run_id = run_id
         self.debug = debug
+        self.force_overwrite = force_overwrite
+
+        if not self.force_overwrite and self.run_path().exists():
+            raise FileExistsError(
+                f"Output directory for run_id='{self.run_id}' and stage_name='{self.stage_name}' already exists at {self.run_path()}. Change the stage_name or use force_overwrite=True to overwrite."
+            )
 
     @staticmethod
     def _mkdir(path: Path) -> Path:
@@ -37,7 +50,19 @@ class PathProvider:
             output_root_path=self.output_root,
             run_id=run_id if run_id is not None else self.run_id,
             stage_name=stage_name,
+            force_overwrite=True,
         )
+
+    def run_path(self) -> Path:
+        if self.debug:
+            stage_output_path = self.output_root / "debug" / self.run_id
+        else:
+            stage_output_path = self.output_root / self.run_id
+
+        if self.stage_name is not None:
+            return stage_output_path / self.stage_name
+
+        return stage_output_path
 
     @property
     def run_output_path(self) -> Path:
@@ -46,15 +71,8 @@ class PathProvider:
         Returns:
             The output path for the current run.
         """
-        if self.debug:
-            stage_output_path = self.output_root / "debug" / self.run_id
-        else:
-            stage_output_path = self.output_root / self.run_id
 
-        if self.stage_name is not None:
-            stage_output_path = stage_output_path / self.stage_name
-
-        return PathProvider._mkdir(stage_output_path)
+        return PathProvider._mkdir(self.run_path())
 
     @property
     def logfile_uri(self) -> Path:

--- a/src/noether/core/schemas/schema.py
+++ b/src/noether/core/schemas/schema.py
@@ -111,6 +111,8 @@ class ConfigSchema[TModelConfig: ModelBaseConfig, TDatasetConfig: DatasetBaseCon
     """Path to output directory. When omitted, defaults to ``slurm.folder`` if a
     ``slurm`` section is present. Raises a validation error when neither
     ``output_path`` nor ``slurm`` is provided."""
+    overwrite_output: bool = False
+    """Whether to overwrite the output directory if it already exists. Use with caution, as this will delete all existing outputs for the run_id/stage_name!"""
     master_port: int = Field(default_factory=master_port_from_env)
     """Port for distributed master node. If None, will be set from environment variable MASTER_PORT if available."""
 

--- a/src/noether/training/runners/hydra_runner.py
+++ b/src/noether/training/runners/hydra_runner.py
@@ -193,6 +193,7 @@ class HydraRunner:
             run_id=run_id,
             stage_name=config.stage_name,
             debug=config.debug,
+            force_overwrite=config.overwrite_output,
         )
 
         resume_run_id: str | None = config.resume_run_id

--- a/tests/unit/noether/core/initializers/test_checkpoint.py
+++ b/tests/unit/noether/core/initializers/test_checkpoint.py
@@ -47,6 +47,7 @@ def path_provider_with_stage_name():
         run_id="test_run_id",
         stage_name="train",
         debug=False,
+        force_overwrite=True,
     )
 
 

--- a/tests/unit/noether/training/test_hydra_runner.py
+++ b/tests/unit/noether/training/test_hydra_runner.py
@@ -64,6 +64,7 @@ class TestHydraRunnerSetup:
         config.store_code_in_output = False
         config.cudnn_benchmark = False
         config.cudnn_deterministic = False
+        config.overwrite_output = False
 
         config.model = MagicMock()
         config.model.name = "test_model"


### PR DESCRIPTION
We currently don't check if a run is using a existing run directory. This can cause the data being accidentally overwritten by the new run, things such as stored checkpoints, metrics and other output artefacts might write to the existing files. 

To avoid such situations we throw an error since this is most likely unintended. To keep the existing behaviour `overwrite_output` needs to be set to True from now on.