### PR TITLE
feat: allow evaluation on best checkpoint only

### DIFF
--- a/src/noether/core/callbacks/checkpoint/best_checkpoint.py
+++ b/src/noether/core/callbacks/checkpoint/best_checkpoint.py
@@ -1,11 +1,15 @@
 #  Copyright © 2025 Emmi AI GmbH. All rights reserved.
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
+from torch.utils.data import DataLoader, DistributedSampler
 
-from noether.core.callbacks.base import CallBackBaseConfig
-from noether.core.callbacks.periodic import IntervalType, PeriodicCallback
+from noether.core.callbacks.base import CallbackBase, CallBackBaseConfig
+from noether.core.callbacks.periodic import IntervalType, PeriodicCallback, PeriodicDataIteratorCallback
+from noether.core.factory import Factory
+from noether.core.schemas.lib import Discriminated
+from noether.core.writers import PrefixedLogWriter
 
 
 class BestCheckpointCallbackConfig(CallBackBaseConfig):
@@ -21,6 +25,19 @@ class BestCheckpointCallbackConfig(CallBackBaseConfig):
     """"If provided, this callback will produce multiple best models which differ in the amount of intervals they allow the metric to not improve. For example, tolerance=[5] with every_n_epochs=1 will store a checkpoint where at most 5 epochs have passed until the metric improved. Additionally, the best checkpoint over the whole training will always be stored (i.e., tolerance=infinite). When setting different tolerances, one can evaluate different early stopping configurations with one training run."""
     model_names: list[str] | None = Field(None)
     """Which model name to save (e.g., if only the encoder of an autoencoder should be stored, one could pass model_name='encoder' here). This only applies when training a CompositeModel. If None, all models are saved."""
+    eval_callbacks: list[Annotated[Any, Discriminated(CallBackBaseConfig)]] | None = Field(None)
+    """Optional nested callbacks to dispatch whenever a new best model is detected. Each child's metric keys
+    are automatically prefixed with ``best=<metric_key>/`` (slashes in the metric key are replaced with dots)
+    so they don't collide with the live-model metrics. Children are invoked via their ``at_eval`` hook, which
+    bypasses their own schedule — the trigger is the new-best event, not the child's ``every_n_*``. Tolerance-
+    exceeded saves do not trigger children. ``before_training`` and ``after_training`` are forwarded
+    unconditionally so children can initialize and finalize cleanly.
+
+    ``PeriodicDataIteratorCallback`` children get a dedicated ``DataLoader`` built from their
+    ``sampler_config``; they are *not* registered on the shared
+    :class:`~noether.data.samplers.InterleavedSampler`. This means a child's ``every_n_*`` is irrelevant
+    here (only the ``dataset_key`` / ``batch_size`` / ``pipeline`` matter) and the child's schedule does
+    not need to match this callback's."""
 
 
 class BestCheckpointCallback(PeriodicCallback):
@@ -40,6 +57,10 @@ class BestCheckpointCallback(PeriodicCallback):
             metric_key: loss/val/total
             model_names:  # only applies when training a CompositeModel
               - encoder
