### PR TITLE
fix: out-of-sync code references in walkthrough docs

### DIFF
--- a/docs/source/guides/training/configuring_ab_upt.rst
+++ b/docs/source/guides/training/configuring_ab_upt.rst
@@ -112,7 +112,8 @@ Concrete patterns
 
 .. literalinclude:: ../../../../recipes/aero_cfd/configs/model/ab_upt.yaml
    :language: yaml
-   :lines: 12-22
+   :start-at: physics_blocks:
+   :end-before: num_domain_decoder_blocks:
 
 A single ``perceiver`` block reads geometry once, then the trunk alternates
 ``self`` (in-domain mixing) with ``cross`` (cross-domain exchange) for four cycles,
@@ -123,7 +124,8 @@ ending in a ``self`` block.
 
 .. literalinclude:: ../../../../recipes/heat_transfer/configs/model/ab_upt.yaml
    :language: yaml
-   :lines: 12-18
+   :start-at: physics_blocks:
+   :end-before: num_domain_decoder_blocks:
 
 With only one domain, ``cross`` and ``joint`` are equivalent to ``self``, so the
 trunk is a stack of ``perceiver`` + ``self`` blocks.

--- a/docs/source/tutorials/walkthrough/callbacks.rst
+++ b/docs/source/tutorials/walkthrough/callbacks.rst
@@ -13,7 +13,7 @@ Overview
 --------
 
 The
-``AeroMetricsCallback`` (in ``callbacks/aero_metrics.py``)
+``AeroMetricsCallback`` (in ``src/aero_cfd/callbacks/aero_metrics.py``)
 is a specific callback that runs the current model on a separate validation or test set,
 computes error metrics, and logs them. This class inherits from
 :py:class:`~noether.core.callbacks.periodic.PeriodicDataIteratorCallback`,
@@ -54,14 +54,14 @@ Weights & Biases.
 
 The ``process_data`` method of the ``AeroMetricsCallback`` simply looks like:
 
-.. literalinclude:: ../../../../recipes/aero_cfd/callbacks/aero_metrics.py
+.. literalinclude:: ../../../../recipes/aero_cfd/src/aero_cfd/callbacks/aero_metrics.py
    :language: python
    :pyobject: AeroMetricsCallback.process_data
    :dedent:
 
 First, it computes the model outputs, and next, it adds the desired metrics to an output
 dictionary. All the substeps are implemented by individual methods in the callback itself.
-See the full implementation in :source:`callbacks/aero_metrics.py <../../../../recipes/aero_cfd/callbacks/aero_metrics.py>` for details.
+See the full implementation in :source:`callbacks/aero_metrics.py <../../../../recipes/aero_cfd/src/aero_cfd/callbacks/aero_metrics.py>` for details.
 
 
 Configuring callbacks
@@ -101,17 +101,18 @@ executed by the dataset, we retrieve the data normalizers via the ``DataContaine
 ``__init__`` method of the callback we implement, we use the available ``self.data_container``
 to get the correct dataset used for this callback and retrieve the normalizers:
 
-.. literalinclude:: ../../../../recipes/aero_cfd/callbacks/aero_metrics.py
+.. literalinclude:: ../../../../recipes/aero_cfd/src/aero_cfd/callbacks/aero_metrics.py
    :language: python
-   :lines: 89-95
+   :start-at: self.dataset_normalizers =
+   :end-at: self.dataset_normalizers =
    :dedent:
 
-To denormalize predictions, the ``_denormalize`` method looks up the normalizer by key and
-calls ``inverse``:
+To denormalize predictions before computing metrics, ``_compute_mode_metrics`` retrieves the
+dataset and calls its ``denormalize`` method for both the prediction and the target:
 
-.. literalinclude:: ../../../../recipes/aero_cfd/callbacks/aero_metrics.py
+.. literalinclude:: ../../../../recipes/aero_cfd/src/aero_cfd/callbacks/aero_metrics.py
    :language: python
-   :pyobject: AeroMetricsCallback._denormalize
+   :pyobject: AeroMetricsCallback._compute_mode_metrics
    :dedent:
 
 

--- a/docs/source/tutorials/walkthrough/configuration.rst
+++ b/docs/source/tutorials/walkthrough/configuration.rst
@@ -40,7 +40,7 @@ Let's break down its key components:
 
 .. literalinclude:: ../../../../recipes/aero_cfd/configs/train_shapenet.yaml
    :language: yaml
-   :lines: 1-25
+   :end-at: - _self_
 
 Each entry like ``dataset_normalizers: shapenet_dataset_normalizers`` tells Hydra to load
 :source:`configs/dataset_normalizers/shapenet_dataset_normalizers.yaml <../../../../recipes/aero_cfd/configs/dataset_normalizers/shapenet_dataset_normalizers.yaml>`
