### PR TITLE
feat: use anchor kv-cache in chunked query inference

### DIFF
--- a/recipes/aero_cfd/src/aero_cfd/callbacks/query_inference.py
+++ b/recipes/aero_cfd/src/aero_cfd/callbacks/query_inference.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from typing import Any
 
 import torch
 
@@ -36,9 +37,12 @@ class QueryInferenceCallback(AeroMetricsCallback):
     - **Anchors** (first ``num_*_anchors`` positions) — same as training
     - **Queries** (the rest) — processed in chunks
 
-    Each forward pass receives fixed anchors + one chunk of queries.  The model
-    outputs anchor predictions (constant across chunks) and query predictions
-    (concatenated).  Metrics and VTK export use the combined result.
+    The first chunk runs a full forward pass against the AB-UPT backbone and
+    keeps the returned ``kv_cache`` (geometry encoding + RoPE, anchor K/V in
+    every physics and decoder block). Subsequent chunks reuse that cache and
+    pass only the new query slice, so the geometry encoder + anchor projection
+    run exactly once per sample. Anchor predictions come from the first chunk
+    only — subsequent chunks return query outputs only.
     """
 
     def __init__(self, callback_config: QueryInferenceCallbackConfig, **kwargs):
@@ -48,10 +52,11 @@ class QueryInferenceCallback(AeroMetricsCallback):
         self.query_chunk_size = callback_config.query_chunk_size
 
     def _run_model_inference(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """Run chunked query-based inference.
+        """Run chunked query-based inference with geometry/anchor KV caching.
 
-        Splits batch positions into anchors + queries, iterates through query
-        chunks while keeping anchors fixed, and returns combined outputs.
+        Splits batch positions into anchors + queries, runs the first chunk
+        through the full backbone, then iterates remaining chunks reusing the
+        first chunk's cache. Returns combined anchor + query outputs.
         """
         # Split positions: [anchors | queries]
         surface_all = batch["surface_anchor_position"]
@@ -69,41 +74,55 @@ class QueryInferenceCallback(AeroMetricsCallback):
             # No queries — standard anchor-only inference
             return super()._run_model_inference(batch)
 
-        base_kwargs = {
-            "geometry_position": batch["geometry_position"],
-            "geometry_supernode_idx": batch["geometry_supernode_idx"],
-            "geometry_batch_idx": batch["geometry_batch_idx"],
-            "surface_anchor_position": surface_anchors,
-            "volume_anchor_position": volume_anchors,
-        }
-
         cs = self.query_chunk_size
         n_chunks = max(1, math.ceil(n_sq / cs), math.ceil(n_vq / cs))
 
+        # Bypass the AeroABUPT wrapper (which discards the kv_cache) and drive
+        # the AnchoredBranchedUPT backbone directly so the cache survives
+        # across chunks.
+        backbone = self.model.backbone
+        anchor_positions = {"surface": surface_anchors, "volume": volume_anchors}
+
         anchor_outputs: dict[str, torch.Tensor] = {}
         query_chunks: dict[str, list[torch.Tensor]] = defaultdict(list)
+        kv_cache: dict[str, Any] | None = None
 
         for i in range(n_chunks):
-            chunk_kwargs = dict(base_kwargs)
-
             s_start, s_end = i * cs, min((i + 1) * cs, n_sq)
             v_start, v_end = i * cs, min((i + 1) * cs, n_vq)
 
+            query_positions: dict[str, torch.Tensor] = {}
             if s_start < n_sq:
-                chunk_kwargs["query_surface_position"] = surface_queries[:, s_start:s_end]
+                query_positions["surface"] = surface_queries[:, s_start:s_end]
             if v_start < n_vq:
-                chunk_kwargs["query_volume_position"] = volume_queries[:, v_start:v_end]
+                query_positions["volume"] = volume_queries[:, v_start:v_end]
 
             with self.trainer.autocast_context:
-                out = self.model(**chunk_kwargs)
+                if i == 0:
+                    out, kv_cache = backbone(
+                        geometry_position=batch["geometry_position"],
+                        geometry_supernode_idx=batch["geometry_supernode_idx"],
+                        geometry_batch_idx=batch["geometry_batch_idx"],
+                        domain_anchor_positions=anchor_positions,
+                        domain_query_positions=query_positions or None,
+                    )
+                else:
+                    # Reuse cached geometry encoding + anchor K/V; the backbone
+                    # refuses geometry tensors / anchor positions when
+                    # 'physics_blocks' is in the cache, and accepts a subset of
+                    # domains in query_positions when others are exhausted.
+                    out, _ = backbone(
+                        domain_query_positions=query_positions,
+                        kv_cache=kv_cache,
+                    )
 
             for key, value in out.items():
                 if key.startswith("query_"):
                     base_key = key[len("query_") :]
                     query_chunks[base_key].append(value)
                 elif i == 0:
-                    # Anchor outputs vary slightly across chunks due to decoder
-                    # self-attention over [anchors, queries]. Keep first chunk's.
+                    # Anchor outputs come from chunk 0 only. With anchors_cached
+                    # the backbone emits query_* keys exclusively.
                     anchor_outputs[key] = value
 
         # Combine: [anchor_predictions, query_predictions]

--- a/src/noether/modeling/models/ab_upt.py
+++ b/src/noether/modeling/models/ab_upt.py
@@ -602,15 +602,19 @@ class AnchoredBranchedUPT(nn.Module):
         query_position: torch.Tensor | None,
         anchor_feature: torch.Tensor | None,
         query_feature: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
         """Build the physics-block input segment and combined positions for a single domain.
 
         Concatenates ``[anchor | query]`` along the token dim. Each segment is
         ``bias(pos_embed(pos)) + (proj(features) or 0)``; the returned position
         is the concatenation of anchor and query positions in token order.
+
+        Returns ``None`` when both ``anchor_position`` and ``query_position``
+        are ``None`` — the domain contributes no new tokens this call (used when
+        anchor K/V is in the cache and there are no queries for this domain).
         """
         if anchor_position is None and query_position is None:
-            raise ValueError(f"domain {name!r} has neither anchor nor query positions")
+            return None
 
         proj: torch.nn.Module | None = (
             self.domain_feature_projs[name] if self.domain_feature_projs and name in self.domain_feature_projs else None
@@ -665,13 +669,19 @@ class AnchoredBranchedUPT(nn.Module):
         segments: list[torch.Tensor] = []
         physics_positions: dict[str, torch.Tensor] = {}
         for name in self.domain_names:
-            segment, position = self._build_domain_segment(
+            built = self._build_domain_segment(
                 name,
                 anchor_position=domain_anchor_positions.get(name),
                 query_position=domain_query_positions.get(name),
                 anchor_feature=domain_anchor_features.get(name),
                 query_feature=domain_query_features.get(name),
             )
+            if built is None:
+                # Domain contributes no new tokens. Its cached anchor K/V (if
+                # any) still participates in attention via ``kv_cache``; we
+                # just don't extend the input or emit positions for it.
+                continue
+            segment, position = built
             segments.append(segment)
             physics_positions[name] = position
         return torch.cat(segments, dim=1), physics_positions
@@ -794,6 +804,12 @@ class AnchoredBranchedUPT(nn.Module):
                     f"{name} tensor size ({x_domain.size(1)}) does not match expected size ({expected_size})."
                 )
 
+            if expected_size == 0:
+                # Domain has no new tokens this call (all anchors cached, no
+                # queries). Skip the decoder; its cached K/V is preserved by
+                # the outer forward when ``anchors_cached`` is True.
+                continue
+
             preds, new_cache = self._decode_domain(
                 x_domain,
                 name,
@@ -848,14 +864,19 @@ class AnchoredBranchedUPT(nn.Module):
             geometry_attn_kwargs["freqs"] = geometry_rope
             physics_perceiver_attn_kwargs["k_freqs"] = geometry_rope
 
-        # Per-domain rope + concatenated physics rope
-        domain_rope = {name: self.rope(physics_positions[name]) for name in self.domain_names}
-        rope_all = torch.cat([domain_rope[name] for name in self.domain_names], dim=1)
+        # Per-domain rope + concatenated physics rope. Domains absent from
+        # ``physics_positions`` contribute no new tokens this call (e.g. when
+        # their anchor K/V is cached and they have no queries), so they're
+        # skipped here too — their RoPE was baked into the cached K at the
+        # call that built the cache.
+        active_names = [name for name in self.domain_names if name in physics_positions]
+        domain_rope = {name: self.rope(physics_positions[name]) for name in active_names}
+        rope_all = torch.cat([domain_rope[name] for name in active_names], dim=1)
 
         physics_perceiver_attn_kwargs["q_freqs"] = rope_all
         physics_attn_kwargs["freqs"] = rope_all
 
-        decoder_attn_kwargs = {name: {"freqs": domain_rope[name]} for name in self.domain_names}
+        decoder_attn_kwargs = {name: {"freqs": domain_rope[name]} for name in active_names}
 
         return (
             geometry_attn_kwargs,


### PR DESCRIPTION
We had support for Anchor KV caching for a while and have a good use case in the QueryInference callback: when iterating in chunks over the full geometry, we can reuse the anchors from the first chunk and thus avoid unnecessary compute. This is mathematically equivalent and speeds up inference by roughly 25% in my tests.