+            eval_callbacks:
+              - kind: noether.training.callbacks.OfflineLossCallback
+                every_n_epochs: 1  # ignored; the parent triggers on new-best
+                dataset_key: test
     """
 
     def __init__(
@@ -67,6 +88,36 @@ class BestCheckpointCallback(PeriodicCallback):
         self.tolerances_is_exceeded = dict.fromkeys(callback_config.tolerances or [], False)
         self.tolerance_counter = 0
         self.metric_at_exceeded_tolerance: dict[float, float] = {}
+
+        # Build nested eval callbacks. Each child gets a PrefixedLogWriter so its metric keys are namespaced
+        # as ``best=<metric_key>/<original_key>``. Children are dispatched on new-best detection (bypassing
+        # their own schedule via ``at_eval``).
+        self.eval_callbacks: list[PeriodicCallback] = []
+        eval_callback_configs = getattr(callback_config, "eval_callbacks", None)
+        if eval_callback_configs:
+            prefix = f"best={self.metric_key.replace('/', '.')}"
+            child_kwargs = {
+                **kwargs,
+                "log_writer": PrefixedLogWriter(inner=kwargs["log_writer"], prefix=prefix),
+            }
+            self.eval_callbacks = Factory().create_list(eval_callback_configs, **child_kwargs)
+
+        # Cache one DataLoader per iterator child. Built lazily on first new-best so we don't pay the cost
+        # if the metric never improves (e.g. divergence). Reused thereafter — ``iter(loader)`` returns a
+        # fresh iterator each time and rebuilds the (deterministic) sampler order.
+        self._iterator_child_loaders: dict[int, DataLoader] = {}
+
+    def get_children(self) -> list[CallbackBase]:
+        """Non-iterator children only — iterator children are owned end-to-end here and must not be
+        registered on the shared :class:`~noether.data.samplers.InterleavedSampler` (we build their
+        loaders on dispatch instead). The trainer always passes ``batch_size`` to every
+        :class:`~noether.core.callbacks.periodic.PeriodicCallback` hook, so we can build child loaders
+        without needing the trainer's iterator-args bundle.
+        """
+        children: list[CallbackBase] = [
+            child for child in self.eval_callbacks if not isinstance(child, PeriodicDataIteratorCallback)
+        ]
+        return children
 
     def state_dict(self) -> dict[str, Any]:
         """Return the state of the callback for checkpointing.
@@ -96,17 +147,21 @@ class BestCheckpointCallback(PeriodicCallback):
         self.tolerance_counter = state_dict["tolerance_counter"]
         self.metric_at_exceeded_tolerance = state_dict["metric_at_exceeded_tolerance"]
 
-    def before_training(self, *, update_counter) -> None:
+    def before_training(self, *, update_counter, **kwargs) -> None:
         """Validate callback configuration before training starts.
 
         Args:
             update_counter: The training update counter.
+            **kwargs: Additional keyword arguments forwarded to child eval callbacks.
 
         Raises:
             NotImplementedError: If resuming training with tolerances is attempted.
         """
         if len(self.tolerances_is_exceeded) > 0 and update_counter.cur_iteration.sample > 0:
             raise NotImplementedError(f"{type(self).__name__} with tolerances resuming not implemented")
