### PR TITLE
fix: noether-eval failing with unrecognized arguments when --hp is supplied

### DIFF
--- a/docs/source/guides/inference/how_to_run_evaluation_on_trained_models.rst
+++ b/docs/source/guides/inference/how_to_run_evaluation_on_trained_models.rst
@@ -199,9 +199,12 @@ Run with either:
    noether-eval run_dir=outputs/2026-01-10_abc12 --hp configs/eval_extra.yaml
    noether-eval run_dir=outputs/2026-01-10_abc12 --hp configs/save_predictions.yaml
 
-When ``--hp`` is supplied, that file becomes the Hydra base config — use this
-escape hatch for power users composing their own inference/eval pipeline. The
-``run_dir`` argument and CLI overrides above still work the same way.
+When ``--hp`` is supplied together with ``run_dir``, the file is merged on top
+of the training config: dict keys merge recursively, while lists (such as
+``trainer.callbacks``) are **replaced** — so the YAMLs above run *only* the
+listed callback. The ``run_dir`` argument and CLI overrides above still work
+the same way. Supplying ``--hp`` *without* ``run_dir`` is an escape hatch for
+power users composing their own complete inference/eval config.
 
 **Flipping a flag on an existing callback (no YAML)** — when the change is
 just enabling a feature already supported by a configured callback (e.g.

--- a/src/noether/inference/cli/main_inference.py
+++ b/src/noether/inference/cli/main_inference.py
@@ -72,6 +72,22 @@ def _build_run_dir(path_values: dict[str, str]) -> Path | None:
     return None
 
 
+def _pop_user_hp_arg(argv: list[str]) -> tuple[str | None, list[str]]:
+    """Extract a user-supplied ``--hp <path>`` pair from ``argv``.
+
+    Returns the path (or ``None`` if ``--hp`` is absent) and the remaining args.
+
+    Raises:
+        ValueError: If ``--hp`` is the last argument or not followed by a ``.yaml`` path.
+    """
+    if "--hp" not in argv:
+        return None, argv
+    i = argv.index("--hp")
+    if i + 1 >= len(argv) or not argv[i + 1].endswith(".yaml"):
+        raise ValueError("--hp must be followed by a path to a .yaml file")
+    return argv[i + 1], argv[:i] + argv[i + 2 :]
+
+
 def _inject_hp_resolved_into_argv() -> None:
     """Pre-process ``sys.argv`` so Hydra loads ``run_dir/hp_resolved.yaml`` as
     the base config.
@@ -80,20 +96,23 @@ def _inject_hp_resolved_into_argv() -> None:
     ``trainer.max_epochs=1``) without the Hydra ``+`` force-add prefix, the
     same way ``noether-train --hp <config>.yaml`` works.
 
-    A user-supplied ``--hp <other.yaml>`` takes precedence and is left alone
-    (escape hatch for power users composing their own eval config).
+    A user-supplied ``--hp <extra.yaml>`` combined with ``run_dir=...`` is merged
+    on top of the training config (dicts merge recursively, lists are replaced) —
+    used to add post-training-only keys such as extra callbacks. ``--hp`` without
+    ``run_dir`` is left alone (escape hatch for power users composing their own
+    complete eval config).
     """
     if len(sys.argv) < 2:
         return
     if "--help" in sys.argv or "-h" in sys.argv:
         return
-    if "--hp" in sys.argv:
-        return
 
     path_values, remaining = _pop_eval_path_args(sys.argv[1:])
     run_dir = _build_run_dir(path_values)
     if run_dir is None:
-        return  # let setup_hydra/main raise a clearer error
+        return  # --hp-only escape hatch, or let setup_hydra/main raise a clearer error
+
+    user_hp, remaining = _pop_user_hp_arg(remaining)
 
     hp_resolved = run_dir / "hp_resolved.yaml"
     if not hp_resolved.exists():
@@ -109,6 +128,20 @@ def _inject_hp_resolved_into_argv() -> None:
     # writes alongside the training run and resume picks the right checkpoint.
     with open(safe_hp) as f:
         hp_data = yaml.safe_load(f)
+
+    if user_hp is not None:
+        user_hp_path = Path(user_hp)
+        if not user_hp_path.exists():
+            raise FileNotFoundError(f"--hp file does not exist ('{user_hp_path.as_posix()}')")
+        with open(user_hp_path) as f:
+            user_data = yaml.safe_load(f) or {}
+        # Merge the user's extra config on top of the training config and write it back to the sanitized temp copy
+        # that Hydra will load as the base config. Interpolations (e.g. `${model.forward_properties}`) are kept
+        # unresolved for Hydra to resolve at compose time.
+        merged = OmegaConf.merge(OmegaConf.create(hp_data), OmegaConf.create(user_data))
+        hp_data = OmegaConf.to_container(merged, resolve=False)
+        with open(safe_hp, "w") as f:
+            yaml.safe_dump(hp_data, f, sort_keys=False)
     stage_name = hp_data.get("stage_name") or ""
     inferred_run_id = run_dir.parent.name if stage_name else run_dir.name
     run_id = hp_data.get("run_id") or inferred_run_id

--- a/src/noether/training/cli/__init__.py
+++ b/src/noether/training/cli/__init__.py
@@ -7,17 +7,20 @@ from pathlib import Path
 from omegaconf import DictConfig, OmegaConf
 
 
-def _rewrite_hydra_args(relpath, insert_at: int):
+def _rewrite_hydra_args(relpath):
     hp = Path(os.getcwd()) / relpath
     if not hp.exists():
         raise FileNotFoundError(f"--hp file does not exist ('{hp.as_posix()}')")
 
     cn = hp.name
     cp = hp.parent.as_posix()
-    sys.argv.insert(insert_at, "-cp")
-    sys.argv.insert(insert_at + 1, cp)
-    sys.argv.insert(insert_at + 2, "-cn")
-    sys.argv.insert(insert_at + 3, cn)
+    # Insert directly after the program name so that all remaining args form a single contiguous positional group.
+    # Argparse cannot parse positionals split around optionals (e.g. `run_dir=... -cp <dir> -cn <name> overrides...`
+    # fails with "unrecognized arguments"), which happens when `--hp` is not the first argument.
+    sys.argv.insert(1, "-cp")
+    sys.argv.insert(2, cp)
+    sys.argv.insert(3, "-cn")
+    sys.argv.insert(4, cn)
 
     # backup the --hp argument to log it to the tracker (hydra operates on absolute path)
 
@@ -59,7 +62,7 @@ def setup_hydra():
 
     if sys.argv[1].endswith(".yaml"):
         relpath = sys.argv.pop(1)
-        _rewrite_hydra_args(relpath, 1)
+        _rewrite_hydra_args(relpath)
     else:
         i = 0
         while i < len(sys.argv) - 1:
@@ -68,7 +71,7 @@ def setup_hydra():
                     raise ValueError(f"invalid --hp file {sys.argv[i + 1]}")
                 sys.argv.pop(i)  # remove --hp
                 relpath = sys.argv.pop(i)
-                _rewrite_hydra_args(relpath, i)
+                _rewrite_hydra_args(relpath)
                 break
             i += 1
 

--- a/tests/unit/noether/inference/test_cli.py
+++ b/tests/unit/noether/inference/test_cli.py
@@ -142,13 +142,65 @@ class TestInjectHpResolved:
         assert "++run_id='my_run'" in sys.argv
         assert "++stage_name=train" in sys.argv
 
-    def test_no_op_when_user_supplies_hp(self, tmp_path, monkeypatch):
-        original = ["noether-eval", "--hp", "configs/eval.yaml", "run_dir=outputs/abc"]
+    def test_no_op_when_user_supplies_hp_without_run_dir(self, tmp_path, monkeypatch):
+        """`--hp` without `run_dir` is the power-user escape hatch: argv is left alone."""
+        original = ["noether-eval", "--hp", "configs/eval.yaml", "tracker=disabled"]
         monkeypatch.setattr(sys, "argv", list(original))
 
         main_inference._inject_hp_resolved_into_argv()
 
         assert sys.argv == original
+
+    def test_merges_user_hp_on_top_of_training_config(self, tmp_path, monkeypatch):
+        """`run_dir=... --hp extra.yaml` merges the user's yaml onto hp_resolved.yaml
+        (dicts merge recursively, lists are replaced) and Hydra loads the merged file."""
+        run_dir = self._make_run_dir(
+            tmp_path,
+            {"run_id": "abc", "trainer": {"max_epochs": 100, "callbacks": [{"kind": "TrainCallback"}]}},
+        )
+        user_hp = tmp_path / "eval_extra.yaml"
+        user_hp.write_text(yaml.safe_dump({"trainer": {"callbacks": [{"kind": "OfflineLossCallback"}]}}))
+        monkeypatch.setattr(
+            sys, "argv", ["noether-eval", f"run_dir={run_dir}", "--hp", str(user_hp), "tracker=disabled"]
+        )
+
+        main_inference._inject_hp_resolved_into_argv()
+
+        # The user's --hp is consumed; Hydra is pointed at the merged temp copy.
+        assert sys.argv[1] == "--hp"
+        merged = yaml.safe_load(Path(sys.argv[2]).read_text())
+        assert merged["trainer"]["max_epochs"] == 100  # training key preserved
+        assert merged["trainer"]["callbacks"] == [{"kind": "OfflineLossCallback"}]  # list replaced
+        assert sys.argv.count("--hp") == 1
+        assert str(user_hp) not in sys.argv
+        assert "tracker=disabled" in sys.argv
+        assert "++resume_run_id='abc'" in sys.argv
+
+    def test_user_hp_keeps_interpolations_unresolved(self, tmp_path, monkeypatch):
+        """Interpolations in the user's --hp yaml survive the merge for Hydra to resolve."""
+        run_dir = self._make_run_dir(tmp_path, {"run_id": "abc", "model": {"forward_properties": ["p"]}})
+        user_hp = tmp_path / "extra.yaml"
+        user_hp.write_text(yaml.safe_dump({"props": "${model.forward_properties}"}))
+        monkeypatch.setattr(sys, "argv", ["noether-eval", f"run_dir={run_dir}", "--hp", str(user_hp)])
+
+        main_inference._inject_hp_resolved_into_argv()
+
+        merged = yaml.safe_load(Path(sys.argv[2]).read_text())
+        assert merged["props"] == "${model.forward_properties}"
+
+    def test_raises_when_user_hp_missing(self, tmp_path, monkeypatch):
+        run_dir = self._make_run_dir(tmp_path, {"run_id": "abc"})
+        monkeypatch.setattr(sys, "argv", ["noether-eval", f"run_dir={run_dir}", "--hp", "does/not/exist.yaml"])
+
+        with pytest.raises(FileNotFoundError, match="--hp file does not exist"):
+            main_inference._inject_hp_resolved_into_argv()
+
+    def test_raises_when_hp_flag_has_no_value(self, tmp_path, monkeypatch):
+        run_dir = self._make_run_dir(tmp_path, {"run_id": "abc"})
+        monkeypatch.setattr(sys, "argv", ["noether-eval", f"run_dir={run_dir}", "--hp"])
+
+        with pytest.raises(ValueError, match="--hp must be followed"):
+            main_inference._inject_hp_resolved_into_argv()
 
     def test_no_op_for_help_flag(self, monkeypatch):
         original = ["noether-eval", "--help"]
@@ -175,6 +227,70 @@ class TestInjectHpResolved:
         main_inference._inject_hp_resolved_into_argv()
 
         assert sys.argv == original
+
+
+class TestArgvRewriteEndToEnd:
+    """Chain `_inject_hp_resolved_into_argv` through the *real* `setup_hydra` and assert the
+    final argv parses with Hydra's actual argparse parser.
+
+    Regression guard: overrides are positional args for argparse, which can only consume them
+    as one contiguous group — `setup_hydra` inserting `-cp/-cn` mid-argv used to fail with
+    `unrecognized arguments: hydra.run.dir=. ...`.
+    """
+
+    def _make_run_dir(self, tmp_path):
+        run_dir = tmp_path / "outputs" / "abc"
+        run_dir.mkdir(parents=True)
+        (run_dir / "hp_resolved.yaml").write_text(yaml.safe_dump({"run_id": "abc"}))
+        return run_dir
+
+    def _rewrite_and_parse(self):
+        from hydra._internal.utils import get_args_parser
+        from omegaconf import OmegaConf
+
+        from noether.training.cli import setup_hydra
+
+        main_inference._inject_hp_resolved_into_argv()
+        try:
+            setup_hydra()
+        finally:
+            OmegaConf.clear_resolver("seed")  # setup_hydra registers it; clear so repeated calls don't collide
+        args = get_args_parser().parse_args(sys.argv[1:])
+        assert args.config_name == "hp_resolved.yaml"
+        return args
+
+    def test_run_dir_syntax(self, tmp_path, monkeypatch):
+        run_dir = self._make_run_dir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["noether-eval", f"run_dir={run_dir}", "tracker=disabled"])
+
+        args = self._rewrite_and_parse()
+
+        assert "tracker=disabled" in args.overrides
+        assert "++resume_run_id='abc'" in args.overrides
+        assert "hydra.run.dir=." in args.overrides
+
+    def test_run_dir_with_user_hp(self, tmp_path, monkeypatch):
+        run_dir = self._make_run_dir(tmp_path)
+        user_hp = tmp_path / "extra.yaml"
+        user_hp.write_text(yaml.safe_dump({"tracker": "disabled"}))
+        monkeypatch.setattr(sys, "argv", ["noether-eval", f"run_dir={run_dir}", "--hp", str(user_hp)])
+
+        args = self._rewrite_and_parse()
+
+        assert "hydra.run.dir=." in args.overrides
+
+    def test_legacy_trio_syntax(self, tmp_path, monkeypatch):
+        run_dir = self._make_run_dir(tmp_path)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["noether-eval", f"input_dir={run_dir.parent}", "run_id=abc", "trainer.max_epochs=1"],
+        )
+
+        args = self._rewrite_and_parse()
+
+        assert "trainer.max_epochs=1" in args.overrides
+        assert "hydra.run.dir=." in args.overrides
 
 
 @patch(_MODULE_PATH + ".InferenceRunner")

