### PR TITLE
fix: serialize config-passed normalizer stats as plain lists in hp_resolved.yaml

### DIFF
--- a/src/noether/core/configs/hyperparameters.py
+++ b/src/noether/core/configs/hyperparameters.py
@@ -98,15 +98,13 @@ class Hyperparameters:
         """
 
         with open(out_file_uri, "w") as f:
-            # ``serialize_as_any=True`` preserves subclass-specific fields when
-            # the schema annotates a polymorphic field as the base class
-            # (e.g. ``trainer.callbacks: list[CallBackBaseConfig]``) — without
-            # it, Pydantic strips fields like ``OfflineLossCallbackConfig.dataset_key``
-            # from the dump because they don't exist on the annotated base, and
-            # the saved YAML fails to re-validate.
-            config_dict = stage_hyperparameters.model_dump(
-                exclude_unset=True, exclude_computed_fields=True, serialize_as_any=True
-            )
+            # Polymorphic fields annotated with a base class (e.g.
+            # ``trainer.callbacks``) keep their subclass-specific fields
+            # because ``Discriminated`` serializes by runtime class — a global
+            # ``serialize_as_any=True`` must NOT be used here, as it would
+            # duck-type *all* values and bypass field-level serializers (e.g.
+            # ``TorchTensor``), pickling tensors as ``!!binary`` YAML blobs.
+            config_dict = stage_hyperparameters.model_dump(exclude_unset=True, exclude_computed_fields=True)
             _inject_discriminator_fields(stage_hyperparameters, config_dict)
             config_dict["config_schema_kind"] = stage_hyperparameters.config_schema_kind
             yaml.dump(config_dict, f, sort_keys=False)

--- a/src/noether/core/schemas/lib.py
+++ b/src/noether/core/schemas/lib.py
@@ -5,7 +5,8 @@ from abc import ABC
 from functools import partial
 from typing import Any, ClassVar, TypeVar, get_type_hints
 
-from pydantic import BaseModel, BeforeValidator
+from pydantic import BaseModel, GetCoreSchemaHandler
+from pydantic_core import core_schema
 
 
 class _RegistryBase(BaseModel, ABC):
@@ -65,13 +66,37 @@ def resolve_config_class[T: _RegistryBase](kind: str, base_cls: type[T]) -> type
     )
 
 
-def Discriminated(registry_cls: type[_RegistryBase]):
-    """
-    Returns a BeforeValidator that instantiates components based on their registry keys.
-    Usage: field: Annotated[Any, Discriminated(MyComponent)]
+class Discriminated:
+    """Annotated-metadata marker for polymorphic registry config fields.
+
+    Usage: ``field: Annotated[Any, Discriminated(MyComponent)]``
+
+    Contributes two behaviors to the annotated field:
+
+    * **Validation** — dicts are instantiated to the concrete config class
+      resolved from their registry key (``kind``/type field), like a
+      ``BeforeValidator`` around :func:`_discriminated_validator`.
+    * **Serialization** — the value is serialized by its *runtime* class
+      (equivalent to ``pydantic.SerializeAsAny``), so subclass-only fields
+      survive ``model_dump`` even when the field is annotated with the base
+      class. Unlike a global ``model_dump(serialize_as_any=True)``, this
+      duck-types only the model boundary and still respects field-level
+      serializers nested inside the concrete config (e.g. ``TorchTensor``).
     """
 
-    return BeforeValidator(partial(_discriminated_validator, registry_cls=registry_cls))
+    def __init__(self, registry_cls: type[_RegistryBase]) -> None:
+        self.registry_cls = registry_cls
+
+    def __get_pydantic_core_schema__(self, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        schema = core_schema.no_info_before_validator_function(
+            partial(_discriminated_validator, registry_cls=self.registry_cls),
+            handler(source_type),
+        )
+        schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
+            lambda value, serializer: serializer(value),
+            schema=core_schema.any_schema(),
+        )
+        return schema
 
 
 def _discriminated_validator(item, registry_cls: type[_RegistryBase]) -> Any:

--- a/tests/unit/noether/core/configs/test_hyperparameters.py
+++ b/tests/unit/noether/core/configs/test_hyperparameters.py
@@ -11,8 +11,10 @@ import yaml
 from pydantic import BaseModel, Field, RootModel
 
 from noether.core.configs.hyperparameters import Hyperparameters, _inject_discriminator_fields