+
+        for child in self.eval_callbacks:
+            child.before_training(update_counter=update_counter, **kwargs)
 
     def _is_new_best_model(self, metric_value):
         """Check if the current metric value is better than the best recorded value.
@@ -121,19 +176,81 @@ class BestCheckpointCallback(PeriodicCallback):
             return metric_value > self.best_metric_value
         return metric_value < self.best_metric_value
 
+    def _build_loader_for_child(self, child: PeriodicDataIteratorCallback, batch_size: int | None) -> DataLoader:
+        """Build (and cache) a standalone ``DataLoader`` for an iterator child.
+
+        Uses the child's existing ``sampler_config`` — the sampler, dataset, collate pipeline and batch
+        size have already been resolved against the data container during the child's ``__init__``. We
+        just hand them to a plain ``DataLoader`` so the child can iterate its dataset without going
+        through the shared :class:`~noether.data.samplers.InterleavedSampler`.
+        """
+        cache_key = id(child)
+        if cache_key in self._iterator_child_loaders:
+            return self._iterator_child_loaders[cache_key]
+
+        config = child.sampler_config
+        sampler = config.sampler
+        # ``sampler`` is typed as ``SizedIterable`` in ``SamplerIntervalConfig``; in practice it's either
+        # a torch ``DistributedSampler`` (has ``dataset``) or a ``SequentialSampler`` (has ``data_source``)
+        # — both built by ``PeriodicDataIteratorCallback._create_sampler_config``.
+        dataset = sampler.dataset if isinstance(sampler, DistributedSampler) else sampler.data_source  # type: ignore[attr-defined]
+        loader = DataLoader(
+            dataset=dataset,
+            batch_size=config.batch_size or batch_size,
+            sampler=sampler,
+            collate_fn=config.pipeline,
+            persistent_workers=True,
+        )
+        self._iterator_child_loaders[cache_key] = loader
+        return loader
+
+    def _dispatch_children(self, *, interval_type: IntervalType, update_counter=None, **kwargs) -> None:
+        """Dispatch each child against the live (= new best) model.
+
+        Iterator children receive a fresh ``data_iter`` built from their own dataset (the trainer's
+        shared ``data_iter`` is *not* used). ``trainer_model`` / ``batch_size`` arrive via ``kwargs``
+        from the trainer — both are always passed to every :class:`PeriodicCallback` hook.
+
+        Children are invoked via :meth:`periodic_callback` (not :meth:`at_eval`) so they observe the
+        parent's actual ``interval_type`` (e.g. ``"epoch"`` / ``"update"``) instead of a synthetic
+        ``"eval"`` — matching the context in which the new-best event was raised.
+        """
+        batch_size = kwargs.get("batch_size")
+        for child in self.eval_callbacks:
+            child_kwargs = dict(kwargs)
+            if isinstance(child, PeriodicDataIteratorCallback):
+                loader = self._build_loader_for_child(child, batch_size=batch_size)
+                child_kwargs["data_iter"] = iter(loader)
+            child.periodic_callback(
+                interval_type=interval_type,
+                update_counter=update_counter,
+                **child_kwargs,
+            )
+
     # noinspection PyMethodOverriding
-    def periodic_callback(self, *, interval_type: IntervalType, **_) -> None:
+    def periodic_callback(self, *, interval_type: IntervalType, **kwargs) -> None:
         """Execute the periodic callback to check and save best model.
 
         This method is called at the configured frequency (e.g., every N epochs).
         It checks if the current metric value is better than the previous best,
         and if so, saves the model checkpoint. Also tracks tolerance-based checkpoints.
 