--- a/tests/unit/noether/training/cli/test_setup_hydra.py
+++ b/tests/unit/noether/training/cli/test_setup_hydra.py
@@ -1,0 +1,60 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+import sys
+
+import pytest
+from hydra._internal.utils import get_args_parser
+from omegaconf import OmegaConf
+
+from noether.training.cli import setup_hydra
+
+
+@pytest.fixture
+def hp_file(tmp_path, monkeypatch):
+    """A minimal config yaml; cwd is moved to tmp_path so relative --hp paths resolve."""
+    hp = tmp_path / "config.yaml"
+    hp.write_text("tracker: disabled\n")
+    monkeypatch.chdir(tmp_path)
+    yield hp
+    # setup_hydra registers the `seed` resolver; clear it so repeated calls across tests don't collide.
+    OmegaConf.clear_resolver("seed")
+
+
+def _assert_hydra_parseable() -> None:
+    """Hydra's argparse parser must accept the rewritten argv.
+
+    Argparse can only consume positionals (Hydra overrides) as a single contiguous
+    group, so `-cp/-cn` must not be inserted between overrides.
+    """
+    args = get_args_parser().parse_args(sys.argv[1:])
+    assert args.config_name == "config.yaml"
+
+
+class TestSetupHydra:
+    def test_hp_first(self, hp_file, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["noether-train", "--hp", "config.yaml", "trainer.max_epochs=1"])
+
+        setup_hydra()
+
+        _assert_hydra_parseable()
+
+    def test_positional_yaml(self, hp_file, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["noether-train", "config.yaml", "trainer.max_epochs=1"])
+
+        setup_hydra()
+
+        _assert_hydra_parseable()
+
+    def test_override_before_hp(self, hp_file, monkeypatch):
+        """Regression: an override before --hp (e.g. `noether-eval run_dir=... --hp extra.yaml`)
+        used to split Hydra's positional overrides around -cp/-cn, making argparse fail with
+        `unrecognized arguments: hydra.run.dir=. ...`."""
+        monkeypatch.setattr(sys, "argv", ["noether-eval", "tracker=disabled", "--hp", "config.yaml"])
+
+        setup_hydra()
+
+        _assert_hydra_parseable()
+        # All overrides (user + appended hydra.* ones) form one contiguous positional group.
+        args = get_args_parser().parse_args(sys.argv[1:])
+        assert "tracker=disabled" in args.overrides
+        assert "hydra.run.dir=." in args.overrides