-from noether.core.schemas.lib import _RegistryBase
+from noether.core.schemas.lib import Discriminated, _RegistryBase
 from noether.core.schemas.schema import ConfigSchema
+from noether.data.base.dataset import DatasetBaseConfig
+from noether.data.preprocessors.normalizers import MeanStdNormalizerConfig
 
 
 class DimSpec(RootModel[OrderedDict[str, int]]):
@@ -36,6 +38,12 @@ def mock_params() -> MockHyperparameters:
         trainer=dict(kind="mock", effective_batch_size=32, callbacks=[], max_epochs=1),
         spec=DimSpec({"def": 1, "abc": 2}),
     )
+
+
+class _NormalizedDatasetConfig(DatasetBaseConfig):
+    """Dataset config stub whose ``kind`` resolves back to this class on reload."""
+
+    kind: str | None = "tests.unit.noether.core.configs.test_hyperparameters._NormalizedDatasetConfig"
 
 
 class _RegistryStub(_RegistryBase):
@@ -238,19 +246,88 @@ class TestHyperparameters:
         with pytest.raises(FileNotFoundError, match="resolved hyperparameters"):
             Hyperparameters.load_resolved(tmp_path / "does_not_exist.yaml")
 
-    def test_save_resolved_preserves_polymorphic_subclass_fields(self, tmp_path: Path):
-        """When a field is annotated with a base type but holds a subclass
-        instance, ``save_resolved`` must preserve the subclass-specific fields.
+    def test_save_resolved_serializes_tensor_stats_as_plain_lists(self, tmp_path: Path):
+        """Normalizer stats passed via the config (``TorchTensor`` fields) must be
+        written as plain YAML lists, not pickled tensors.
 
