### PR TITLE
fix: no overwrite check for checkpoint loading

### DIFF
--- a/src/noether/core/initializers/checkpoint.py
+++ b/src/noether/core/initializers/checkpoint.py
@@ -64,6 +64,7 @@ class CheckpointInitializer(InitializerBase):
                 run_id=self.run_id,
                 stage_name=self.stage_name,
                 debug=self.path_provider.debug,
+                force_overwrite=True,
             )
         else:
             self.init_run_path_provider = self.path_provider.with_run(

--- a/src/noether/training/runners/hydra_runner.py
+++ b/src/noether/training/runners/hydra_runner.py
@@ -220,6 +220,7 @@ class HydraRunner:
                 run_id=resume_run_id,
                 stage_name=config.resume_stage_name,
                 debug=config.debug,
+                force_overwrite=True,
             )
             path_provider.link(ancestor)
 

--- a/tests/unit/noether/training/test_hydra_runner.py
+++ b/tests/unit/noether/training/test_hydra_runner.py
@@ -177,6 +177,7 @@ class TestHydraRunnerSetup:
             run_id="run_123",
             stage_name="prev_stage",
             debug=False,
+            force_overwrite=True,
         )
         mock_path_instance.link.assert_called()
         assert mock_config.trainer.initializer is not None


### PR DESCRIPTION
The new force_overwrite argument needs to be supplied in cases we don't care about the check, this is necessary for loading a checkpoint and for linking the ancestor.