@@ -223,7 +223,7 @@ validates configuration: checks types, ranges, and constraints before training b
 All schemas in the Noether Framework follow an inheritance pattern. For example, model schemas
 inherit from ``ModelBaseConfig``:
 
-.. literalinclude:: ../../../../src/noether/core/schemas/models/base.py
+.. literalinclude:: ../../../../src/noether/core/models/base.py
    :language: python
    :pyobject: ModelBaseConfig
    :end-before: @property
@@ -247,12 +247,12 @@ Transformer models looks like:
 
 **TransformerBlockConfig** defines individual block parameters:
 
-.. literalinclude:: ../../../../src/noether/core/schemas/modules/blocks.py
+.. literalinclude:: ../../../../src/noether/modeling/modules/blocks/transformer.py
    :pyobject: TransformerBlockConfig
 
 **TransformerConfig** extends the block config:
 
-.. literalinclude:: ../../../../src/noether/core/schemas/models/transformer.py
+.. literalinclude:: ../../../../src/noether/modeling/models/transformer.py
    :pyobject: TransformerConfig
 
 **Multiple inheritance** means ``TransformerConfig`` inherits:
@@ -301,9 +301,9 @@ Each component (model, trainer, dataset, etc.) has a corresponding config class 
 from a base schema.
 
 For example, the trainer config schema for this recipe is defined in
-:source:`trainers/aerodynamics_cfd.py <../../../../recipes/aero_cfd/trainers/aerodynamics_cfd.py>`:
+:source:`trainers/aerodynamics_cfd.py <../../../../recipes/aero_cfd/src/aero_cfd/trainers/aerodynamics_cfd.py>`:
 
-.. literalinclude:: ../../../../recipes/aero_cfd/trainers/aerodynamics_cfd.py
+.. literalinclude:: ../../../../recipes/aero_cfd/src/aero_cfd/trainers/aerodynamics_cfd.py
    :language: python
    :pyobject: AerodynamicsCfdTrainerConfig
    :dedent:

--- a/docs/source/tutorials/walkthrough/models.rst
+++ b/docs/source/tutorials/walkthrough/models.rst
@@ -18,9 +18,9 @@ The ``ModelBaseConfig`` schema
 
 Each model in the Noether Framework must inherit from the :py:class:`~noether.core.models.Model`
 class. The config schema for models is defined by
-:py:class:`~noether.core.schemas.models.base.ModelBaseConfig`:
+:py:class:`~noether.core.models.base.ModelBaseConfig`:
 
-.. literalinclude:: ../../../../src/noether/core/schemas/models/base.py
+.. literalinclude:: ../../../../src/noether/core/models/base.py
    :language: python
    :pyobject: ModelBaseConfig
    :end-before: @property

--- a/docs/source/tutorials/walkthrough/pipeline.rst
+++ b/docs/source/tutorials/walkthrough/pipeline.rst
@@ -104,7 +104,8 @@ When the multi-stage pipeline runs, the sample processors are called as follows:
 
 .. literalinclude:: ../../../../src/noether/data/pipeline/multistage.py
    :language: python
-   :lines: 103-107
+   :start-at: # pre-process on a sample level
+   :end-before: # create batch out of the samples
    :dedent:
 
 Each **sample processor** takes a sample as input and returns the (pre)processed sample.
@@ -125,7 +126,8 @@ The code for calling the collators in the multi-stage pipeline looks as follows:
 
 .. literalinclude:: ../../../../src/noether/data/pipeline/multistage.py
    :language: python
-   :lines: 109-117
+   :start-at: # create batch out of the samples
+   :end-before: # process the batch
    :dedent:
 
 Each collator defines how to merge certain keys from each sample into a batch. In most cases,
@@ -146,5 +148,6 @@ batch. Below is the code showing how batch processors are called:
 
 .. literalinclude:: ../../../../src/noether/data/pipeline/multistage.py
    :language: python
-   :lines: 119-121
+   :start-at: # process the batch
+   :end-at: return batch
    :dedent:

--- a/docs/source/tutorials/walkthrough/trainer.rst
+++ b/docs/source/tutorials/walkthrough/trainer.rst
@@ -108,7 +108,7 @@ which of these potential losses should be computed during training.
 
 This method contains the core logic of the trainer for computing the loss:
 
-.. literalinclude:: ../../../../recipes/aero_cfd/trainers/aerodynamics_cfd.py
+.. literalinclude:: ../../../../recipes/aero_cfd/src/aero_cfd/trainers/aerodynamics_cfd.py
    :language: python
    :pyobject: AerodynamicsCFDTrainer.loss_compute
    :dedent:


### PR DESCRIPTION
I noticed the inline code blocks that references snippets from the source got outdated and needed fixing.