-        Without ``serialize_as_any=True``, Pydantic walks the *annotated* base
-        type when serializing and silently drops fields that exist only on the
-        subclass — e.g. ``OfflineLossCallbackConfig.dataset_key`` disappears
-        from a ``list[CallBackBaseConfig]`` dump, breaking re-validation.
+        ``model_dump(serialize_as_any=True)`` duck-types serialization from the
+        runtime value and bypasses the ``PlainSerializer`` of the ``TorchTensor``
+        annotation, leaving raw ``torch.Tensor`` objects in the dump —
+        ``yaml.dump`` then pickles them as ``!!binary`` blobs that neither
+        ``yaml.safe_load`` (noether-eval, notebooks) nor ``yaml.full_load``
+        (``load_resolved``) can read back.
+        """
+        os.environ["MASTER_PORT"] = "12345"
+
+        params = MockHyperparameters(
+            output_path="/tmp",
+            datasets={
+                "train": _NormalizedDatasetConfig(
+                    dataset_normalizers={"pressure": MeanStdNormalizerConfig(mean=[1.0, 2.0], std=[0.5, 0.25])}
+                )
+            },
+            model=dict(name="abc", kind="xyz"),
+            trainer=dict(kind="mock", effective_batch_size=32, callbacks=[], max_epochs=1),
+            spec=DimSpec({"def": 1, "abc": 2}),
+        )
+
+        out_file = tmp_path / "hp.yaml"
+        Hyperparameters.save_resolved(params, out_file)
+
+        raw = out_file.read_text()
+        assert "!!binary" not in raw
+        assert "!!python/object" not in raw
+
+        # noether-eval and notebooks load with yaml.safe_load — this must not raise.
+        with open(out_file) as f:
+            content = yaml.safe_load(f)
+
+        normalizer = content["datasets"]["train"]["dataset_normalizers"]["pressure"]
+        assert normalizer["mean"] == [1.0, 2.0]
+        assert normalizer["std"] == [0.5, 0.25]
+
+    def test_load_resolved_round_trips_tensor_stats(self, tmp_path: Path):
+        """``load_resolved`` reads back a config whose normalizer stats came from
+        the config (not a STATS_FILE) — and the tensor values survive."""
+        os.environ["MASTER_PORT"] = "12345"
+
+        params = MockHyperparameters(
+            output_path="/tmp",
+            datasets={
+                "train": _NormalizedDatasetConfig(
+                    dataset_normalizers={"pressure": MeanStdNormalizerConfig(mean=[1.0, 2.0], std=[0.5, 0.25])}
+                )
+            },
+            model=dict(name="abc", kind="xyz"),
+            trainer=dict(kind="mock", effective_batch_size=32, callbacks=[], max_epochs=1),
+            spec=DimSpec({"def": 1, "abc": 2}),
+        )
+
+        out_file = tmp_path / "hp.yaml"
+        Hyperparameters.save_resolved(params, out_file)
+
+        loaded = Hyperparameters.load_resolved(out_file)
+
+        normalizer = loaded.datasets["train"].dataset_normalizers["pressure"]
+        assert isinstance(normalizer, MeanStdNormalizerConfig)
+        assert normalizer.mean.tolist() == [1.0, 2.0]
+        assert normalizer.std.tolist() == [0.5, 0.25]
+
+    def test_save_resolved_preserves_polymorphic_subclass_fields(self, tmp_path: Path):
+        """When a ``Discriminated`` field is annotated with a base type but
+        holds a subclass instance, ``save_resolved`` must preserve the
+        subclass-specific fields.
+
+        ``Discriminated`` serializes by runtime class — without it, Pydantic
+        walks the *annotated* base type when serializing and silently drops
+        fields that exist only on the subclass — e.g.
+        ``OfflineLossCallbackConfig.dataset_key`` disappears from a
+        ``list[CallBackBaseConfig]`` dump, breaking re-validation.
         """
         os.environ["MASTER_PORT"] = "12345"
 
         class _PolymorphicHP(ConfigSchema):
-            items: list[_RegistryStub] = Field(default_factory=list)
+            items: list[Annotated[_RegistryStub, Discriminated(_RegistryStub)]] = Field(default_factory=list)
 
         params = _PolymorphicHP(
             output_path="/tmp",


### PR DESCRIPTION
## Problem

Normalization stats passed via the config (rather than the `STATS_FILE` next to the dataset) were saved in `hp_resolved.yaml` as pickled `!!binary` blobs:

```yaml
mean: !!python/object/apply:torch._utils._rebuild_tensor_v2
- !!python/object/apply:torch.storage._load_from_bytes
  - !!binary |
      gAKKCmz8nEb5IGqoUBku...
```

This breaks `noether-eval` and notebook loading (`yaml.safe_load` rejects the tags), and even `Hyperparameters.load_resolved` itself (`yaml.full_load` refuses `!!python/object/apply`).

## Root cause

#218 added `serialize_as_any=True` to `Hyperparameters.save_resolved` to keep subclass-only fields on polymorphic slots (e.g. `trainer.callbacks: list[CallBackBaseConfig]`). However, the *global* flag duck-types serialization of **every** value from its runtime type, which bypasses field-level serializers — including the `PlainSerializer` on the `TorchTensor` annotation used by normalizer configs. Raw `torch.Tensor` objects survived `model_dump()` and `yaml.dump` pickled them.

## Fix

Remove the global flag and move runtime-class serialization into the `Discriminated` annotation itself: it now implements `__get_pydantic_core_schema__`, keeping its before-validator and additionally attaching `SerializeAsAny`-style serialization to the field. This duck-types only the model boundary, so:

- subclass-only fields on all polymorphic slots (`model`, `trainer`, `datasets`, `tracker`, `pipeline`, `dataset_normalizers`, `callbacks`, `eval_callbacks`) still survive the dump — the guarantee #218 introduced the flag for, and
- nested field serializers (e.g. `TorchTensor`'s `.tolist()`) are respected again, so stats serialize as plain YAML lists.

## Tests

- `test_save_resolved_serializes_tensor_stats_as_plain_lists` — asserts no `!!binary`/`!!python/object` tags and that the YAML is `yaml.safe_load`-able. **Fails before the fix** with exactly the reported blobs.
- `test_load_resolved_round_trips_tensor_stats` — config-passed stats survive a full save/load round trip (also fails before the fix).
- Updated `test_save_resolved_preserves_polymorphic_subclass_fields` to use the `Discriminated` annotation (matching real usage), confirming the #218 guarantee holds without the global flag.

Full suite: 1447 passed, 25 skipped. `ruff`, `mypy` clean.