### PR TITLE
fix(slurm): default inner srun to --cpu-bind=none

### DIFF
--- a/src/noether/training/cli/submit_job.py
+++ b/src/noether/training/cli/submit_job.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
 # SLURM patterns that require a running job and cannot be resolved at submission time.
 _UNSUPPORTED_FOLDER_PATTERNS: frozenset[str] = frozenset({"%j", "%J", "%A", "%a", "%N", "%x"})
 
+# Default args for submitit's inner ``srun``. ``--cpu-bind=none`` disables per-task CPU
+# binding, which otherwise fails ("Unable to satisfy cpu bind request") on clusters whose
+# GPU partitions expose a non-contiguous CPU mask. Harmless where binding would succeed.
+_DEFAULT_SRUN_ARGS: list[str] = ["--cpu-bind=none"]
+
 
 class SlurmConfig(BaseModel):
     """Configuration for SLURM job submission via :mod:`submitit`.
@@ -97,6 +102,14 @@ class SlurmConfig(BaseModel):
     ``{"nice": 0, "reservation": "my_res", "chdir": "/work"}``. Keys are passed as
     ``--key=value`` to ``sbatch``."""
 
+    slurm_srun_args: list[str] | None = None
+    """Extra arguments for the inner ``srun`` launched by submitit. When left unset it
+    defaults to :data:`_DEFAULT_SRUN_ARGS` (``['--cpu-bind=none']``) to avoid SLURM
+    ``Unable to satisfy cpu bind request`` failures on clusters whose GPU-partition CPU
+    masks are non-contiguous — there ``srun``'s default per-task CPU binding cannot be
+    satisfied and the job step aborts before the program starts. Set to ``[]`` to restore
+    ``srun``'s default binding, or provide your own args."""
+
     @field_validator("folder")
     @classmethod
     def _resolve_folder_patterns(cls, value: str) -> str:
@@ -146,6 +159,8 @@ class SlurmConfig(BaseModel):
             if name == "folder" or value is None:
                 continue
             params[name] = value
+        # Default the inner srun to --cpu-bind=none unless the user set srun args explicitly.
+        params.setdefault("slurm_srun_args", list(_DEFAULT_SRUN_ARGS))
         return self.folder, params
 
 

--- a/tests/unit/noether/training/cli/test_submit_job.py
+++ b/tests/unit/noether/training/cli/test_submit_job.py
@@ -358,7 +358,24 @@ class TestSlurmConfigToExecutorKwargs:
     def test_excludes_none_fields(self):
         folder, params = SlurmConfig(name="job", slurm_partition="gpu").to_executor_kwargs()
         assert folder == "submitit_logs"
-        assert params == {"name": "job", "slurm_partition": "gpu", "timeout_min": 0}
+        assert params == {
+            "name": "job",
+            "slurm_partition": "gpu",
+            "timeout_min": 0,
+            "slurm_srun_args": ["--cpu-bind=none"],
+        }
+
+    def test_defaults_srun_args_to_cpu_bind_none(self):
+        """By default the inner srun gets --cpu-bind=none (avoids cpu-bind failures)."""
+        _, params = SlurmConfig(name="job").to_executor_kwargs()
+        assert params["slurm_srun_args"] == ["--cpu-bind=none"]
+
+    def test_srun_args_override_is_respected(self):
+        """An explicit srun_args list (including empty) overrides the default."""
+        _, disabled = SlurmConfig(name="job", slurm_srun_args=[]).to_executor_kwargs()
+        assert disabled["slurm_srun_args"] == []
+        _, custom = SlurmConfig(name="job", slurm_srun_args=["--cpu-bind=cores"]).to_executor_kwargs()
+        assert custom["slurm_srun_args"] == ["--cpu-bind=cores"]
 
     def test_folder_is_returned_separately(self):
         folder, params = SlurmConfig(folder="/tmp/logs").to_executor_kwargs()


### PR DESCRIPTION
## Problem
`noether-train-submit-job` launches training via submitit, whose inner `srun` applies per-task CPU binding by default. On clusters whose GPU-partition CPU mask is non-contiguous this fails with `srun: error: Unable to satisfy cpu bind request`, aborting the job step **before** the program starts.

## Fix
Add a `slurm_srun_args` field to `SlurmConfig`, defaulting to `['--cpu-bind=none']`, applied in `to_executor_kwargs` so every submission gets it regardless of recipe. Overridable: set `slurm_srun_args: []` to restore srun's default binding, or pass custom args.

## Validation
- Unit tests for the default, override, and empty cases.
- Confirmed the rendered sbatch `srun` line contains `--cpu-bind=none`.
- A real submission on the affected cluster completed successfully (previously aborted at srun launch).