### PR DESCRIPTION
## Problem

As reported: passing an hp file to `noether-eval` fails with

```
noether-eval: error: unrecognized arguments: hydra.run.dir=. hydra.output_subdir=null hydra/hydra_logging=disabled hydra/job_logging=disabled
```

regardless of the config file's content — including the exact commands from the docs (`noether-eval run_dir=... --hp configs/eval_extra.yaml`).

## Root cause

Two stacked bugs:

1. **argparse positional split** — `setup_hydra` rewrites `--hp <file>` into `-cp <dir> -cn <name>` *at the flag's original position*, then appends four `hydra.*` overrides at the end of argv. Hydra's CLI is plain argparse, which can only consume positional overrides as one contiguous group. Any override before `--hp` (e.g. `run_dir=...`) splits the positionals around the inserted flags → the trailing overrides become "unrecognized arguments".
2. **`--hp` disabled `run_dir` handling** — `_inject_hp_resolved_into_argv` returned early whenever `--hp` was present, so `run_dir=` was left in argv as a bogus config override and no resume fields were injected, contradicting the documented behavior ("the `run_dir` argument and CLI overrides still work the same way").

## Fix

- `setup_hydra` now inserts `-cp/-cn` directly after the program name, keeping all overrides contiguous (fixes `noether-train` and `noether-eval` alike).
- `noether-eval run_dir=... --hp extra.yaml` merges the user's yaml on top of the run's `hp_resolved.yaml` (dicts merge recursively, lists — e.g. `trainer.callbacks` — are replaced) and injects the resume overrides as usual. `--hp` *without* `run_dir` keeps the existing power-user escape hatch (complete self-composed config).
- Docs updated to state the merge semantics explicitly.

## Tests

- New `tests/unit/noether/training/cli/test_setup_hydra.py`: validates the rewritten argv against Hydra's *actual* argparse parser for all CLI shapes (`--hp` first, positional yaml, override-before-`--hp` regression).
- `tests/unit/noether/inference/test_cli.py`: merge semantics, interpolation preservation, error paths, plus a `TestArgvRewriteEndToEnd` class chaining both argv rewrite stages through the real `setup_hydra`, covering the plain `run_dir=` syntax and the legacy `input_dir=/run_id=` trio.
- Verified the regression test fails against the unfixed code.
- Full unit suite: 1453 passed; ruff + mypy clean.

> **Note on merge semantics:** lists are *replaced* (standard OmegaConf), so an `--hp` file with `trainer.callbacks` runs only the listed callbacks. The old docs said "add ... callbacks" — if append semantics were intended, that's a follow-up discussion.