+        When a new best is detected, child eval callbacks (if configured) are dispatched against the live
+        (newly-best) model. Iterator children iterate their own :class:`~torch.utils.data.DataLoader`
+        (built on first use) — they do **not** consume from the trainer's shared ``data_iter``.
+
+        On ``interval_type="eval"`` (post-training eval, where the trainer loads the saved best checkpoint
+        into the live model and calls every callback's ``at_eval``), children are dispatched
+        unconditionally so they evaluate the loaded best model. No checkpoint save / tolerance bookkeeping
+        runs in eval mode (the in-memory ``best_metric_value`` starts at ±inf in a fresh eval process).
+
         Raises:
             KeyError: If the log cache is empty or the metric key is not found.
         """
         if interval_type == "eval":
-            return  # checkpoints are only saved during training
+            # Post-training eval: model is already the loaded best; just dispatch children.
+            self._dispatch_children(interval_type=interval_type, **kwargs)
+            return
         if self.writer.log_cache is None:
             raise KeyError("Log cache is empty, can't retrieve metric value.")
         if self.metric_key not in self.writer.log_cache:
@@ -160,6 +277,8 @@ class BestCheckpointCallback(PeriodicCallback):
             # Reset the tolerance flag and the exceeded flags so tolerance tracking starts over:
             self.tolerance_counter = 0
             self.tolerances_is_exceeded = dict.fromkeys(self.tolerances_is_exceeded, False)
+
+            self._dispatch_children(interval_type=interval_type, **kwargs)
         else:
             self.tolerance_counter += 1
             for tolerance, is_exceeded in self.tolerances_is_exceeded.items():
@@ -184,8 +303,11 @@ class BestCheckpointCallback(PeriodicCallback):
         """Log the best metric values at different tolerance thresholds after training completes.
 
         Args:
-            **kwargs: Additional keyword arguments (unused).
+            **kwargs: Additional keyword arguments forwarded to child eval callbacks.
         """
         # best metric doesn't need to be logged as it is summarized anyways
         for tolerance, value in self.metric_at_exceeded_tolerance.items():
             self.logger.info(f"best {self.metric_key} with tolerance={tolerance}: {value}")
+
+        for child in self.eval_callbacks:
+            child.after_training(**kwargs)

--- a/src/noether/training/trainers/base.py
+++ b/src/noether/training/trainers/base.py
@@ -875,28 +875,23 @@ class BaseTrainer:
         batch_size: int,
         end_of_epoch: bool = False,
     ) -> bool:
-        iterator_callback_args = dict(
-            trainer_model=dist_model,
-            data_iter=map(BaseTrainer.drop_metadata, data_iter),
-            batch_size=batch_size,
-        )
         from noether.core.callbacks.early_stoppers import EarlyStopIteration
 
         early_exit = False
         first_error = None
         for callback in periodic_callbacks:
-            needs_iter_args = _needs_iterator_args(callback)
             try:
-                if end_of_epoch:
-                    callback.after_epoch(
-                        update_counter=self.update_counter,
-                        **(iterator_callback_args if needs_iter_args else {}),
-                    )
-                else:
-                    callback.after_update(
-                        update_counter=self.update_counter,
-                        **(iterator_callback_args if needs_iter_args else {}),
-                    )
+                callback_fn = callback.after_epoch if end_of_epoch else callback.after_update
+                callback_fn(
+                    update_counter=self.update_counter,
+                    trainer_model=dist_model,
+                    batch_size=batch_size,
+                    **(
+                        {"data_iter": map(BaseTrainer.drop_metadata, data_iter)}
+                        if _needs_iterator_args(callback)
+                        else {}
+                    ),
+                )
             except EarlyStopIteration:
                 self.logger.info(f"Callback {callback} requested early stop of training")
                 early_exit = True
@@ -1251,16 +1246,10 @@ class BaseTrainer:
                 if not isinstance(callback, PeriodicCallback):
                     continue
                 self.logger.info(f"Running periodic callback: {callback}")
-                iterator_callback_args = (
-                    dict(
-                        trainer_model=dist_model,
-                        data_iter=map(BaseTrainer.drop_metadata, data_iter),
-                        batch_size=batch_size,
-                    )
-                    if _needs_iterator_args(callback)
-                    else {}
-                )
-                callback.at_eval(self.update_counter, **iterator_callback_args)
+                extra = dict(batch_size=batch_size, trainer_model=dist_model)
+                if _needs_iterator_args(callback):
+                    extra["data_iter"] = map(BaseTrainer.drop_metadata, data_iter)
+                callback.at_eval(self.update_counter, **extra)
 
     @property
     def total_training_updates(self) -> int:

--- a/tests/unit/noether/core/callbacks/checkpoint/test_best_checkpoint.py
+++ b/tests/unit/noether/core/callbacks/checkpoint/test_best_checkpoint.py
@@ -7,6 +7,8 @@ import pytest
 
 from noether.core.callbacks.checkpoint.best_checkpoint import BestCheckpointCallback
 
+_MODULE_PATH = "noether.core.callbacks.checkpoint.best_checkpoint"
+
 
 @pytest.fixture
 def callback_deps():
@@ -34,6 +36,7 @@ def base_config():
         "model_name": None,
         "tolerances": None,
         "save_frozen_weights": False,
+        "eval_callbacks": None,
     }
 
 
@@ -175,6 +178,455 @@ class TestBestCheckpointCallback:
         cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
         with pytest.raises(KeyError, match="couldn't find metric_key"):
             cb.periodic_callback(interval_type="epoch")
+
+    def test_non_iterator_child_fires_on_new_best(self, monkeypatch, callback_deps, base_config):
+        """A non-iterator child dispatches via ``periodic_callback`` only when a new best is detected.
+
+        Verifies that:
+          - each child's log_writer is a PrefixedLogWriter scoped to ``best=<metric_key>/``
+          - ``before_training`` / ``after_training`` are forwarded unconditionally
+          - ``periodic_callback`` is invoked only on the new-best step, not on non-improving steps or
+            tolerance-exceeded saves
+          - the child sees the parent's actual ``interval_type``
+        """
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+        base_config["tolerances"] = [1]
+
+        child = Mock(spec=["before_training", "periodic_callback", "after_training"])
+
+        captured_kwargs: dict = {}
+
+        def fake_create_list(_configs, **child_kwargs):
+            captured_kwargs.update(child_kwargs)
+            return [child]
+
+        fake_factory = Mock()
+        fake_factory.create_list.side_effect = fake_create_list
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]  # sentinel; Factory is mocked
+
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        from noether.core.writers import PrefixedLogWriter
+
+        assert isinstance(captured_kwargs["log_writer"], PrefixedLogWriter)
+        assert captured_kwargs["log_writer"]._prefix == "best=val.acc"
+
+        update_counter = SimpleNamespace(cur_iteration=SimpleNamespace(sample=0))
+        cb.before_training(update_counter=update_counter, extra="forwarded")
+        child.before_training.assert_called_once()
+        assert child.before_training.call_args.kwargs["extra"] == "forwarded"
+
+        # New best -> child.periodic_callback fires with the parent's actual interval_type.
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.9}
+        cb.periodic_callback(interval_type="epoch", update_counter=update_counter, trainer_model="m")
+        assert child.periodic_callback.call_count == 1
+        assert child.periodic_callback.call_args.kwargs["update_counter"] is update_counter
+        assert child.periodic_callback.call_args.kwargs["interval_type"] == "epoch"
+
+        # Non-improving step -> no extra child dispatch.
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.85}
+        cb.periodic_callback(interval_type="epoch", update_counter=update_counter)
+        assert child.periodic_callback.call_count == 1
+
+        # Tolerance-exceeded save -> still no child dispatch (only main best triggers children).
+        cb.periodic_callback(interval_type="epoch", update_counter=update_counter)
+        assert cb.tolerances_is_exceeded[1] is True
+        assert child.periodic_callback.call_count == 1
+
+        cb.after_training(extra="forwarded")
+        child.after_training.assert_called_once()
+        assert child.after_training.call_args.kwargs["extra"] == "forwarded"
+
+    def test_iterator_child_gets_fresh_loader_on_new_best(self, monkeypatch, callback_deps, base_config):
+        """Iterator children receive their own fresh ``data_iter`` from a standalone ``DataLoader``
+        built off their ``sampler_config`` — they do NOT consume from the trainer's shared
+        ``data_iter`` (which is why we don't expose them via ``get_children``).
+        """
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        # Non-distributed sampler path: sampler has ``data_source`` and isinstance(_, DistributedSampler)
+        # is False, so ``_build_loader_for_child`` reads the dataset from ``data_source``.
+        fake_dataset = object()
+        fake_sampler = SimpleNamespace(data_source=fake_dataset)
+
+        child = Mock(spec=PeriodicDataIteratorCallback)
+        child.sampler_config = SimpleNamespace(sampler=fake_sampler, batch_size=None, pipeline="pipeline_sentinel")
+
+        # Capture the DataLoader kwargs and stub iteration so the assertion can check the iterator
+        # handed to ``at_eval`` came from this loader.
+        captured_loader_kwargs: dict = {}
+
+        class FakeLoader:
+            def __iter__(self):
+                return iter([("batch0",), ("batch1",)])
+
+        def fake_DataLoader(**kwargs):
+            captured_loader_kwargs.update(kwargs)
+            return FakeLoader()
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", fake_DataLoader)
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        update_counter = SimpleNamespace(cur_iteration=SimpleNamespace(sample=0))
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.9}
+        # The trainer always passes ``batch_size`` and ``trainer_model`` to every PeriodicCallback hook;
+        # ``data_iter`` is *not* passed to us (we hide iterator children from ``get_children``, so
+        # ``_needs_iterator_args`` returns False). We build the child's ``data_iter`` ourselves.
+        cb.periodic_callback(
+            interval_type="update",
+            update_counter=update_counter,
+            trainer_model="dist_model",
+            batch_size=8,
+        )
+
+        # DataLoader built from the child's sampler_config — sampler, pipeline, batch_size pass through.
+        assert captured_loader_kwargs["dataset"] is fake_dataset
+        assert captured_loader_kwargs["sampler"] is fake_sampler
+        assert captured_loader_kwargs["batch_size"] == 8
+        assert captured_loader_kwargs["collate_fn"] == "pipeline_sentinel"
+
+        # Child receives the fresh iter() and the forwarded trainer args.
+        assert child.periodic_callback.call_count == 1
+        kwargs = child.periodic_callback.call_args.kwargs
+        assert kwargs["interval_type"] == "update"  # parent's interval_type, not "eval"
+        assert kwargs["update_counter"] is update_counter
+        assert kwargs["trainer_model"] == "dist_model"
+        assert kwargs["batch_size"] == 8
+        assert next(kwargs["data_iter"]) == ("batch0",)
+
+    def test_children_fire_on_eval_interval(self, monkeypatch, callback_deps, base_config):
+        """When the trainer calls ``at_eval`` (post-training eval), children dispatch unconditionally
+        against the loaded best model — no new-best detection, no checkpoint save, no tolerance update.
+        """
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        iterator_child = Mock(spec=PeriodicDataIteratorCallback)
+        iterator_child.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=2, pipeline=None
+        )
+        non_iterator_child = Mock(spec=["periodic_callback"])
+
+        class FakeLoader:
+            def __iter__(self):
+                return iter([])
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", lambda **_: FakeLoader())
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [iterator_child, non_iterator_child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object(), object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        update_counter = SimpleNamespace()
+        cb.periodic_callback(
+            interval_type="eval",
+            update_counter=update_counter,
+            trainer_model="dist_model",
+            batch_size=2,
+        )
+
+        # Both children invoked with interval_type="eval"; no checkpoint save.
+        assert iterator_child.periodic_callback.call_count == 1
+        assert iterator_child.periodic_callback.call_args.kwargs["interval_type"] == "eval"
+        assert non_iterator_child.periodic_callback.call_count == 1
+        assert non_iterator_child.periodic_callback.call_args.kwargs["interval_type"] == "eval"
+        callback_deps["checkpoint_writer"].save.assert_not_called()
+
+    def test_iterator_child_loader_is_cached(self, monkeypatch, callback_deps, base_config):
+        """The DataLoader is built once per child and reused across new-best events."""
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        fake_sampler = SimpleNamespace(data_source=object())
+        child = Mock(spec=PeriodicDataIteratorCallback)
+        child.sampler_config = SimpleNamespace(sampler=fake_sampler, batch_size=4, pipeline=None)
+
+        construction_count = 0
+
+        class FakeLoader:
+            def __iter__(self):
+                return iter([])
+
+        def fake_DataLoader(**_kwargs):
+            nonlocal construction_count
+            construction_count += 1
+            return FakeLoader()
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", fake_DataLoader)
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        # Two consecutive new-best events.
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.5}
+        cb.periodic_callback(interval_type="update", trainer_model="m", batch_size=4)
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.9}
+        cb.periodic_callback(interval_type="update", trainer_model="m", batch_size=4)
+
+        assert construction_count == 1
+        assert child.periodic_callback.call_count == 2
+
+    def test_iterator_child_not_fired_on_non_best(self, monkeypatch, callback_deps, base_config):
+        """No DataLoader construction and no child dispatch on a non-new-best step — there's no
+        shared stream to keep aligned, so we simply do nothing for the child."""
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        child = Mock(spec=PeriodicDataIteratorCallback)
+        child.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=None, pipeline=None
+        )
+
+        constructed = False
+
+        def fake_DataLoader(**_):
+            nonlocal constructed
+            constructed = True
+            return SimpleNamespace(__iter__=lambda self: iter([]))
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", fake_DataLoader)
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+        cb.best_metric_value = 0.95  # any new metric below this is non-improving
+
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.5}
+        cb.periodic_callback(interval_type="update", trainer_model="m", batch_size=4)
+
+        assert child.periodic_callback.call_count == 0
+        assert constructed is False
+
+    def test_get_children_excludes_iterator_children(self, monkeypatch, callback_deps, base_config):
+        """``get_children`` hides iterator children (trainer must not register their samplers on the
+        shared ``InterleavedSampler``) but still exposes non-iterator children."""
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        iterator_child = Mock(spec=PeriodicDataIteratorCallback)
+        iterator_child.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=1, pipeline=None
+        )
+        non_iterator_child = Mock()
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [iterator_child, non_iterator_child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object(), object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        assert cb.get_children() == [non_iterator_child]
+
+    def test_no_eval_callbacks_when_unconfigured(self, callback_deps, base_config):
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+        assert cb.eval_callbacks == []
+        assert cb.get_children() == []
+
+    def test_build_loader_for_distributed_sampler_reads_dataset_attr(self, monkeypatch, callback_deps, base_config):
+        """Distributed sampler path of ``_build_loader_for_child``: when the child's sampler is a
+        ``DistributedSampler``, the dataset is read from ``sampler.dataset`` (not ``data_source``).
+        """
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        # Patch the module's DistributedSampler to a class we control so isinstance(..., DistributedSampler)
+        # resolves to True for our fake sampler without needing a torch.distributed setup.
+        class FakeDistributedSampler:
+            def __init__(self, dataset):
+                self.dataset = dataset
+
+        monkeypatch.setattr(_MODULE_PATH + ".DistributedSampler", FakeDistributedSampler)
+
+        fake_dataset = object()
+        fake_sampler = FakeDistributedSampler(dataset=fake_dataset)
+        child = Mock(spec=PeriodicDataIteratorCallback)
+        child.sampler_config = SimpleNamespace(sampler=fake_sampler, batch_size=2, pipeline=None)
+
+        captured_loader_kwargs: dict = {}
+
+        class FakeLoader:
+            def __iter__(self):
+                return iter([])
+
+        def fake_DataLoader(**kwargs):
+            captured_loader_kwargs.update(kwargs)
+            return FakeLoader()
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", fake_DataLoader)
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.9}
+        cb.periodic_callback(interval_type="update", trainer_model="m", batch_size=4)
+
+        assert captured_loader_kwargs["dataset"] is fake_dataset
+
+    def test_before_after_training_reach_iterator_children(self, monkeypatch, callback_deps, base_config):
+        """Both iterator and non-iterator children receive ``before_training`` / ``after_training``."""
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        iter_child = Mock(spec=PeriodicDataIteratorCallback)
+        iter_child.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=1, pipeline=None
+        )
+        non_iter_child = Mock(spec=["before_training", "periodic_callback", "after_training"])
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [iter_child, non_iter_child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object(), object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        update_counter = SimpleNamespace(cur_iteration=SimpleNamespace(sample=0))
+        cb.before_training(update_counter=update_counter)
+        cb.after_training()
+
+        iter_child.before_training.assert_called_once()
+        iter_child.after_training.assert_called_once()
+        non_iter_child.before_training.assert_called_once()
+        non_iter_child.after_training.assert_called_once()
+
+    def test_each_iterator_child_gets_distinct_cached_loader(self, monkeypatch, callback_deps, base_config):
+        """With multiple iterator children, the cache builds one loader per child (keyed by ``id``)."""
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        child_a = Mock(spec=PeriodicDataIteratorCallback)
+        child_a.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=1, pipeline=None
+        )
+        child_b = Mock(spec=PeriodicDataIteratorCallback)
+        child_b.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=1, pipeline=None
+        )
+
+        constructed_loaders: list[object] = []
+
+        class FakeLoader:
+            def __iter__(self):
+                return iter([])
+
+        def fake_DataLoader(**_):
+            loader = FakeLoader()
+            constructed_loaders.append(loader)
+            return loader
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", fake_DataLoader)
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [child_a, child_b]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object(), object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        # Two consecutive new-best events -> 2 loaders total (one per child), each reused.
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.5}
+        cb.periodic_callback(interval_type="update", trainer_model="m", batch_size=4)
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.9}
+        cb.periodic_callback(interval_type="update", trainer_model="m", batch_size=4)
+
+        assert len(constructed_loaders) == 2
+        assert constructed_loaders[0] is not constructed_loaders[1]
+        assert child_a.periodic_callback.call_count == 2
+        assert child_b.periodic_callback.call_count == 2
+
+    def test_mixed_children_dispatch_on_new_best(self, monkeypatch, callback_deps, base_config):
+        """On a new-best step, an iterator child gets ``data_iter`` injected; a non-iterator child
+        does not. Both still receive ``trainer_model`` / ``batch_size`` from the trainer's kwargs.
+        """
+        from noether.core.callbacks.periodic import PeriodicDataIteratorCallback
+
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        iter_child = Mock(spec=PeriodicDataIteratorCallback)
+        iter_child.sampler_config = SimpleNamespace(
+            sampler=SimpleNamespace(data_source=object()), batch_size=1, pipeline=None
+        )
+        non_iter_child = Mock(spec=["periodic_callback"])
+
+        class FakeLoader:
+            def __iter__(self):
+                return iter([])
+
+        monkeypatch.setattr(_MODULE_PATH + ".DataLoader", lambda **_: FakeLoader())
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [iter_child, non_iter_child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object(), object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        callback_deps["log_writer"].log_cache = {"val/acc": 0.9}
+        cb.periodic_callback(interval_type="update", trainer_model="dist_model", batch_size=4)
+
+        iter_kwargs = iter_child.periodic_callback.call_args.kwargs
+        assert "data_iter" in iter_kwargs
+        assert iter_kwargs["trainer_model"] == "dist_model"
+        assert iter_kwargs["batch_size"] == 4
+
+        non_iter_kwargs = non_iter_child.periodic_callback.call_args.kwargs
+        assert "data_iter" not in non_iter_kwargs
+        assert non_iter_kwargs["trainer_model"] == "dist_model"
+        assert non_iter_kwargs["batch_size"] == 4
+
+    def test_eval_interval_does_not_require_log_cache(self, monkeypatch, callback_deps, base_config):
+        """The ``"eval"`` interval short-circuits before reading ``log_cache``, so children still
+        dispatch even if no metric has been logged in the current process."""
+        callback_deps["metric_property_provider"].higher_is_better.return_value = True
+
+        child = Mock(spec=["periodic_callback"])
+
+        fake_factory = Mock()
+        fake_factory.create_list.return_value = [child]
+        monkeypatch.setattr(_MODULE_PATH + ".Factory", Mock(return_value=fake_factory))
+
+        base_config["eval_callbacks"] = [object()]
+        cb = BestCheckpointCallback(callback_config=SimpleNamespace(**base_config), **callback_deps)
+
+        # Log cache is None (would raise KeyError on a non-eval interval).
+        callback_deps["log_writer"].log_cache = None
+        cb.periodic_callback(interval_type="eval", trainer_model="m", batch_size=4)
+
+        assert child.periodic_callback.call_count == 1
+        callback_deps["checkpoint_writer"].save.assert_not_called()
 
     def test_after_training_logs_tolerance_metrics(self, callback_deps, base_config):
         callback_deps["metric_property_provider"].higher_is_better.return_value = True


### PR DESCRIPTION
Analog to EMA callback supporting child callbacks, adding support to BestCheckpointCallback too. This allows the callback to be configured such that certain callbacks are executed whenever a new best checkpoint is saved. This way we always have metrics on the best checkpoint.