### PR TITLE
feat(data): DrivAerStar EnSight -> chunked Zarr preprocessing

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Welcome to the Noether Framework documentation. Here you will find available API
    noether/dataset_zoo
    noether/recipe_zoo
    noether/understanding_the_data_pipeline
+   noether/efficient_zarr_store
 
 
 .. toctree::

--- a/docs/source/noether/efficient_zarr_store.rst
+++ b/docs/source/noether/efficient_zarr_store.rst
@@ -138,6 +138,19 @@ Validate a converted store (equivalence vs ``.pt`` and read-amplification) with:
    uv run python -m noether.data.zarr_store.benchmark \
        --pt-root /path/to/dataset --zarr-root /path/to/dataset/zarr_store
 
+Compute normalization statistics (``stats.yaml`` inputs) directly from a store with
+:func:`~noether.data.zarr_store.statistics.calculate_store_statistics` — one streaming
+pass yields ``{field}_mean/std/min/max``, the logscale moments and the global
+``raw_pos_min``/``raw_pos_max`` position bounds::
+
+   uv run python -m noether.data.zarr_store.statistics \
+       --store oci://bucket@namespace/zarr_store \
+       --split-file train_design_ids.txt \
+       --workers 8 --read-concurrency 4 --output-json stats.json
+
+``--split-file`` restricts the pass to the ids listed in a file (a bare name is resolved
+against the store root); ids missing from the store are skipped with a warning.
+
 Notes and limitations
 ---------------------
 
@@ -149,3 +162,13 @@ Notes and limitations
   and the datasets built on it read directly from object storage (raise the dataset's
   ``read_concurrency`` there to hide per-request latency). The ``store_factory`` hook
   remains available for custom backends or instrumentation.
+* **Faster S3 backend (optional).** For ``s3://`` roots, installing the optional
+  ``obstore`` package (``uv sync --extra obstore``) makes
+  :func:`~noether.data.zarr_store.stores.make_store` transparently use the Rust-backed
+  :class:`zarr.storage.ObjectStore` instead of :class:`~zarr.storage.FsspecStore`;
+  credentials/region/endpoint come from the standard ``AWS_*`` environment variables.
+  It is a drop-in speedup (≈2× on the warm per-sample read path in benchmarks) and falls
+  back to fsspec automatically when obstore is absent or the URL is not ``s3://``. OCI is
+  reachable this way via its S3-compatible endpoint (``AWS_ENDPOINT_URL`` +
+  ``s3://bucket/...``) using a Customer Secret Key, but the default ``oci://`` path keeps
+  using ``ocifs``/API-key auth.

--- a/docs/source/noether/efficient_zarr_store.rst
+++ b/docs/source/noether/efficient_zarr_store.rst
@@ -1,0 +1,151 @@
+Blob-Storage-Efficient Zarr Store
+=================================
+
+The default CFD layout stores every field of every sample as a separate ``.pt`` file.
+This is simple but ill-suited to blob storage (S3): a sample is many imbalanced
+objects, and because training subsamples only a few thousand points per sample, the
+whole sample is fetched and then mostly discarded — large *read amplification*.
+
+The :mod:`noether.data.zarr_store` package provides a chunked, sharded, pre-shuffled
+`Zarr <https://zarr.dev>`_ alternative that lets the dataloader **read only the points
+it samples**.
+
+Format
+------
+
+Each sample is an independent Zarr *group* holding **one array per field**
+(``surface/position``, ``surface/pressure``, ``volume/velocity``, …): positions are
+float32, physical quantities float16. Storing fields separately means any subset of
+fields can be read without transferring the rest (see the reader's ``fields=`` argument).
+
+Arrays are chunked along the point axis only and packed into a **single whole-array
+shard** by default, so the per-sample object count stays at one object per field while
+individual chunks remain range-readable inside the shard. For datasets whose per-field
+arrays grow large, cap the shard with ``--shard-points`` (rounded down to a whole number
+of chunks; shard bytes ≈ ``shard_points × dim × dtype_size``) — smaller shards bound the
+writer's per-shard memory and a corrupt object's blast radius at the cost of more
+objects. All arrays of a domain share the chunk and shard grid plus the per-sample
+shuffle permutation, so chunk ``c`` addresses the same physical points in every field.
+Points are **shuffled once at write time**, so any contiguous chunk is already a
+uniform-random subset of the sample.
+
+A small ``manifest.json`` at the store root records the global column layout once and
+the per-sample chunk grid (point count, chunk size, shard size, number of chunks).
+
+Why this is fast on S3
+----------------------
+
+* **Partial reads.** Reading one chunk from a sharded array is a byte-range request.
+  Subsampling ``T`` points reads ``ceil(T / chunk_points)`` chunks per array instead of
+  the whole sample — bytes transferred scale with ``T``, not sample size.
+* **Random sampling without scatter.** Because points are pre-shuffled, a *random chunk*
+  is a *random subset*; epoch-to-epoch diversity comes from picking different chunk
+  indices, with no scattered per-point gathers.
+* **Smaller + fewer objects.** float16 + zstd roughly halves field bytes, and one shard
+  per array keeps object count low while preserving chunk-level read granularity.
+
+Converting a dataset
+--------------------
+
+The converter is dataset-agnostic: point it at any FileMap-based ``AeroDataset`` by its
+``kind`` and ``root``, and it reuses the dataset's own ``FileMap``, split lists and
+per-sample ``_load`` (which encode the on-disk layout) — so ShapeNet-Car, DrivAerML,
+AhmedML and DrivAerNet all convert the same way:
+
+.. code-block:: bash
+
+   uv run python -m noether.data.zarr_store.convert \
+       --dataset-kind noether.data.datasets.cfd.DrivAerMLDataset \
+       --root /path/to/drivaerml \
+       --output s3://my-bucket/drivaerml/zarr_store \
+       --splits train test val \
+       --chunk-points 16384 \
+       --workers 16
+
+All requested splits are written into a single store (sample ids are unique across
+splits); unsupported splits are skipped with a warning. Pick ``--chunk-points`` close to
+the training subsample size to minimise read amplification.
+
+The source can also live on object storage: pass ``--source-url`` instead of ``--root``
+(any fsspec location — ``oci://bucket@namespace/prefix``, ``s3://bucket/prefix``, or a
+plain directory) and samples are discovered by listing the prefix and streamed without a
+local staging copy. The dataset's ``FileMap`` is resolved from ``--dataset-kind``. For
+OCI install ``ocifs`` and set ``OCIFS_IAM_TYPE`` (e.g. ``api_key`` to use
+``~/.oci/config``); for S3 install ``s3fs``.
+
+.. code-block:: bash
+
+   OCIFS_IAM_TYPE=api_key uv run python -m noether.data.zarr_store.convert \
+       --dataset-kind noether.data.datasets.cfd.DrivAerNetDataset \
+       --source-url oci://emmi-drivaernet@<namespace>/subsampled_volume10x \
+       --output /data/drivaernet/zarr_store \
+       --chunk-points 16384 --workers 16
+
+``--output`` likewise accepts a local path or any fsspec URL — the writer, manifest and
+reader all resolve store roots through fsspec, so stores can live directly on object
+storage. ``--workers`` converts samples in a **process pool** (each worker owns its
+source handle and writer), so the GIL-bound ``torch.load``/numpy work parallelizes fully;
+the result is bit-identical to a sequential run (shuffles are seeded per sample id).
+
+In code, :func:`noether.data.zarr_store.convert.convert` does the same; for full control
+build a :class:`~noether.data.zarr_store.writer.ZarrStoreWriter` and call
+:func:`~noether.data.zarr_store.convert.convert_aero_dataset` per dataset/split, or
+:func:`~noether.data.zarr_store.convert.convert_fsspec_source` for an fsspec ``.pt`` tree.
+
+Training against the store
+--------------------------
+
+:class:`~noether.data.datasets.cfd.ZarrShapeNetCarDataset` reads from the converted store
+and is fully config-driven via
+:class:`~noether.data.datasets.cfd.ZarrShapeNetCarDatasetConfig` (``kind`` already points at
+the dataset, so it resolves through the standard factory). Set ``num_surface_points`` /
+``num_volume_points`` to chunk-subsample at read time — the pipeline's
+``PointSamplingSampleProcessor`` then becomes a no-op automatically (it skips whenever the
+requested count is at least the available points). Leave them ``None`` for full-sample reads
+at evaluation. ``num_geometry_points`` additionally emits ``geometry_position`` (an
+independent surface draw) for AB-UPT.
+
+.. code-block:: python
+
+   from noether.data.datasets.cfd import ZarrShapeNetCarDataset, ZarrShapeNetCarDatasetConfig
+
+   cfg = ZarrShapeNetCarDatasetConfig(
+       root="/path/to/dataset/zarr_store",
+       split="train",
+       num_surface_points=3586,
+       num_volume_points=4096,
+       num_geometry_points=3586,  # optional, AB-UPT geometry input
+       read_concurrency=1,  # raise (~chunks/sample) to hide latency on S3
+   )
+   dataset = ZarrShapeNetCarDataset(cfg)
+
+Because the config carries a ``kind`` of ``noether.data.datasets.cfd.ZarrShapeNetCarDataset``,
+it can be selected from YAML/Hydra exactly like the other datasets (``kind: ${dataset_kind}``)
+with the ``num_*`` fields set on the dataset config.
+
+:class:`~noether.data.datasets.cfd.ZarrDrivAerNetDataset` /
+:class:`~noether.data.datasets.cfd.ZarrDrivAerNetDatasetConfig` work the same way for
+DrivAerNet(++): ``root`` may be a remote store
+(e.g. ``oci://emmi-drivaernet@frwnorq7ern2/zarr_store``), and the split files
+(``{train,val,test}_design_ids.txt``) plus blacklists (``blacklist.txt``,
+``blacklist2.txt``) are read from the store root via fsspec, so the store is
+self-contained. ``filter_categories`` matches the ``.pt`` dataset's behaviour. See
+``recipes/aero_cfd/configs/experiment/drivaernet/ab_upt_zarr.yaml`` for an end-to-end
+AB-UPT experiment against the OCI store.
+
+Validate a converted store (equivalence vs ``.pt`` and read-amplification) with::
+
+   uv run python -m noether.data.zarr_store.benchmark \
+       --pt-root /path/to/dataset --zarr-root /path/to/dataset/zarr_store
+
+Notes and limitations
+---------------------
+
+* float16 fields introduce a small, bounded error (positions stay float32, lossless);
+  set ``--values-dtype float32`` if a field needs full precision.
+* Pre-shuffling reorders points, so stored connectivity (e.g. ``edge_index``) is **not**
+  carried over — the format targets point-cloud sampling, not graph models.
+* Store roots may be fsspec URLs: :class:`~noether.data.zarr_store.reader.ZarrChunkReader`
+  and the datasets built on it read directly from object storage (raise the dataset's
+  ``read_concurrency`` there to hide per-request latency). The ``store_factory`` hook
+  remains available for custom backends or instrumentation.

--- a/docs/source/noether/index.rst
+++ b/docs/source/noether/index.rst
@@ -22,3 +22,6 @@ Get started by exploring the core components and principles of the framework:
 
 * :doc:`understanding_the_data_pipeline`
   How data flows from disk to training batches: point subsampling, epoch semantics, shuffling, and performance characteristics.
+
+* :doc:`efficient_zarr_store`
+  A blob-storage-friendly chunked/sharded Zarr format that subsamples by reading only the chunks it needs, instead of loading whole samples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,20 @@ dependencies = [
     "ocifs>=1.3.4",
 ]
 
+[project.optional-dependencies]
+# Extra raw-dataset preprocessing scripts (e.g. DrivAerStar EnSight -> Zarr) that need a
+# KD-tree for surface-distance fields. Install with `uv sync --extra preprocessing`.
+preprocessing = [
+    "scipy>=1.13",
+]
+# Rust-backed object store for faster s3:// Zarr reads. When installed, the zarr store's
+# make_store() transparently uses zarr.storage.ObjectStore for s3:// URLs (credentials from
+# the standard AWS_* env vars); otherwise it falls back to FsspecStore. Install with
+# `uv sync --extra obstore`.
+obstore = [
+    "obstore>=0.10",
+]
+
 [project.urls]
 Source = "https://github.com/Emmi-AI/noether"
 Docs = "https://noether-docs.emmi.ai/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "psutil>=5.9.0",
     "submitit>=1.5.2",
     # ---
+    "zarr>=3.2.1",
+    "ocifs>=1.3.4",
 ]
 
 [project.urls]

--- a/recipes/aero_cfd/configs/datasets/drivaernet_zarr_dataset.yaml
+++ b/recipes/aero_cfd/configs/datasets/drivaernet_zarr_dataset.yaml
@@ -1,0 +1,53 @@
+# Dataset config for the chunked/sharded Zarr DrivAerNet store.
+# `root` points at a converted Zarr store (local path or fsspec URL such as
+# oci://bucket@namespace/zarr_store) holding manifest.json plus the split/blacklist files.
+# The num_* fields push subsampling into the dataset (chunked reads): they mirror the
+# AB-UPT pipeline anchor/geometry counts so the pipeline's sampling becomes a no-op.
+train:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: train
+  pipeline: ${pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  num_surface_points: ${pipeline.num_surface_anchor_points}
+  num_volume_points: ${pipeline.num_volume_anchor_points}
+  num_geometry_points: ${pipeline.num_geometry_points}
+  read_concurrency: 8
+val:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: val
+  pipeline: ${pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  num_surface_points: ${pipeline.num_surface_anchor_points}
+  num_volume_points: ${pipeline.num_volume_anchor_points}
+  num_geometry_points: ${pipeline.num_geometry_points}
+  read_concurrency: 8
+test:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: test
+  pipeline: ${pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  num_surface_points: ${pipeline.num_surface_anchor_points}
+  num_volume_points: ${pipeline.num_volume_anchor_points}
+  num_geometry_points: ${pipeline.num_geometry_points}
+  read_concurrency: 8
+chunked_test:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: test
+  pipeline: ${inference_pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  # inference anchors are effectively "all points" -> full-sample reads
+  num_surface_points: ${inference_pipeline.num_surface_anchor_points}
+  num_volume_points: ${inference_pipeline.num_volume_anchor_points}
+  num_geometry_points: ${inference_pipeline.num_geometry_points}
+  read_concurrency: 8
+  dataset_wrappers:
+    - kind: noether.data.base.wrappers.RepeatWrapper
+      repetitions: 10

--- a/recipes/aero_cfd/configs/datasets/shapenet_zarr_dataset.yaml
+++ b/recipes/aero_cfd/configs/datasets/shapenet_zarr_dataset.yaml
@@ -1,0 +1,37 @@
+# Dataset config for the chunked/sharded Zarr ShapeNet-Car store.
+# `root` must point at a converted Zarr store (see noether.data.zarr_store.convert).
+# The num_* fields push subsampling into the dataset (chunked reads): they mirror the
+# AB-UPT pipeline anchor/geometry counts so the pipeline's sampling becomes a no-op.
+train:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: train
+  pipeline: ${pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  num_surface_points: ${pipeline.num_surface_anchor_points}
+  num_volume_points: ${pipeline.num_volume_anchor_points}
+  num_geometry_points: ${pipeline.num_geometry_points}
+test:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: test
+  pipeline: ${pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  num_surface_points: ${pipeline.num_surface_anchor_points}
+  num_volume_points: ${pipeline.num_volume_anchor_points}
+  num_geometry_points: ${pipeline.num_geometry_points}
+test_repeat:
+  root: ${dataset_root}
+  kind: ${dataset_kind}
+  split: test
+  pipeline: ${pipeline}
+  dataset_normalizers: ${dataset_normalizers}
+  excluded_properties: ${excluded_properties}
+  num_surface_points: ${pipeline.num_surface_anchor_points}
+  num_volume_points: ${pipeline.num_volume_anchor_points}
+  num_geometry_points: ${pipeline.num_geometry_points}
+  dataset_wrappers:
+    - kind: noether.data.base.wrappers.RepeatWrapper
+      repetitions: 10

--- a/recipes/aero_cfd/configs/experiment/drivaernet/ab_upt_zarr.yaml
+++ b/recipes/aero_cfd/configs/experiment/drivaernet/ab_upt_zarr.yaml
@@ -1,0 +1,44 @@
+# @package _global_
+# AB-UPT on DrivAerNet++ reading from the chunked/sharded Zarr store on OCI.
+# The chunked dataset owns surface/volume anchor + geometry subsampling (via num_* on the
+# dataset config), so the pipeline's anchor/geometry sampling is inert:
+#   - geometry_position_from_dataset=true  -> pipeline uses the dataset's geometry_position
+#   - PointSampling / AnchorPointSampling skip when num_points >= available (rename only)
+# Requires OCIFS_IAM_TYPE=api_key (ocifs reads ~/.oci/config) in the job environment.
+defaults:
+  - override /model: ab_upt
+  - override /tracker: development_tracker
+  - override /optimizer: lion
+  - override /datasets: drivaernet_zarr_dataset
+
+name: drivaernet-ab-upt-zarr
+
+dataset_kind: noether.data.datasets.cfd.ZarrDrivAerNetDataset
+dataset_root: oci://emmi-drivaernet@frwnorq7ern2/zarr_store
+
+pipeline:
+  num_geometry_points: 65536
+  num_geometry_supernodes: 16384
+  num_surface_anchor_points: 16384
+  num_volume_anchor_points: 16384
+  geometry_position_from_dataset: true
+
+inference_pipeline:
+  num_geometry_points: 65536
+  num_geometry_supernodes: 16384
+  num_surface_anchor_points: 1000000000
+  num_volume_anchor_points: 1000000000
+  geometry_position_from_dataset: true
+
+trainer:
+  precision: float16
+
+model:
+  supernode_pooling_config:
+    radius: 0.25
+
+sample_size_property: surface_anchor_position
+chunk_size: ${pipeline.num_surface_anchor_points}
+chunk_properties:
+  - surface_anchor_position
+  - volume_anchor_position

--- a/recipes/aero_cfd/configs/experiment/shapenet/ab_upt_zarr.yaml
+++ b/recipes/aero_cfd/configs/experiment/shapenet/ab_upt_zarr.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+# AB-UPT on ShapeNet-Car reading from the chunked/sharded Zarr store.
+# The chunked dataset owns surface/volume anchor + geometry subsampling (via num_* on the
+# dataset config), so the pipeline's anchor/geometry sampling is inert:
+#   - geometry_position_from_dataset=true  -> pipeline uses the dataset's geometry_position
+#   - PointSampling / AnchorPointSampling skip when num_points >= available (rename only)
+defaults:
+  - override /model: ab_upt
+  - override /tracker: development_tracker
+  - override /optimizer: lion
+  - override /datasets: shapenet_zarr_dataset
+
+name: shapenet-car-ab-upt-zarr
+
+dataset_kind: noether.data.datasets.cfd.ZarrShapeNetCarDataset
+dataset_root: /nfs-gpu/research/datasets/shapenet_car/zarr_store_per_field
+
+model:
+  supernode_pooling_config:
+    radius: 9
+
+pipeline:
+  num_geometry_points: 3586
+  num_geometry_supernodes: 3586
+  num_surface_anchor_points: 3586
+  num_volume_anchor_points: 4096
+  geometry_position_from_dataset: true
+
+trainer:
+  precision: float16

--- a/recipes/aero_cfd/src/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
+++ b/recipes/aero_cfd/src/aero_cfd/pipeline/multistage_pipelines/aero_multistage.py
@@ -59,6 +59,10 @@ class AeroCFDPipelineConfig(PipelineConfig):
     callback (e.g. the showcase eval pipeline) needs it; off by default since variable-sized point clouds
     break batch collation when ``batch_size > 1``."""
 
+    geometry_position_from_dataset: bool = False
+    """If True, the dataset already provides ``geometry_position`` (e.g. the chunked Zarr dataset), so the
+    AB-UPT anchor stage skips duplicating/sampling it from ``surface_position`` and uses it directly."""
+
     seed: int | None = None
     """Random seed for sampling processes."""
     data_specs: ModelDataSpecs
@@ -154,6 +158,7 @@ class AeroMultistagePipeline(MultiStagePipeline):
         self.use_physics_features = (
             pipeline_config.use_physics_features
         )  # Whether to use physics features (i.e., SDF, normals, etc.) as input to the model.
+        self.geometry_position_from_dataset = pipeline_config.geometry_position_from_dataset
 
         surface_spec = pipeline_config.data_specs.domains.get("surface")
         volume_spec = pipeline_config.data_specs.domains.get("volume")
@@ -455,13 +460,20 @@ class AeroMultistagePipeline(MultiStagePipeline):
             "surface_anchor_position",
             "volume_anchor_position",
         ]
+        # When the dataset already supplies ``geometry_position`` (chunked Zarr dataset), use it
+        # directly; otherwise derive it from ``surface_position`` by duplicate-and-subsample.
+        geometry_processors: list[SampleProcessor] = []
+        if not self.geometry_position_from_dataset:
+            geometry_processors = [
+                DuplicateKeysSampleProcessor(key_map={"surface_position": "geometry_position"}),
+                PointSamplingSampleProcessor(
+                    items={"geometry_position"},
+                    num_points=self.num_geometry_points,
+                    seed=None if self.seed is None else self.seed + 1,
+                ),
+            ]
         processors = [
-            DuplicateKeysSampleProcessor(key_map={"surface_position": "geometry_position"}),
-            PointSamplingSampleProcessor(
-                items={"geometry_position"},
-                num_points=self.num_geometry_points,
-                seed=None if self.seed is None else self.seed + 1,
-            ),
+            *geometry_processors,
             SupernodeSamplingSampleProcessor(
                 item="geometry_position",
                 num_supernodes=self.num_geometry_supernodes,

--- a/recipes/aero_cfd/src/aero_cfd/pipeline/sample_processors/anchor_point_sampling.py
+++ b/recipes/aero_cfd/src/aero_cfd/pipeline/sample_processors/anchor_point_sampling.py
@@ -67,6 +67,14 @@ class AnchorPointSamplingSampleProcessor(SampleProcessor):
             generator = None
         first_item_tensor = output_sample[any_item]
         assert torch.is_tensor(first_item_tensor)
+        # If the dataset already subsampled to (at least) the anchor count and no disjoint
+        # query split is needed, the random permutation is a redundant reshuffle: just emit
+        # the ``*_anchor_*`` keys. This lets a chunked dataset own the anchor subsampling.
+        if not self.keep_queries and self.num_points >= len(first_item_tensor):
+            for item in self.items:
+                prefix, postfix = self.to_prefix_and_postfix(item)
+                output_sample[f"{prefix}_anchor_{postfix}"] = output_sample[item]
+            return output_sample
         if self.keep_queries:
             perm = torch.randperm(len(first_item_tensor), generator=generator)
             if len(first_item_tensor) <= self.num_points:

--- a/src/noether/data/base/wrappers/property_subset.py
+++ b/src/noether/data/base/wrappers/property_subset.py
@@ -1,6 +1,7 @@
 #  Copyright © 2025 Emmi AI GmbH. All rights reserved.
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -65,6 +66,8 @@ class PropertySubsetWrapper(DatasetWrapper):
         if not isinstance(properties, set):
             raise TypeError("Properties must be a set.")
         self.properties = properties
+        # cache: does a getitem fn accept the pre_getitem kwargs (more than just idx)?
+        self._accepts_kwargs_cache: dict[str, bool] = {}
 
         # split properties into _getitem_fns
         self._getitem_functions = {}
@@ -88,9 +91,25 @@ class PropertySubsetWrapper(DatasetWrapper):
         """Generic implementation that allows "index" to be contained in mode without implementing getitem_index."""
         return idx
 
+    def _accepts_kwargs(self, key: str, getitem_fn: Any) -> bool:
+        """Whether *getitem_fn* takes the ``pre_getitem`` payload as kwargs (more than just ``idx``)."""
+        cached = self._accepts_kwargs_cache.get(key)
+        if cached is None:
+            try:
+                cached = len(inspect.signature(getitem_fn).parameters) > 1
+            except (TypeError, ValueError):
+                cached = False
+            self._accepts_kwargs_cache[key] = cached
+        return cached
+
     def __getitem__(self, idx: int) -> dict[str, Any]:
         """Iterates over all items contained in self.mode and calls the getitem_<ITEM> method to load the specified
         property. The result of all getitem methods is returned as dictionary.
+
+        Mirrors :meth:`Dataset.__getitem__`: the wrapped dataset's :meth:`pre_getitem` hook is run once before the
+        getitem methods (and its return value forwarded as kwargs to getitems that accept them), and
+        :meth:`post_getitem` is always run afterwards. This keeps datasets that share per-sample state across their
+        getitem_* methods (e.g. an open file handle or a single chunk read) working when wrapped.
 
         Args:
             idx: Index of the sample that should be loaded.
@@ -110,9 +129,18 @@ class PropertySubsetWrapper(DatasetWrapper):
         if idx >= len(self.dataset):
             raise IndexError(f"Index {idx} is out of bounds for dataset of size {len(self.dataset)}.")
 
-        items: dict[str, Any] = {}
-        for key, getitem_fn in self._getitem_functions.items():
-            items[key] = getitem_fn(idx)
+        pre = self.dataset.pre_getitem(idx)
+        if not isinstance(pre, dict):
+            raise TypeError(f"Expected dict from pre_getitem, got {type(pre)}.")
+        try:
+            items: dict[str, Any] = {}
+            for key, getitem_fn in self._getitem_functions.items():
+                if pre and self._accepts_kwargs(key, getitem_fn):
+                    items[key] = getitem_fn(idx, **pre)
+                else:
+                    items[key] = getitem_fn(idx)
+        finally:
+            self.dataset.post_getitem(idx, pre)
         return items
 
     def __getattr__(self, item: str) -> Any:

--- a/src/noether/data/datasets/cfd/__init__.py
+++ b/src/noether/data/datasets/cfd/__init__.py
@@ -3,8 +3,14 @@
 from .caeml.ahmedml import AhmedMLDataset, AhmedMLDefaultSplitIDs
 from .caeml.drivaerml import DrivAerMLDataset, DrivAerMLDefaultSplitIDs
 from .drivaernet.dataset import DrivAerNetDataset
+from .drivaernet.zarr_dataset import ZarrDrivAerNetDataset, ZarrDrivAerNetDatasetConfig
 from .emmi_wing import EmmiWingDataset, EmmiWingHFDataset
-from .shapenet_car import ShapeNetCarDataset, ShapeNetCarDefaultSplitIDs
+from .shapenet_car import (
+    ShapeNetCarDataset,
+    ShapeNetCarDefaultSplitIDs,
+    ZarrShapeNetCarDataset,
+    ZarrShapeNetCarDatasetConfig,
+)
 from .simshift_heatsink import SimshiftHeatsinkDataset
 
 __all__ = [
@@ -18,4 +24,8 @@ __all__ = [
     "ShapeNetCarDataset",
     "ShapeNetCarDefaultSplitIDs",
     "SimshiftHeatsinkDataset",
+    "ZarrDrivAerNetDataset",
+    "ZarrDrivAerNetDatasetConfig",
+    "ZarrShapeNetCarDataset",
+    "ZarrShapeNetCarDatasetConfig",
 ]

--- a/src/noether/data/datasets/cfd/drivaernet/dataset.py
+++ b/src/noether/data/datasets/cfd/drivaernet/dataset.py
@@ -66,7 +66,8 @@ class DrivAerNetDataset(AeroDataset):
         all_design_ids = datasplits[self.split]
         self.design_ids = [all_design_ids[i] for i in subset_indices] if subset_indices else all_design_ids
 
-    def _parse_split_subset(self, split_spec: str) -> tuple[str, list[int] | range | None]:
+    @staticmethod
+    def _parse_split_subset(split_spec: str) -> tuple[str, list[int] | range | None]:
         """Parse a split specification with optional subset info in brackets.
 
         Examples:

--- a/src/noether/data/datasets/cfd/drivaernet/stats.yaml
+++ b/src/noether/data/datasets/cfd/drivaernet/stats.yaml
@@ -1,5 +1,5 @@
 raw_pos_min:  [-12.01]
-raw_pos_max: [6.41,]
+raw_pos_max: [32.0032,]
 surface_domain_min: [-1.15154e00, -1.19442e00, 0.00000e00]
 surface_domain_max: [4.20453e00, 1.19442e00, 1.76205e00]
 surface_pos_mean: [1.53702e00, -8.12572e-03, 5.93542e-01]

--- a/src/noether/data/datasets/cfd/drivaernet/zarr_dataset.py
+++ b/src/noether/data/datasets/cfd/drivaernet/zarr_dataset.py
@@ -1,0 +1,124 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Zarr-backed DrivAerNet(++) dataset with chunk-based subsampling.
+
+Reads from a converted Zarr store (local path or fsspec URL such as
+``oci://bucket@namespace/zarr_store``). The store is self-contained: the split files
+(``{train,test,val}_design_ids.txt``) and blacklists (``blacklist.txt``,
+``blacklist2.txt``) live next to ``manifest.json`` and are read through fsspec, so the
+same split/blacklist semantics as :class:`DrivAerNetDataset` apply.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import fsspec
+
+from noether.data.datasets.cfd.drivaernet.dataset import VALID_CATEGORIES, DrivAerNetDataset
+from noether.data.datasets.cfd.zarr_aero_dataset import ZarrAeroDataset, ZarrAeroDatasetConfig
+from noether.data.zarr_store import stores
+
+logger = logging.getLogger(__name__)
+
+
+class ZarrDrivAerNetDatasetConfig(ZarrAeroDatasetConfig):
+    """Config for the Zarr-backed DrivAerNet dataset (``root`` = converted Zarr store)."""
+
+    kind: str | None = "noether.data.datasets.cfd.ZarrDrivAerNetDataset"
+
+    filter_categories: list[str] | None = None
+    """Optional design-category filter (e.g. ``["E_S_WWC_WM"]``), as in the ``.pt`` dataset."""
+
+
+class ZarrDrivAerNetDataset(ZarrAeroDataset):
+    """DrivAerNet(++) dataset reading from a converted Zarr store.
+
+    Mirrors :class:`DrivAerNetDataset`'s split handling (split id files, blacklists,
+    category filtering and ``"train[0:100]"`` subset notation) while subsampling via
+    chunked Zarr reads. When the config's ``num_*`` counts are set, the pipeline's
+    anchor/geometry sampling becomes inert (see ``geometry_position_from_dataset``).
+    """
+
+    STATS_FILE: str = DrivAerNetDataset.STATS_FILE
+
+    def __init__(self, dataset_config: ZarrDrivAerNetDatasetConfig) -> None:
+        """
+
+        Args:
+            dataset_config: DrivAerNet Zarr config; ``root`` is the Zarr store root (local
+                or fsspec URL) and the ``num_*`` / ``sampling_seed`` / ``read_concurrency``
+                fields drive subsampling.
+        """
+        super().__init__(
+            dataset_config=dataset_config,
+            filemap=DrivAerNetDataset.FILEMAP,
+            num_points={
+                "surface": dataset_config.num_surface_points,
+                "volume": dataset_config.num_volume_points,
+            },
+            sampling_seed=dataset_config.sampling_seed,
+            read_concurrency=dataset_config.read_concurrency,
+            num_geometry_points=dataset_config.num_geometry_points,
+        )
+        datasplits = self._load_datasplits()
+        if dataset_config.filter_categories:
+            for category in dataset_config.filter_categories:
+                if category not in VALID_CATEGORIES:
+                    raise ValueError(f"Invalid category: {category}. Valid categories: {VALID_CATEGORIES}")
+            datasplits = {
+                split: [i for i in ids if "_".join(i.split("_")[:-1]) in dataset_config.filter_categories]
+                for split, ids in datasplits.items()
+            }
+
+        # Reuse the .pt dataset's "train[0:100]" subset notation.
+        self.split, subset_indices = DrivAerNetDataset._parse_split_subset(dataset_config.split)
+        if self.split not in datasplits:
+            raise ValueError(f"Unknown split '{self.split}'. Available splits: {list(datasplits)}")
+        all_design_ids = datasplits[self.split]
+        self.design_ids = [all_design_ids[i] for i in subset_indices] if subset_indices else all_design_ids
+
+        missing = [design_id for design_id in self.design_ids if design_id not in self.manifest.samples]
+        if missing:
+            raise KeyError(
+                f"{len(missing)} '{self.split}' samples missing from the Zarr store "
+                f"(e.g. {missing[0]}). Re-run conversion to include them."
+            )
+        logger.info(
+            "Initialized ZarrDrivAerNetDataset with %d samples for split '%s'", len(self.design_ids), self.split
+        )
+
+    def _read_lines(self, name: str) -> list[str]:
+        with fsspec.open(f"{str(self.store_root).rstrip('/')}/{name}", "r") as f:
+            return [line.strip() for line in f if line.strip()]
+
+    def _load_datasplits(self) -> dict[str, list[str]]:
+        """Load split design ids from the store root, excluding blacklisted designs."""
+        blacklist = {
+            line.split("/")[-1].split(".vtk")[0]
+            for name in ("blacklist.txt", "blacklist2.txt")
+            for line in self._read_lines(name)
+        }
+        return {
+            split: [
+                design_id for design_id in self._read_lines(f"{split}_design_ids.txt") if design_id not in blacklist
+            ]
+            for split in ("train", "test", "val")
+        }
+
+    def __len__(self) -> int:
+        return len(self.design_ids)
+
+    def _sample_id(self, idx: int) -> str:
+        return str(self.design_ids[idx % len(self.design_ids)])
+
+    def sample_info(self, idx: int) -> dict[str, str | int | None]:
+        """Get information about a sample such as its store path and design id."""
+        idx = idx % len(self.design_ids)
+        design_id = self.design_ids[idx]
+        return {
+            "sample_uri": stores.join(self.store_root, self.manifest.samples[design_id].relpath),
+            "run_name": design_id,
+            "design_id": design_id,
+            "split": self.split,
+        }

--- a/src/noether/data/datasets/cfd/drivaerstar/__init__.py
+++ b/src/noether/data/datasets/cfd/drivaerstar/__init__.py
@@ -1,0 +1,1 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.

--- a/src/noether/data/datasets/cfd/drivaerstar/preprocessing.py
+++ b/src/noether/data/datasets/cfd/drivaerstar/preprocessing.py
@@ -1,0 +1,498 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Process raw DrivAerStar EnSight cases and convert them into a chunked Zarr store.
+
+DrivAerStar ships each simulation as an EnSight Gold case (``<T>_<id>.case`` + ``.geo`` +
+per-cell ``Pressure`` / ``Velocity`` / ``WallShearStress`` files) under
+``case_<T>/<id>/case/``. This is the DrivAerStar analogue of
+:mod:`noether.data.datasets.cfd.caeml.preprocessing`, but instead of writing per-field
+``.pt`` files it writes directly into the blob-storage-friendly chunked/sharded Zarr store
+(:class:`~noether.data.zarr_store.writer.ZarrStoreWriter`), so the result is consumable by
+:class:`~noether.data.datasets.cfd.ZarrAeroDataset` and friends.
+
+Surface / volume split follows the convention used in ``Emmi-AI/proprioceptive``'s
+``match_experiment_probes.py``:
+
+* **volume** — the ``domain`` block (Pressure + Velocity per cell);
+* **surface** — every ``WallShearStress``-bearing block that is *not* the volume and *not*
+  a wind-tunnel wall (``Block.*``, including the ground plane ``Block.bottom``); i.e. the
+  car / wheel shell. Combined and surface-extracted, fields taken at cell centres.
+
+For each case the script stores (canonical field → array):
+
+* ``surface_position`` / ``surface_pressure`` / ``surface_friction`` (WallShearStress) /
+  ``surface_normals``;
+* ``volume_position`` / ``volume_pressure`` / ``volume_velocity``;
+* ``volume_sdf`` (distance from each volume cell centre to the car surface) — **only when
+  ``--sdf`` is passed**; off by default since it needs scipy and a KD-tree query over all
+  volume points.
+
+Robustness: some DrivAerStar binaries crash VTK's EnSight reader at the C level
+(uncatchable from Python), so each case is read/extracted in a *child process*; a crashing
+case yields a non-zero exit and is skipped with a warning rather than killing the run.
+
+Source may be local or any fsspec URL (the bucket lives at
+``oci://emmi-drivaer-star``; ``ocifs`` needs ``OCIFS_IAM_TYPE=api_key``)::
+
+    OCIFS_IAM_TYPE=api_key uv run python -m noether.data.datasets.cfd.drivaerstar.preprocessing \\
+        --source oci://emmi-drivaer-star@frwnorq7ern2 \\
+        --output oci://emmi-drivaer-star@frwnorq7ern2/zarr_store \\
+        --case-types E --workers 16
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+from noether.data.schemas import FileMap
+from noether.data.zarr_store import stores
+from noether.data.zarr_store.manifest import SampleEntry
+from noether.data.zarr_store.writer import ZarrStoreWriter
+
+
+# Canonical field -> placeholder filename. The Zarr layout only uses the FileMap to decide
+# which fields exist and their canonical names (``volume_distance_to_surface`` -> ``volume_sdf``);
+# the filenames are what a downstream ``AeroDataset`` would map back from, so keep them stable.
+def build_filemap(compute_sdf: bool = False) -> FileMap:
+    """Return the DrivAerStar FileMap, optionally including the volume SDF field.
+
+    Args:
+        compute_sdf: If ``True``, include ``volume_distance_to_surface`` (canonical
+            ``volume_sdf``); when ``False`` it is omitted so the writer does not expect it.
+    """
+    return FileMap(
+        surface_position="surface_position.pt",
+        surface_pressure="surface_pressure.pt",
+        surface_friction="surface_wallshearstress.pt",
+        surface_normals="surface_normals.pt",
+        volume_position="volume_position.pt",
+        volume_pressure="volume_pressure.pt",
+        volume_velocity="volume_velocity.pt",
+        volume_distance_to_surface="volume_sdf.pt" if compute_sdf else None,
+    )
+
+
+# Full field set (SDF included); use :func:`build_filemap` to opt out of the SDF.
+DRIVAERSTAR_FILEMAP = build_filemap(compute_sdf=True)
+
+# Long-edge human label per case-type prefix (DrivAerStar Estate/Fastback/Notchback).
+VARIANT_BY_TYPE = {"E": "ESTATEBACK", "F": "FASTBACK", "N": "NOTCHBACK"}
+
+# EnSight sibling files that make up one case (relative to the ``.case`` file).
+_CASE_SUFFIXES = (".case", ".geo", ".Pressure", ".Velocity", ".WallShearStress")
+
+
+# --------------------------------------------------------------------------------------
+# Field extraction (runs in a child process, see ``_extract_main``)
+# --------------------------------------------------------------------------------------
+def extract_case_fields(
+    case_path: str | Path, *, subsample_factor: int = 1, compute_sdf: bool = False
+) -> dict[str, np.ndarray]:
+    """Read one EnSight case and return canonical field arrays for surface and volume.
+
+    Args:
+        case_path: Path to a local ``<T>_<id>.case`` file (siblings ``.geo`` / ``.Pressure`` /
+            ``.Velocity`` / ``.WallShearStress`` must be next to it).
+        subsample_factor: Keep ``1 / subsample_factor`` of the volume cells via a seeded
+            permutation (``1`` keeps all). Surface cells are always kept in full.
+        compute_sdf: If ``True``, also compute ``volume_sdf`` (distance from each volume cell
+            centre to the nearest car-surface vertex). Off by default — it needs scipy and
+            adds a KD-tree query over all volume points.
+
+    Returns:
+        Mapping ``canonical_field -> np.ndarray`` (positions ``float32 (N, 3)``, scalar
+        fields ``(N,)``, vector fields ``(N, 3)``), ready for
+        :meth:`~noether.data.zarr_store.writer.ZarrStoreWriter.write_group`.
+
+    Raises:
+        RuntimeError: If the case has no ``domain`` block or no WallShearStress surface.
+    """
+    import pyvista as pv
+
+    mb = pv.read(str(case_path))
+
+    volume = None
+    wss_parts: list = []  # WallShearStress-bearing blocks = car / wheel surfaces
+    for i in range(mb.n_blocks):
+        block = mb.get_block(i)
+        if block is None or block.n_cells == 0 or block.n_points == 0:
+            continue
+        name = (mb.get_block_name(i) or "").strip().lower()
+        if name == "domain":
+            volume = block
+            continue
+        if name.startswith("block."):
+            continue  # wind-tunnel walls / ground plane
+        if "WallShearStress" not in list(block.array_names):
+            continue  # porosity helpers, interface patches, ...
+        wss_parts.append(block)
+
+    if volume is None:
+        raise RuntimeError(f"no 'domain' (volume) block in {case_path}")
+    if not wss_parts:
+        raise RuntimeError(f"no WallShearStress surface blocks in {case_path}")
+
+    combined = wss_parts[0] if len(wss_parts) == 1 else pv.MultiBlock(wss_parts).combine()
+    surface = combined.extract_surface(algorithm="dataset_surface")
+    surface_normals = surface.compute_normals(
+        cell_normals=True, point_normals=False, auto_orient_normals=True, consistent_normals=True
+    )
+
+    fields: dict[str, np.ndarray] = {
+        "surface_position": np.asarray(surface.cell_centers().points, dtype=np.float32),
+        "surface_pressure": np.asarray(surface.cell_data["Pressure"], dtype=np.float32),
+        "surface_friction": np.asarray(surface.cell_data["WallShearStress"], dtype=np.float32),
+        "surface_normals": np.asarray(surface_normals.cell_data["Normals"], dtype=np.float32),
+    }
+
+    volume_position = np.asarray(volume.cell_centers().points, dtype=np.float32)
+    volume_pressure = np.asarray(volume.cell_data["Pressure"], dtype=np.float32)
+    volume_velocity = np.asarray(volume.cell_data["Velocity"], dtype=np.float32)
+    if subsample_factor > 1:
+        # Seeded so a re-run reproduces the same volume subset (matches caeml's convention).
+        import torch
+
+        seed = abs(hash(str(case_path))) % (2**31)
+        perm = torch.randperm(len(volume_position), generator=torch.Generator().manual_seed(seed)).numpy()
+        perm = perm[: len(perm) // subsample_factor]
+        volume_position, volume_pressure, volume_velocity = (
+            volume_position[perm],
+            volume_pressure[perm],
+            volume_velocity[perm],
+        )
+
+    fields.update(
+        volume_position=volume_position,
+        volume_pressure=volume_pressure,
+        volume_velocity=volume_velocity,
+    )
+
+    if compute_sdf:
+        # Distance from each volume cell centre to the nearest car-surface vertex, via a KD-tree
+        # (the same approximation caeml's preprocessing uses — cheap and accurate to ~mm, vs.
+        # VTK's exact point-to-mesh distance which is ~1000x slower on ~10M points).
+        try:
+            from scipy.spatial import cKDTree
+        except ImportError as exc:  # pragma: no cover - optional preprocessing dependency
+            raise RuntimeError(
+                "DrivAerStar SDF (--sdf) needs scipy; install it (e.g. `uv add scipy` or the 'preprocessing' extra)."
+            ) from exc
+
+        tree = cKDTree(np.asarray(surface.points, dtype=np.float32))
+        volume_sdf, _ = tree.query(volume_position, workers=1)
+        fields["volume_sdf"] = volume_sdf.astype(np.float32)
+
+    return fields
+
+
+def _extract_main() -> int:
+    """Child-process entry point: ``--extract <case_path> --out <npz> [--subsample-factor N] [--sdf]``."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--extract", required=True, help="Path to the local .case file.")
+    parser.add_argument("--out", required=True, help="Where to write the .npz of field arrays.")
+    parser.add_argument("--subsample-factor", type=int, default=1)
+    parser.add_argument("--sdf", action="store_true", help="Also compute the volume SDF field.")
+    args = parser.parse_args(sys.argv[1:])
+    fields = extract_case_fields(args.extract, subsample_factor=args.subsample_factor, compute_sdf=args.sdf)
+    # numpy's savez stub mistypes the first **kwarg as ``allow_pickle: bool``; our kwargs are arrays.
+    np.savez(args.out, **fields)  # type: ignore[arg-type]
+    return 0
+
+
+# --------------------------------------------------------------------------------------
+# Case discovery + per-case driver (parent process)
+# --------------------------------------------------------------------------------------
+def discover_cases(source: str, case_types: list[str], limit: int | None = None) -> list[tuple[str, str, str]]:
+    """Find DrivAerStar cases under ``source`` for the requested case types.
+
+    Args:
+        source: Dataset root (local path or fsspec URL) holding ``case_<T>/<id>/case/...``.
+        case_types: Case-type prefixes to include (subset of ``E`` / ``F`` / ``N``).
+        limit: If set, keep at most this many cases (after sorting) across all types.
+
+    Returns:
+        Sorted list of ``(sample_id, case_type, case_url)`` where ``sample_id`` is
+        ``"<T>_<id>"`` and ``case_url`` points at the ``.case`` file (local path or URL).
+    """
+    cases: list[tuple[str, str, str]] = []
+    if stores.is_remote(source):
+        import fsspec
+
+        fs = fsspec.filesystem(source.split("://", 1)[0])
+        root = source.split("://", 1)[1]
+        for case_type in case_types:
+            pattern = f"{root.rstrip('/')}/case_{case_type}/*/case/{case_type}_*.case"
+            for hit in fs.glob(pattern):
+                case_id = Path(hit).stem.split("_", 1)[1]
+                scheme = source.split("://", 1)[0]
+                cases.append((f"{case_type}_{case_id}", case_type, f"{scheme}://{hit}"))
+    else:
+        base = Path(source)
+        for case_type in case_types:
+            for hit in sorted((base / f"case_{case_type}").glob(f"*/case/{case_type}_*.case")):
+                case_id = hit.stem.split("_", 1)[1]
+                cases.append((f"{case_type}_{case_id}", case_type, str(hit)))
+
+    cases.sort(key=lambda c: c[0])
+    return cases[:limit] if limit else cases
+
+
+def _materialize_case(case_url: str, tmp_dir: Path) -> Path:
+    """Ensure a case's EnSight files are on local disk; return the local ``.case`` path.
+
+    Local sources are used in place; remote sources have their sibling EnSight files
+    downloaded into ``tmp_dir`` via fsspec.
+    """
+    if not stores.is_remote(case_url):
+        return Path(case_url)
+
+    import fsspec
+
+    scheme, path = case_url.split("://", 1)
+    fs = fsspec.filesystem(scheme)
+    stem = Path(path).name.rsplit(".case", 1)[0]  # e.g. "E_03210"
+    remote_dir = path.rsplit("/", 1)[0]
+    for suffix in _CASE_SUFFIXES:
+        remote = f"{remote_dir}/{stem}{suffix}"
+        if fs.exists(remote):
+            fs.get_file(remote, str(tmp_dir / f"{stem}{suffix}"))
+    return tmp_dir / f"{stem}.case"
+
+
+def convert_case(
+    sample_id: str,
+    case_url: str,
+    writer: ZarrStoreWriter,
+    *,
+    subsample_factor: int = 1,
+    compute_sdf: bool = False,
+    timeout_s: int = 1800,
+) -> SampleEntry | None:
+    """Extract one case (in a child process) and write its Zarr group; ``None`` on failure.
+
+    The EnSight read + field extraction run in a separate interpreter so a C-level crash in
+    VTK's reader fails just this case (non-zero exit) instead of the whole run.
+
+    Args:
+        sample_id: Stable id (``"<T>_<id>"``) used for the store path and shuffle seed.
+        case_url: Local path or fsspec URL of the ``.case`` file.
+        writer: Target store writer (its FileMap defines which fields are stored).
+        subsample_factor: Volume subsampling factor passed to the child (``1`` keeps all).
+        compute_sdf: Whether the child should also compute the ``volume_sdf`` field.
+        timeout_s: Per-case wall-clock budget for the extraction child.
+
+    Returns:
+        The :class:`SampleEntry` for the written group, or ``None`` if the case was skipped.
+    """
+    with tempfile.TemporaryDirectory(prefix="drivaerstar_") as tmp:
+        tmp_dir = Path(tmp)
+        try:
+            local_case = _materialize_case(case_url, tmp_dir)
+            out_npz = tmp_dir / f"{sample_id}.npz"
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "noether.data.datasets.cfd.drivaerstar.preprocessing",
+                    "--extract",
+                    str(local_case),
+                    "--out",
+                    str(out_npz),
+                    "--subsample-factor",
+                    str(subsample_factor),
+                    *(["--sdf"] if compute_sdf else []),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+            if proc.returncode != 0 or not out_npz.exists():
+                warnings.warn(
+                    f"Skipping '{sample_id}': extraction failed (exit {proc.returncode}). {proc.stderr.strip()[-500:]}",
+                    stacklevel=2,
+                )
+                return None
+            with np.load(out_npz) as data:
+                fields = {key: data[key] for key in data.files}
+            return writer.write_group(sample_id, fields)
+        except subprocess.TimeoutExpired:
+            warnings.warn(f"Skipping '{sample_id}': extraction timed out after {timeout_s}s.", stacklevel=2)
+            return None
+        except Exception as exc:  # noqa: BLE001 - one bad case must not abort the run
+            warnings.warn(f"Skipping '{sample_id}': {type(exc).__name__}: {exc}", stacklevel=2)
+            return None
+
+
+def convert(
+    source: str,
+    output: str,
+    *,
+    case_types: list[str],
+    workers: int = 1,
+    subsample_factor: int = 1,
+    compute_sdf: bool = False,
+    chunk_points: int = 4096,
+    shard_points: int | None = None,
+    shuffle_seed: int = 0,
+    values_dtype: str = "float16",
+    field_dtypes: dict[str, str] | None = None,
+    limit: int | None = None,
+    timeout_s: int = 1800,
+) -> ZarrStoreWriter:
+    """Convert raw DrivAerStar EnSight cases into a chunked Zarr store.
+
+    Cases are extracted concurrently in up to ``workers`` child processes (crash-isolated);
+    completed cases are written into the store and recorded in the manifest as they finish.
+    Failed cases are skipped with a warning. The manifest is saved once at the end.
+
+    Args:
+        source: Dataset root (local path or fsspec URL) with ``case_<T>/<id>/case/...``.
+        output: Zarr store root (local path or fsspec URL).
+        case_types: Case-type prefixes to convert (subset of ``E`` / ``F`` / ``N``).
+        workers: Maximum number of concurrent extraction child processes.
+        subsample_factor: Volume subsampling factor (``1`` keeps all ~10M cells).
+        compute_sdf: Whether to also compute and store the ``volume_sdf`` field (off by default).
+        chunk_points: Points per chunk along the point axis.
+        shard_points: Optional shard-size cap (point-multiple of ``chunk_points``).
+        shuffle_seed: Base seed for the per-sample point shuffle.
+        values_dtype: Default dtype for value fields (positions are always float32).
+        field_dtypes: Per-canonical-field dtype overrides, e.g. ``{"volume_pressure": "float32"}``.
+        limit: Convert at most this many cases.
+        timeout_s: Per-case extraction timeout.
+
+    Returns:
+        The :class:`ZarrStoreWriter` after all cases are written and the manifest saved.
+
+    Raises:
+        RuntimeError: If no cases are found, or every discovered case failed to convert.
+    """
+    cases = discover_cases(source, case_types, limit=limit)
+    if not cases:
+        raise RuntimeError(f"No DrivAerStar cases found under '{source}' for types {case_types}.")
+    print(f"Found {len(cases)} case(s) for types {case_types}; converting with {workers} worker(s).")
+
+    writer = ZarrStoreWriter(
+        store_root=output,
+        filemap=build_filemap(compute_sdf=compute_sdf),
+        dataset_name="drivaerstar",
+        shuffle_seed=shuffle_seed,
+        chunk_points=chunk_points,
+        shard_points=shard_points,
+        values_dtype=values_dtype,
+        field_dtypes=field_dtypes,
+    )
+
+    # Bounded scheduler: each case is extracted by its own interpreter (crash isolation),
+    # at most ``workers`` at a time, and written to the store from the parent as it finishes.
+    converted = 0
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    # Threads only orchestrate subprocesses + the (GIL-light) zarr writes, so a thread pool
+    # is enough to overlap extraction and I/O without the BrokenProcessPool crash hazard.
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(
+                convert_case,
+                sample_id,
+                case_url,
+                writer,
+                subsample_factor=subsample_factor,
+                compute_sdf=compute_sdf,
+                timeout_s=timeout_s,
+            ): sample_id
+            for sample_id, _case_type, case_url in cases
+        }
+        for done in as_completed(futures):
+            sample_id = futures[done]
+            entry = done.result()
+            if entry is not None:
+                writer.manifest.samples[sample_id] = entry
+                converted += 1
+                print(f"[{converted}/{len(cases)}] wrote {sample_id}")
+
+    if converted == 0:
+        raise RuntimeError("All discovered cases failed to convert.")
+    path = writer.save_manifest()
+    print(f"Converted {converted}/{len(cases)} case(s). Manifest: {path}")
+    return writer
+
+
+def _parse_field_dtypes(values: list[str] | None) -> dict[str, str] | None:
+    if not values:
+        return None
+    out: dict[str, str] = {}
+    for item in values:
+        field, _, dtype = item.partition("=")
+        if not dtype:
+            raise ValueError(f"--field-dtype expects FIELD=DTYPE, got '{item}'")
+        out[field] = dtype
+    return out
+
+
+def main() -> None:
+    """CLI entry point for DrivAerStar EnSight -> Zarr conversion."""
+    # Child-process fast path: ``--extract`` is handled before the full CLI is built.
+    if "--extract" in sys.argv:
+        raise SystemExit(_extract_main())
+
+    parser = argparse.ArgumentParser("Convert raw DrivAerStar EnSight cases into a chunked Zarr store.")
+    parser.add_argument("--source", required=True, help="Dataset root (local path or fsspec URL).")
+    parser.add_argument("--output", required=True, help="Zarr store root (local path or fsspec URL).")
+    parser.add_argument(
+        "--case-types",
+        nargs="+",
+        default=["E", "F", "N"],
+        choices=["E", "F", "N"],
+        help="Case-type prefixes to convert (Estate / Fastback / Notchback).",
+    )
+    parser.add_argument("--workers", type=int, default=1, help="Concurrent extraction child processes.")
+    parser.add_argument("--subsample-factor", type=int, default=1, help="Keep 1/factor of volume cells (1 = keep all).")
+    parser.add_argument(
+        "--sdf",
+        action="store_true",
+        help="Also compute the volume SDF (distance to surface); off by default. Needs scipy.",
+    )
+    parser.add_argument("--chunk-points", type=int, default=4096, help="Points per chunk.")
+    parser.add_argument("--shard-points", type=int, default=None, help="Optional shard-size cap (point count).")
+    parser.add_argument("--shuffle-seed", type=int, default=0, help="Base seed for the per-sample point shuffle.")
+    parser.add_argument("--values-dtype", default="float16", help="Default dtype for value fields.")
+    parser.add_argument(
+        "--field-dtype",
+        action="append",
+        default=None,
+        metavar="FIELD=DTYPE",
+        help="Per-field dtype override (repeatable), e.g. --field-dtype volume_pressure=float32.",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Convert at most this many cases.")
+    parser.add_argument("--timeout-s", type=int, default=1800, help="Per-case extraction timeout in seconds.")
+    args = parser.parse_args()
+
+    convert(
+        source=args.source,
+        output=args.output,
+        case_types=args.case_types,
+        workers=args.workers,
+        subsample_factor=args.subsample_factor,
+        compute_sdf=args.sdf,
+        chunk_points=args.chunk_points,
+        shard_points=args.shard_points,
+        shuffle_seed=args.shuffle_seed,
+        values_dtype=args.values_dtype,
+        field_dtypes=_parse_field_dtypes(args.field_dtype),
+        limit=args.limit,
+        timeout_s=args.timeout_s,
+    )
+
+
+if __name__ == "__main__":
+    # Avoid oversubscription when many workers each spawn a VTK-heavy child.
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    main()

--- a/src/noether/data/datasets/cfd/shapenet_car/__init__.py
+++ b/src/noether/data/datasets/cfd/shapenet_car/__init__.py
@@ -2,8 +2,11 @@
 
 from .dataset import ShapeNetCarDataset
 from .split import ShapeNetCarDefaultSplitIDs
+from .zarr_dataset import ZarrShapeNetCarDataset, ZarrShapeNetCarDatasetConfig
 
 __all__ = [
     "ShapeNetCarDataset",
     "ShapeNetCarDefaultSplitIDs",
+    "ZarrShapeNetCarDataset",
+    "ZarrShapeNetCarDatasetConfig",
 ]

--- a/src/noether/data/datasets/cfd/shapenet_car/zarr_dataset.py
+++ b/src/noether/data/datasets/cfd/shapenet_car/zarr_dataset.py
@@ -1,0 +1,82 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Zarr-backed ShapeNet-Car dataset with chunk-based subsampling."""
+
+from __future__ import annotations
+
+import logging
+
+from noether.data.datasets.cfd.shapenet_car.dataset import SUPPORTED_SPLITS, ShapeNetCarDataset
+from noether.data.datasets.cfd.shapenet_car.filemap import SHAPENET_CAR_FILEMAP
+from noether.data.datasets.cfd.shapenet_car.split import ShapeNetCarDefaultSplitIDs
+from noether.data.datasets.cfd.zarr_aero_dataset import ZarrAeroDataset, ZarrAeroDatasetConfig
+from noether.data.zarr_store import stores
+
+logger = logging.getLogger(__name__)
+
+
+class ZarrShapeNetCarDatasetConfig(ZarrAeroDatasetConfig):
+    """Config for the Zarr-backed ShapeNet-Car dataset (``root`` = converted Zarr store)."""
+
+    kind: str | None = "noether.data.datasets.cfd.ZarrShapeNetCarDataset"
+
+
+class ZarrShapeNetCarDataset(ZarrAeroDataset):
+    """ShapeNet-Car dataset that reads from a converted Zarr store.
+
+    Config-driven analogue of :class:`~noether.data.datasets.cfd.shapenet_car.dataset.ShapeNetCarDataset`
+    where ``dataset_config.root`` points at the converted Zarr store. When the config's
+    ``num_surface_points`` / ``num_volume_points`` are given, the dataset chunk-subsamples
+    at read time and returns exactly that many points per domain, so the pipeline's
+    ``PointSamplingSampleProcessor`` becomes a no-op.
+    """
+
+    STATS_FILE: str = ShapeNetCarDataset.STATS_FILE
+
+    def __init__(self, dataset_config: ZarrShapeNetCarDatasetConfig) -> None:
+        """
+
+        Args:
+            dataset_config: ShapeNet-Car Zarr config; ``root`` is the Zarr store root and the
+                ``num_*`` / ``sampling_seed`` / ``read_concurrency`` fields drive subsampling.
+        """
+        super().__init__(
+            dataset_config=dataset_config,
+            filemap=SHAPENET_CAR_FILEMAP,
+            num_points={
+                "surface": dataset_config.num_surface_points,
+                "volume": dataset_config.num_volume_points,
+            },
+            sampling_seed=dataset_config.sampling_seed,
+            read_concurrency=dataset_config.read_concurrency,
+            num_geometry_points=dataset_config.num_geometry_points,
+        )
+        self.split = dataset_config.split
+        if self.split not in SUPPORTED_SPLITS:
+            raise ValueError(f"Unsupported split '{self.split}'. Supported splits are: {SUPPORTED_SPLITS}")
+        self.design_ids = list(getattr(ShapeNetCarDefaultSplitIDs(), self.split))
+        missing = [d for d in self.design_ids if d not in self.manifest.samples]
+        if missing:
+            raise KeyError(
+                f"{len(missing)} '{self.split}' samples missing from the Zarr store "
+                f"(e.g. {missing[0]}). Re-run conversion to include them."
+            )
+        logger.info(
+            "Initialized ZarrShapeNetCarDataset with %d samples for split '%s'", len(self.design_ids), self.split
+        )
+
+    def __len__(self) -> int:
+        return len(self.design_ids)
+
+    def _sample_id(self, idx: int) -> str:
+        return str(self.design_ids[idx % len(self.design_ids)])
+
+    def sample_info(self, idx: int) -> dict[str, str | int | None]:
+        """Get information about a sample such as its store path and run name."""
+        idx = idx % len(self.design_ids)
+        design_id = self.design_ids[idx]
+        return {
+            "sample_uri": stores.join(self.store_root, self.manifest.samples[design_id].relpath),
+            "run_name": design_id,
+            "split": self.split,
+        }

--- a/src/noether/data/datasets/cfd/zarr_aero_dataset.py
+++ b/src/noether/data/datasets/cfd/zarr_aero_dataset.py
@@ -1,0 +1,181 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Zarr-backed :class:`AeroDataset` that subsamples by reading chunks.
+
+This is the read side of the chunked/sharded Zarr format. Instead of loading every
+field of a sample and discarding most points (the ``.pt`` + ``PointSamplingSampleProcessor``
+path), the dataset reads only the random chunks it needs:
+
+* :meth:`pre_getitem` selects random chunks per domain and fetches just those rows
+  (byte-range reads against the sharded arrays), splitting the fused arrays back into
+  per-field tensors.
+* the inherited ``getitem_*`` / ``with_normalizers`` machinery then serves those
+  pre-read tensors, so normalization, key names and downstream collation are unchanged.
+
+Set ``num_points`` to ``None`` per domain (the default) to read full samples — e.g. for
+evaluation — or to an integer to chunk-subsample at read time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from noether.core.utils.common import validate_path
+from noether.data.base.dataset import StandardDatasetConfig, with_normalizers
+from noether.data.datasets.cfd.dataset import AeroDataset
+from noether.data.schemas import FileMap
+from noether.data.zarr_store import stores
+from noether.data.zarr_store.layout import filename_to_canonical
+from noether.data.zarr_store.manifest import StoreManifest
+from noether.data.zarr_store.reader import ZarrChunkReader
+
+# getitem_* methods that do not correspond to a stored field (computed/derived).
+_COMPUTED_GETITEMS = {"getitem_surface_sdf"}
+
+# Domain the AB-UPT geometry input is drawn from (a random draw of the car surface).
+_GEOMETRY_SOURCE_DOMAIN = "surface"
+
+
+class ZarrAeroDatasetConfig(StandardDatasetConfig):
+    """Config for Zarr-backed aerodynamic datasets with chunk-based subsampling.
+
+    ``root`` points at the converted Zarr store. Leave the ``num_*`` fields ``None`` to
+    read full samples (e.g. evaluation); set them to chunk-subsample at read time, in
+    which case the pipeline's ``PointSamplingSampleProcessor`` becomes a no-op.
+    """
+
+    num_surface_points: int | None = None
+    """Surface points to chunk-sample per item (``None`` = full surface)."""
+    num_volume_points: int | None = None
+    """Volume points to chunk-sample per item (``None`` = full volume)."""
+    num_geometry_points: int | None = None
+    """If set, also emit ``geometry_position`` — an independent draw of this many surface points (AB-UPT)."""
+    sampling_seed: int | None = None
+    """Seed for deterministic chunk selection (``None`` = fresh subset each call)."""
+    read_concurrency: int = 1
+    """Threads used to fetch a sample's chunks in parallel (``1`` = serial; raise for S3)."""
+
+
+class ZarrAeroDataset(AeroDataset):
+    """AeroDataset reading from a converted Zarr store with chunk-based subsampling."""
+
+    def __init__(
+        self,
+        dataset_config: StandardDatasetConfig,
+        filemap: FileMap,
+        num_points: dict[str, int | None] | None = None,
+        sampling_seed: int | None = None,
+        read_concurrency: int = 1,
+        num_geometry_points: int | None = None,
+    ) -> None:
+        """
+
+        Args:
+            dataset_config: Standard dataset config; ``root`` points at the Zarr store root.
+            filemap: Field-to-filename mapping (same one used for conversion).
+            num_points: Per-domain target counts (``{"surface": 3586, "volume": 4096}``).
+                A ``None`` value reads the whole domain. Defaults to full reads.
+            sampling_seed: If set, chunk selection is deterministic per sample
+                (seed ``sampling_seed + idx``); otherwise a fresh subset is drawn each call.
+            read_concurrency: Threads used to fetch a sample's chunks in parallel. Keep at
+                ``1`` for local stores; raise it to hide per-request latency on S3.
+            num_geometry_points: If set, also emit ``geometry_position`` — an independent
+                random draw of this many surface points (the AB-UPT shape-encoder input,
+                distinct from the surface anchor points). ``None`` disables it.
+        """
+        super().__init__(dataset_config=dataset_config, filemap=filemap)
+        # Store roots may live on object storage (oci://, s3://, …); only validate local paths.
+        root = str(dataset_config.root)
+        self.store_root: str | Path = root if stores.is_remote(root) else validate_path(root)
+        self.manifest = StoreManifest.load(self.store_root)
+        self.reader = ZarrChunkReader(self.store_root, self.manifest, read_concurrency=read_concurrency)
+        self.num_points = num_points or {}
+        self.sampling_seed = sampling_seed
+        self.num_geometry_points = num_geometry_points
+        if self.num_geometry_points and _GEOMETRY_SOURCE_DOMAIN not in self.manifest.domains:
+            raise ValueError(
+                f"geometry_position requires a '{_GEOMETRY_SOURCE_DOMAIN}' domain in the store, "
+                f"found {sorted(self.manifest.domains)}."
+            )
+
+        self._filename_to_canonical = filename_to_canonical(filemap)
+        self._available_fields = self._collect_available_fields()
+        # Per-sample read cache so all getitem_* of one sample share a single chunk read.
+        # Bounded because PropertySubsetWrapper calls getitem_* directly (bypassing
+        # pre_getitem/post_getitem), so we cannot rely on those hooks to clear it.
+        self._sample_cache: dict[int, dict[str, torch.Tensor]] = {}
+        self._cache_capacity = 8
+
+    def _collect_available_fields(self) -> set[str]:
+        """Canonical field names physically present in the store (from the manifest layout)."""
+        fields: set[str] = set()
+        for layout in self.manifest.domains.values():
+            fields.update(layout.arrays)
+        return fields
+
+    def get_all_getitem_names(self) -> list[str]:
+        """Restrict to ``getitem_*`` for stored fields (+ computed/derived ones that apply)."""
+        allowed: list[str] = []
+        for name in super().get_all_getitem_names():
+            key = name[len("getitem_") :]
+            if key in self._available_fields:
+                allowed.append(name)
+            elif name in _COMPUTED_GETITEMS and "surface_normals" in self._available_fields:
+                allowed.append(name)
+            elif name == "getitem_geometry_position" and self.num_geometry_points:
+                allowed.append(name)
+        return allowed
+
+    def _sample_id(self, idx: int) -> str:
+        raise NotImplementedError("Subclasses must map an index to a manifest sample id.")
+
+    def _read_sample(self, idx: int) -> dict[str, torch.Tensor]:
+        """Chunk-read all fields (and the optional geometry draw) for one sample."""
+        generator = None
+        if self.sampling_seed is not None:
+            generator = torch.Generator().manual_seed(self.sampling_seed + idx)
+        sample_id = self._sample_id(idx)
+        fields = self.reader.read_sample(sample_id, num_points=self.num_points, generator=generator)
+        if self.num_geometry_points:
+            # Independent draw of surface positions. Reusing `generator` continues its
+            # sequence, so the geometry selection is uncorrelated with the surface-field one.
+            fields["geometry_position"] = self.reader.read_coords(
+                sample_id, _GEOMETRY_SOURCE_DOMAIN, self.num_geometry_points, generator
+            )
+        return fields
+
+    def _ensure_loaded(self, idx: int) -> dict[str, torch.Tensor]:
+        """Return the cached fields for *idx*, reading them once on first access (bounded cache)."""
+        cached = self._sample_cache.get(idx)
+        if cached is None:
+            if len(self._sample_cache) >= self._cache_capacity:
+                self._sample_cache.clear()
+            cached = self._read_sample(idx)
+            self._sample_cache[idx] = cached
+        return cached
+
+    def pre_getitem(self, idx: int) -> dict[str, Any]:
+        """Pre-read the sample so all getitem_* share one chunk read (used by ``__getitem__``)."""
+        self._ensure_loaded(idx)
+        return {}
+
+    @with_normalizers(f"{_GEOMETRY_SOURCE_DOMAIN}_position")
+    def getitem_geometry_position(self, idx: int) -> torch.Tensor:
+        """Random draw of surface positions used as the AB-UPT geometry/shape-encoder input.
+
+        Independent of the surface anchor points; only emitted when ``num_geometry_points``
+        is set. Normalized with the surface position normalizer.
+        """
+        return self._ensure_loaded(idx)["geometry_position"]
+
+    def post_getitem(self, idx: int, pre: dict[str, Any] | None) -> None:
+        """Drop the cached tensors for *idx* (used by ``__getitem__``)."""
+        self._sample_cache.pop(idx, None)
+
+    def _load(self, idx: int, filename: str) -> torch.Tensor:
+        """Return a (raw, un-normalized) field tensor, reading the sample's chunks on first access."""
+        canonical = self._filename_to_canonical[filename]
+        return self._ensure_loaded(idx)[canonical]

--- a/src/noether/data/pipeline/sample_processors/point_sampling.py
+++ b/src/noether/data/pipeline/sample_processors/point_sampling.py
@@ -66,6 +66,13 @@ class PointSamplingSampleProcessor(SampleProcessor):
         first_item_tensor = output_sample[any_item]
         if not torch.is_tensor(first_item_tensor):
             raise ValueError(f"Item {any_item} in is not a tensor.")
+        # Skip subsampling when we would keep every point: ``randperm(N)[:num_points]`` with
+        # ``num_points >= N`` is a full permutation, i.e. a redundant reshuffle that leaves the
+        # point *set* unchanged (a no-op for permutation-invariant point models). This makes the
+        # processor inert when the dataset already subsampled to ``num_points`` (e.g. the chunked
+        # Zarr dataset), so no pipeline flag is needed to disable it.
+        if self.num_points >= len(first_item_tensor):
+            return output_sample
         if self.seed is not None:
             if "index" not in output_sample:
                 raise ValueError("Sample index is required for deterministic sampling with a seed.")

--- a/src/noether/data/stats.py
+++ b/src/noether/data/stats.py
@@ -285,6 +285,11 @@ class RunningStats:
             self._n = total_n
 
     @property
+    def count(self) -> int:
+        """Number of points pushed so far."""
+        return self._n
+
+    @property
     def min(self) -> torch.Tensor:
         assert self._n > 0 and self._stats is not None
         return self._stats.min

--- a/src/noether/data/zarr_store/__init__.py
+++ b/src/noether/data/zarr_store/__init__.py
@@ -25,6 +25,7 @@ from noether.data.zarr_store.manifest import (
     StoreManifest,
 )
 from noether.data.zarr_store.reader import ZarrChunkReader
+from noether.data.zarr_store.statistics import calculate_store_statistics
 from noether.data.zarr_store.stores import is_remote, make_store
 from noether.data.zarr_store.writer import ZarrStoreWriter
 
@@ -40,6 +41,7 @@ __all__ = [
     "ZarrChunkReader",
     "ZarrStoreWriter",
     "build_domain_layouts",
+    "calculate_store_statistics",
     "filename_to_canonical",
     "is_remote",
     "make_store",

--- a/src/noether/data/zarr_store/__init__.py
+++ b/src/noether/data/zarr_store/__init__.py
@@ -1,0 +1,47 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Chunked, sharded, pre-shuffled Zarr store for CFD datasets.
+
+This package provides a blob-storage-friendly alternative to the per-field ``.pt``
+layout: each sample is a Zarr group with fused float32 ``coords`` and float16
+``fields`` arrays per domain, chunked along the point axis and packed into shards.
+Pre-shuffling points at write time lets the dataloader subsample by reading a few
+random chunks (byte-range reads) instead of loading the whole sample.
+"""
+
+from noether.data.zarr_store.layout import (
+    CANONICAL_TO_SPEC,
+    FIELD_SPECS,
+    FieldSpec,
+    build_domain_layouts,
+    filename_to_canonical,
+    present_specs,
+)
+from noether.data.zarr_store.manifest import (
+    ArrayLayout,
+    DomainLayout,
+    DomainSample,
+    SampleEntry,
+    StoreManifest,
+)
+from noether.data.zarr_store.reader import ZarrChunkReader
+from noether.data.zarr_store.stores import is_remote, make_store
+from noether.data.zarr_store.writer import ZarrStoreWriter
+
+__all__ = [
+    "ArrayLayout",
+    "CANONICAL_TO_SPEC",
+    "DomainLayout",
+    "DomainSample",
+    "FIELD_SPECS",
+    "FieldSpec",
+    "SampleEntry",
+    "StoreManifest",
+    "ZarrChunkReader",
+    "ZarrStoreWriter",
+    "build_domain_layouts",
+    "filename_to_canonical",
+    "is_remote",
+    "make_store",
+    "present_specs",
+]

--- a/src/noether/data/zarr_store/benchmark.py
+++ b/src/noether/data/zarr_store/benchmark.py
@@ -1,0 +1,128 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Validate and benchmark a converted ShapeNet-Car Zarr store against the ``.pt`` source.
+
+Checks, for the ``test`` split:
+
+1. **Equivalence** — normalized per-field output of :class:`ZarrShapeNetCarDataset`
+   (full read) matches the original :class:`ShapeNetCarDataset` within float16 error.
+2. **Read amplification** — bytes fetched for a chunk-subsampled read vs a full read,
+   measured by instrumenting the Zarr store.
+
+Run::
+
+    uv run python -m noether.data.zarr_store.benchmark \
+        --pt-root /nfs-gpu/research/datasets/shapenet_car \
+        --zarr-root /nfs-gpu/research/datasets/shapenet_car/zarr_store
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+from zarr.storage import LocalStore
+
+from noether.data.base.dataset import StandardDatasetConfig
+from noether.data.datasets.cfd.shapenet_car.dataset import ShapeNetCarDataset
+from noether.data.datasets.cfd.shapenet_car.zarr_dataset import ZarrShapeNetCarDataset, ZarrShapeNetCarDatasetConfig
+from noether.data.preprocessors.normalizers import FieldNormalizerConfig
+from noether.data.zarr_store.reader import ZarrChunkReader
+
+FIELDS = [
+    "surface_position",
+    "surface_pressure",
+    "surface_normals",
+    "volume_position",
+    "volume_velocity",
+    "volume_sdf",
+    "volume_normals",
+]
+
+_POS = FieldNormalizerConfig(strategy="position", scale=1000, stat_keys={"min": "raw_pos_min", "max": "raw_pos_max"})
+NORMALIZERS = {
+    "surface_pressure": FieldNormalizerConfig(strategy="mean_std"),
+    "volume_velocity": FieldNormalizerConfig(strategy="mean_std"),
+    "volume_sdf": FieldNormalizerConfig(strategy="mean_std"),
+    "surface_position": _POS,
+    "volume_position": _POS,
+}
+
+
+def check_equivalence(pt_root: str, zarr_root: str, num_samples: int) -> None:
+    """Compare normalized fields of the original and Zarr datasets (full read)."""
+    pt_cfg = StandardDatasetConfig(root=pt_root, split="test", dataset_normalizers=NORMALIZERS)
+    zarr_cfg = ZarrShapeNetCarDatasetConfig(root=zarr_root, split="test", dataset_normalizers=NORMALIZERS)
+    original = ShapeNetCarDataset(pt_cfg)
+    converted = ZarrShapeNetCarDataset(zarr_cfg)  # full read (num_* default to None)
+
+    print(f"\n== Equivalence (normalized, {num_samples} samples, sorted per-field) ==")
+    worst = dict.fromkeys(FIELDS, 0.0)
+    for idx in range(min(num_samples, len(converted))):
+        z_sample = converted[idx]
+        for field in FIELDS:
+            ref = getattr(original, f"getitem_{field}")(idx).numpy()
+            got = z_sample[field].numpy()
+            ref_s = np.sort(ref.reshape(len(ref), -1), axis=0)
+            got_s = np.sort(got.reshape(len(got), -1), axis=0)
+            worst[field] = max(worst[field], float(np.abs(ref_s - got_s).max()))
+    for field in FIELDS:
+        kind = "f32 exact" if "position" in field else "f16"
+        print(f"  {field:18s} max abs err = {worst[field]:.2e}   ({kind})")
+
+
+class _CountingLocalStore(LocalStore):
+    """LocalStore that tallies bytes returned for chunk-data keys."""
+
+    bytes_read = 0
+
+    async def get(self, key, prototype, byte_range=None):  # type: ignore[override]
+        res = await super().get(key, prototype, byte_range)
+        if res is not None and "/c/" in str(key):
+            type(self).bytes_read += len(res)
+        return res
+
+
+def check_read_amplification(zarr_root: str, num_volume_points: int) -> None:
+    """Measure bytes fetched for a chunk-subsampled read vs a full read."""
+    reader = ZarrChunkReader(zarr_root, store_factory=lambda p: _CountingLocalStore(p, read_only=True))
+    sample_id = next(iter(reader.manifest.samples))
+
+    _CountingLocalStore.bytes_read = 0
+    reader.read_sample(sample_id, num_points={"surface": None, "volume": num_volume_points})
+    sub = _CountingLocalStore.bytes_read
+
+    reader._groups.clear()
+    _CountingLocalStore.bytes_read = 0
+    reader.read_sample(sample_id, num_points=None)
+    full = _CountingLocalStore.bytes_read
+
+    print(f"\n== Read amplification (sample {sample_id}) ==")
+    print(f"  full read           : {full / 1024:8.1f} KiB")
+    print(f"  volume={num_volume_points} subsample: {sub / 1024:8.1f} KiB")
+    print(f"  bytes saved         : {100 * (1 - sub / full):.1f}%  (full/sub = {full / sub:.1f}x)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate/benchmark a ShapeNet-Car Zarr store.")
+    parser.add_argument("--pt-root", type=str, required=True, help="Original dataset root (contains 'preprocessed').")
+    parser.add_argument("--zarr-root", type=str, required=True, help="Converted Zarr store root.")
+    parser.add_argument("--num-samples", type=int, default=10, help="Samples to check for equivalence.")
+    parser.add_argument("--num-volume-points", type=int, default=4096, help="Volume subsample size for the read test.")
+    args = parser.parse_args()
+
+    print(f"Store size: {_dir_size(args.zarr_root) / 1e9:.3f} GB")
+    check_equivalence(args.pt_root, args.zarr_root, args.num_samples)
+    check_read_amplification(args.zarr_root, args.num_volume_points)
+
+
+def _dir_size(path: str) -> int:
+    total = 0
+    for root, _, files in Path(path).walk():
+        total += sum((root / f).stat().st_size for f in files)
+    return total
+
+
+if __name__ == "__main__":
+    main()

--- a/src/noether/data/zarr_store/convert.py
+++ b/src/noether/data/zarr_store/convert.py
@@ -1,0 +1,477 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Convert a per-field ``.pt`` CFD dataset into the chunked/sharded Zarr store.
+
+Works for any FileMap-based :class:`~noether.data.datasets.cfd.dataset.AeroDataset`
+(ShapeNet-Car, DrivAerML, AhmedML, DrivAerNet, …) from two kinds of sources:
+
+* ``--root`` — a local/NFS dataset root: the dataset class itself supplies the
+  ``FileMap``, the per-split sample lists and the directory layout (via ``_load``).
+* ``--source-url`` — any fsspec location (``oci://bucket@namespace/prefix``,
+  ``s3://bucket/prefix``, a plain directory, …): samples are discovered by listing the
+  prefix and grouping ``.pt`` files by directory, then streamed without a local copy.
+
+Samples are converted in a :class:`~concurrent.futures.ProcessPoolExecutor` so the
+GIL-bound parts (``torch.load`` deserialization, numpy shuffles) parallelize fully;
+each worker process builds its own source handle and writer, and the manifest is
+assembled in the parent from the returned entries (bit-identical to a sequential run —
+per-sample shuffles are seeded by sample id).
+
+Usage::
+
+    uv run python -m noether.data.zarr_store.convert \
+        --dataset-kind noether.data.datasets.cfd.DrivAerNetDataset \
+        --source-url oci://emmi-drivaernet@<namespace>/subsampled_volume10x \
+        --output /data/drivaernet/zarr_store \
+        --chunk-points 16384 --workers 16
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import io
+import logging
+import sys
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from concurrent.futures import ProcessPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+import fsspec
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from noether.core.factory.utils import class_constructor_from_class_path
+from noether.core.schemas.lib import resolve_config_class
+from noether.data.base.dataset import DatasetBaseConfig
+from noether.data.schemas import FileMap
+from noether.data.zarr_store.layout import filename_to_canonical, present_specs
+from noether.data.zarr_store.writer import ZarrStoreWriter
+
+if TYPE_CHECKING:
+    from noether.data.datasets.cfd.dataset import AeroDataset
+    from noether.data.zarr_store.manifest import SampleEntry
+
+logger = logging.getLogger(__name__)
+
+# One fsspec conversion task: (sample_id, canonical_field -> filesystem path).
+FsspecTask = tuple[str, dict[str, str]]
+
+
+# --------------------------------------------------------------------------- #
+# sources
+# --------------------------------------------------------------------------- #
+def build_dataset(kind: str, root: str, split: str) -> AeroDataset:
+    """Instantiate a dataset ``kind`` for one split (raw: no normalizers/wrappers)."""
+    dataset_cls = class_constructor_from_class_path(kind)
+    # Concrete config (StandardDatasetConfig subclass) carries root/split; typed Any so the
+    # call isn't checked against the abstract DatasetBaseConfig signature.
+    config_cls: Any = resolve_config_class(kind, DatasetBaseConfig)
+    config = config_cls(kind=kind, root=root, split=split)
+    return dataset_cls(config)  # type: ignore[no-any-return]
+
+
+def filemap_for_dataset_kind(kind: str) -> FileMap:
+    """Resolve a dataset kind's ``FileMap`` without instantiating the dataset.
+
+    Looks for, in order: a ``FILEMAP`` class attribute, a ``filemap`` ``__init__``
+    default anywhere in the MRO, and finally a ``FileMap`` instance in the dataset's
+    module globals.
+    """
+    dataset_cls: Any = class_constructor_from_class_path(kind)
+    candidate = getattr(dataset_cls, "FILEMAP", None)
+    if isinstance(candidate, FileMap):
+        return candidate
+    for klass in dataset_cls.__mro__:
+        init = klass.__dict__.get("__init__")
+        if init is None:
+            continue
+        try:
+            parameter = inspect.signature(init).parameters.get("filemap")
+        except (TypeError, ValueError):
+            continue
+        if parameter is not None and isinstance(parameter.default, FileMap):
+            return parameter.default
+    module = sys.modules.get(dataset_cls.__module__)
+    for value in vars(module).values() if module else ():
+        if isinstance(value, FileMap):
+            return value
+    raise ValueError(f"Could not resolve a FileMap for '{kind}'; pass one explicitly.")
+
+
+def discover_fsspec_samples(source_url: str, filemap: FileMap, limit: int | None = None) -> list[FsspecTask]:
+    """List *source_url* and group its ``.pt`` files into per-sample conversion tasks.
+
+    A sample is any directory (prefix) containing every field of *filemap*; incomplete
+    samples are skipped with a warning. Sample ids are the directory paths relative to
+    the prefix (e.g. ``"E_S_WWC_WM_005"`` or ``"param1/<hash>"``), matching the ids the
+    dataset-driven path produces.
+    """
+    fs, base = fsspec.url_to_fs(str(source_url))
+    base = base.rstrip("/")
+    to_canonical = filename_to_canonical(filemap)
+    expected = {spec.canonical for spec in present_specs(filemap)}
+
+    grouped: dict[str, dict[str, str]] = defaultdict(dict)
+    for path in fs.find(base):
+        relative = path[len(base) :].lstrip("/")
+        sample_id, _, filename = relative.rpartition("/")
+        canonical = to_canonical.get(filename)
+        if sample_id and canonical:
+            grouped[sample_id][canonical] = path
+
+    tasks = [(sample_id, fields) for sample_id, fields in sorted(grouped.items()) if set(fields) == expected]
+    if len(tasks) < len(grouped):
+        logger.warning("Skipping %d samples with missing fields under %s", len(grouped) - len(tasks), source_url)
+    return tasks[:limit] if limit is not None else tasks
+
+
+def _sample_id(dataset: AeroDataset, idx: int) -> str:
+    """Stable manifest id for sample *idx* — the dataset's run/design id, else its index."""
+    sample_info = getattr(dataset, "sample_info", None)
+    if callable(sample_info):
+        info = sample_info(idx) or {}
+        for key in ("run_name", "design_id"):
+            value = info.get(key)
+            if value is not None:
+                return str(value)
+    design_ids = getattr(dataset, "design_ids", None)
+    if design_ids is not None:
+        return str(design_ids[idx])
+    return str(idx)
+
+
+def _load_dataset_fields(dataset: AeroDataset, idx: int) -> dict[str, np.ndarray]:
+    """Read all present fields of sample *idx* through the dataset's own ``_load`` (raw)."""
+    filemap = dataset.filemap
+    return {
+        spec.canonical: np.asarray(dataset._load(idx, getattr(filemap, spec.filemap_attr)).numpy())
+        for spec in present_specs(filemap)
+    }
+
+
+# --------------------------------------------------------------------------- #
+# process-pool machinery
+# --------------------------------------------------------------------------- #
+# Per-process state, populated by the pool initializer (each worker owns its source
+# handle and writer; only the small SampleEntry results travel back to the parent).
+_WORKER: dict[str, Any] = {}
+
+
+def _init_dataset_worker(dataset: AeroDataset, writer_kwargs: dict[str, Any]) -> None:
+    _WORKER["dataset"] = dataset
+    _WORKER["writer"] = ZarrStoreWriter(**writer_kwargs)
+
+
+def _convert_dataset_sample(idx: int) -> tuple[str, SampleEntry | None, str | None]:
+    dataset, writer = _WORKER["dataset"], _WORKER["writer"]
+    sample_id = _sample_id(dataset, idx)
+    try:
+        return sample_id, writer.write_group(sample_id, _load_dataset_fields(dataset, idx)), None
+    except Exception as exc:  # broken sample (e.g. misaligned fields) — parent reports and skips it
+        return sample_id, None, f"{type(exc).__name__}: {exc}"
+
+
+def _init_fsspec_worker(source_url: str, writer_kwargs: dict[str, Any]) -> None:
+    _WORKER["fs"], _ = fsspec.url_to_fs(source_url)
+    _WORKER["writer"] = ZarrStoreWriter(**writer_kwargs)
+
+
+def _convert_fsspec_sample(task: FsspecTask) -> tuple[str, SampleEntry | None, str | None]:
+    sample_id, field_paths = task
+    fs, writer = _WORKER["fs"], _WORKER["writer"]
+    try:
+        field_arrays = {
+            canonical: np.asarray(torch.load(io.BytesIO(fs.cat_file(path)), weights_only=True).numpy())
+            for canonical, path in field_paths.items()
+        }
+        return sample_id, writer.write_group(sample_id, field_arrays), None
+    except Exception as exc:  # broken sample (e.g. misaligned fields) — parent reports and skips it
+        return sample_id, None, f"{type(exc).__name__}: {exc}"
+
+
+def _run_pool(
+    tasks: Iterable[Any],
+    task_fn: Callable[[Any], tuple[str, SampleEntry | None, str | None]],
+    initializer: Callable[..., None],
+    initargs: tuple[Any, ...],
+    writer: ZarrStoreWriter,
+    max_workers: int,
+    desc: str,
+) -> list[tuple[str, str]]:
+    """Convert *tasks* (in worker processes when ``max_workers > 1``) and collect entries.
+
+    Broken samples (e.g. misaligned fields) are skipped with a warning instead of aborting
+    the run; the ``(sample_id, error)`` pairs of skipped samples are returned. Raises only
+    when *every* task failed (a systemic problem, not a data quirk).
+    """
+    tasks = list(tasks)
+    failures: list[tuple[str, str]] = []
+
+    def _collect(result: tuple[str, SampleEntry | None, str | None]) -> None:
+        sample_id, entry, error = result
+        if entry is None:
+            failures.append((sample_id, error or "unknown error"))
+            logger.warning("Skipping sample '%s': %s", sample_id, error)
+        else:
+            writer.manifest.samples[sample_id] = entry  # parent process only
+        bar.update()
+
+    bar = tqdm(total=len(tasks), desc=desc, unit="sample")
+    if max_workers > 1:
+        with ProcessPoolExecutor(max_workers=max_workers, initializer=initializer, initargs=initargs) as executor:
+            for result in executor.map(task_fn, tasks):
+                _collect(result)
+    else:
+        initializer(*initargs)
+        try:
+            for task in tasks:
+                _collect(task_fn(task))
+        finally:
+            _WORKER.clear()
+    bar.close()
+
+    if failures:
+        skipped = ", ".join(sample_id for sample_id, _ in failures[:5])
+        logger.warning("Skipped %d/%d samples due to errors (e.g. %s)", len(failures), len(tasks), skipped)
+    if tasks and len(failures) == len(tasks):
+        raise RuntimeError(f"All {len(tasks)} samples failed; first error ({failures[0][0]}): {failures[0][1]}")
+    return failures
+
+
+# --------------------------------------------------------------------------- #
+# converters
+# --------------------------------------------------------------------------- #
+def convert_aero_dataset(
+    dataset: AeroDataset, writer: ZarrStoreWriter, *, max_workers: int = 1, limit: int | None = None
+) -> ZarrStoreWriter:
+    """Write every sample of a FileMap-based dataset into *writer* (does not save the manifest).
+
+    Args:
+        dataset: A FileMap-based ``AeroDataset`` instance (one split).
+        writer: Target store writer; reused across splits to build one store.
+        max_workers: Worker *processes* converting samples concurrently; the dataset and
+            a writer clone are set up once per process.
+        limit: If set, convert at most this many samples (debugging).
+
+    Returns:
+        The same ``writer`` (call :meth:`ZarrStoreWriter.save_manifest` once when done).
+
+    Raises:
+        ValueError: If the dataset does not expose a ``filemap``.
+    """
+    if not isinstance(getattr(dataset, "filemap", None), FileMap):
+        raise ValueError(f"{type(dataset).__name__} has no FileMap; the Zarr converter requires one.")
+    count = len(dataset) if limit is None else min(limit, len(dataset))
+    desc = f"split={getattr(dataset, 'split', '?')}"
+    _run_pool(
+        range(count),
+        _convert_dataset_sample,
+        _init_dataset_worker,
+        (dataset, writer.to_init_kwargs()),
+        writer,
+        max_workers,
+        desc,
+    )
+    return writer
+
+
+def convert_fsspec_source(
+    source_url: str, filemap: FileMap, writer: ZarrStoreWriter, *, max_workers: int = 1, limit: int | None = None
+) -> ZarrStoreWriter:
+    """Stream-convert a remote (or local) ``.pt`` tree reachable through fsspec.
+
+    Samples are discovered once in the parent by listing *source_url*; each worker
+    process opens its own filesystem handle and reads sample files directly from the
+    source (no local staging copy).
+
+    Args:
+        source_url: fsspec location of the ``.pt`` tree (``oci://``, ``s3://``, a path, …).
+        filemap: Field-to-filename mapping of the dataset (see :func:`filemap_for_dataset_kind`).
+        writer: Target store writer.
+        max_workers: Worker processes converting samples concurrently.
+        limit: If set, convert at most this many samples (debugging/benchmarks).
+
+    Returns:
+        The same ``writer`` (call :meth:`ZarrStoreWriter.save_manifest` once when done).
+
+    Raises:
+        RuntimeError: If no complete samples are found under *source_url*.
+    """
+    tasks = discover_fsspec_samples(source_url, filemap, limit)
+    if not tasks:
+        raise RuntimeError(f"No complete samples found under {source_url}.")
+    logger.info("Discovered %d samples under %s", len(tasks), source_url)
+    _run_pool(
+        tasks,
+        _convert_fsspec_sample,
+        _init_fsspec_worker,
+        (str(source_url), writer.to_init_kwargs()),
+        writer,
+        max_workers,
+        desc="fsspec-source",
+    )
+    return writer
+
+
+def convert(
+    dataset_kind: str,
+    store_root: str,
+    *,
+    root: str | None = None,
+    source_url: str | None = None,
+    splits: list[str] | None = None,
+    dataset_name: str | None = None,
+    chunk_points: int = 4096,
+    shard_points: int | None = None,
+    shuffle_seed: int = 0,
+    values_dtype: str = "float16",
+    field_dtypes: dict[str, str] | None = None,
+    limit: int | None = None,
+    max_workers: int = 1,
+) -> ZarrStoreWriter:
+    """Convert a FileMap dataset into a single Zarr store.
+
+    Exactly one of *root* (local dataset-driven, per split) or *source_url* (fsspec
+    streaming, all samples under the prefix) must be given.
+
+    Args:
+        dataset_kind: Fully-qualified dataset class path (supplies the ``FileMap``).
+        store_root: Output Zarr store — a local path or fsspec URL (``s3://``, ``gs://``, …).
+        root: Local dataset root (dataset-driven source).
+        source_url: fsspec source prefix (streaming source; ``splits`` is ignored).
+        splits: Splits to convert for the dataset-driven source (default train/test/val);
+            unsupported/empty ones are skipped with a warning.
+        dataset_name: Manifest name (defaults to the dataset class name).
+        chunk_points: Chunk size along the point axis (pick close to the train subsample size).
+        shard_points: Cap on the shard size along the point axis (``None`` = one shard per array).
+        shuffle_seed: Base seed for the per-sample point shuffle.
+        values_dtype: Dtype for the physical field arrays.
+        field_dtypes: Per-field dtype overrides, e.g. ``{"volume_vorticity": "float32"}``
+            for fields whose values exceed the float16 range.
+        limit: If set, convert at most this many samples per split / source.
+        max_workers: Worker processes converting samples concurrently.
+
+    Returns:
+        The writer with the saved manifest.
+
+    Raises:
+        ValueError: If not exactly one of *root* / *source_url* is given.
+        RuntimeError: If nothing could be converted.
+    """
+    if (root is None) == (source_url is None):
+        raise ValueError("Provide exactly one of `root` (local dataset) or `source_url` (fsspec source).")
+    name = dataset_name or dataset_kind.rsplit(".", 1)[-1]
+
+    if source_url is not None:
+        filemap = filemap_for_dataset_kind(dataset_kind)
+        writer = ZarrStoreWriter(
+            store_root=store_root,
+            filemap=filemap,
+            dataset_name=name,
+            shuffle_seed=shuffle_seed,
+            chunk_points=chunk_points,
+            shard_points=shard_points,
+            values_dtype=values_dtype,
+            field_dtypes=field_dtypes,
+        )
+        convert_fsspec_source(source_url, filemap, writer, max_workers=max_workers, limit=limit)
+        writer.save_manifest()
+        logger.info("Done. %d samples from %s -> %s", len(writer.manifest.samples), source_url, store_root)
+        return writer
+
+    maybe_writer: ZarrStoreWriter | None = None
+    total = 0
+    for split in splits or ["train", "test", "val"]:
+        try:
+            dataset = build_dataset(dataset_kind, str(root), split)
+        except Exception as exc:  # unsupported split, missing data, bad root, …
+            logger.warning("Skipping split '%s': %s", split, exc)
+            continue
+        if maybe_writer is None:
+            maybe_writer = ZarrStoreWriter(
+                store_root=store_root,
+                filemap=dataset.filemap,
+                dataset_name=name,
+                shuffle_seed=shuffle_seed,
+                chunk_points=chunk_points,
+                shard_points=shard_points,
+                values_dtype=values_dtype,
+                field_dtypes=field_dtypes,
+            )
+        convert_aero_dataset(dataset, maybe_writer, max_workers=max_workers, limit=limit)
+        converted = len(dataset) if limit is None else min(limit, len(dataset))
+        total += converted
+        logger.info("Converted split '%s' (%d samples)", split, converted)
+
+    if maybe_writer is None:
+        raise RuntimeError(f"No splits converted for {dataset_kind} (tried {splits}). Check --root/--splits.")
+    maybe_writer.save_manifest()
+    logger.info("Done. %d samples -> %s", total, store_root)
+    return maybe_writer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert a FileMap .pt CFD dataset into a chunked/sharded Zarr store.")
+    parser.add_argument(
+        "--dataset-kind",
+        required=True,
+        help="Dataset class path, e.g. noether.data.datasets.cfd.DrivAerNetDataset.",
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--root", help="Local dataset root (dataset-driven source, converted per split).")
+    source.add_argument(
+        "--source-url",
+        help="fsspec source prefix to stream from, e.g. oci://bucket@namespace/prefix or s3://bucket/prefix.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output Zarr store root: a local path or an fsspec URL (e.g. s3://bucket/prefix).",
+    )
+    parser.add_argument("--splits", nargs="+", default=["train", "test", "val"], help="Splits (local source only).")
+    parser.add_argument("--workers", type=int, default=1, help="Worker processes converting samples concurrently.")
+    parser.add_argument("--chunk-points", type=int, default=4096, help="Chunk size along the point axis.")
+    parser.add_argument(
+        "--shard-points",
+        type=int,
+        default=None,
+        help="Cap on the shard size along the point axis (default: one shard per array).",
+    )
+    parser.add_argument("--shuffle-seed", type=int, default=0, help="Base seed for the point shuffle.")
+    parser.add_argument("--values-dtype", type=str, default="float16", help="Dtype for physical fields.")
+    parser.add_argument(
+        "--field-dtype",
+        action="append",
+        default=None,
+        metavar="FIELD=DTYPE",
+        help="Per-field dtype override (repeatable), e.g. --field-dtype volume_vorticity=float32.",
+    )
+    parser.add_argument("--dataset-name", type=str, default=None, help="Manifest dataset name (default: class name).")
+    parser.add_argument("--limit", type=int, default=None, help="Convert at most N samples per split/source (debug).")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    field_dtypes = dict(item.split("=", 1) for item in args.field_dtype) if args.field_dtype else None
+    convert(
+        dataset_kind=args.dataset_kind,
+        store_root=args.output,
+        root=args.root,
+        source_url=args.source_url,
+        splits=args.splits,
+        dataset_name=args.dataset_name,
+        chunk_points=args.chunk_points,
+        shard_points=args.shard_points,
+        shuffle_seed=args.shuffle_seed,
+        values_dtype=args.values_dtype,
+        field_dtypes=field_dtypes,
+        limit=args.limit,
+        max_workers=args.workers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/noether/data/zarr_store/layout.py
+++ b/src/noether/data/zarr_store/layout.py
@@ -1,0 +1,163 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Mapping between Noether ``FileMap`` fields and the per-field Zarr array layout.
+
+Every CFD field is assigned to a domain (``surface`` / ``volume``), a canonical
+name (``f"{domain}_{name}"`` — matching the dataset's ``getitem_*`` / normalizer
+keys), a channel width, and a *kind*:
+
+* ``coord`` — point positions, stored float32;
+* ``value`` — physical quantities, stored float16.
+
+Each field becomes its own Zarr array (``<domain>/<name>``), so fields are read
+independently; all arrays of a domain share the shuffle permutation and chunk grid.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from noether.data.schemas import FileMap
+from noether.data.zarr_store.manifest import ArrayLayout, DomainLayout
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Static description of one CFD field."""
+
+    filemap_attr: str
+    """Attribute name on :class:`~noether.data.schemas.FileMap`."""
+    domain: str
+    name: str
+    """Short name within the domain; combined as ``f"{domain}_{name}"``."""
+    dim: int
+    """Channel width (1 for scalars, 3 for vectors)."""
+    kind: str
+    """``"coord"`` or ``"value"``."""
+
+    @property
+    def canonical(self) -> str:
+        """Canonical field key, e.g. ``"volume_velocity"``."""
+        return f"{self.domain}_{self.name}"
+
+
+# Per-sample metadata that is not a point cloud and therefore not stored as point arrays.
+EXCLUDED_FILEMAP_FIELDS: frozenset[str] = frozenset({"design_parameters"})
+
+# FileMap attributes whose (domain, name) cannot be derived by splitting on the first
+# underscore: the STL point clouds have their own point counts, so they get their own
+# domains (a domain = one aligned point set with one chunk grid).
+_DOMAIN_OVERRIDES: dict[str, tuple[str, str]] = {
+    "surface_position_stl": ("surface_stl", "position"),
+    "surface_position_stl_resampled": ("surface_stl_resampled", "position"),
+}
+
+# Short-name overrides so canonical keys match the dataset getitem_* / normalizer keys.
+_NAME_OVERRIDES: dict[str, str] = {"distance_to_surface": "sdf"}
+
+# Channel width per semantic field name (scalars 1, vectors 3).
+_FIELD_DIMS: dict[str, int] = {
+    "position": 3,
+    "pressure": 1,
+    "friction": 3,
+    "normals": 3,
+    "area": 1,
+    "velocity": 3,
+    "vorticity": 3,
+    "sdf": 1,
+}
+
+
+def _build_field_specs() -> list[FieldSpec]:
+    """Derive one :class:`FieldSpec` per point-cloud field of the ``FileMap`` schema.
+
+    Generic over all CFD datasets: any ``FileMap`` attribute (current or future) must be
+    either excluded here or resolvable to a (domain, name, dim) — unknown names raise at
+    import time so new schema fields cannot be silently dropped from conversion.
+    """
+    specs: list[FieldSpec] = []
+    for attr in FileMap.model_fields:
+        if attr in EXCLUDED_FILEMAP_FIELDS:
+            continue
+        domain, _, name = attr.partition("_")
+        domain, name = _DOMAIN_OVERRIDES.get(attr, (domain, name))
+        name = _NAME_OVERRIDES.get(name, name)
+        if name not in _FIELD_DIMS:
+            raise ValueError(
+                f"FileMap field '{attr}' has no dim/kind mapping in noether.data.zarr_store.layout; "
+                "add it to _FIELD_DIMS (or EXCLUDED_FILEMAP_FIELDS if it is not a point cloud)."
+            )
+        kind = "coord" if name == "position" else "value"
+        specs.append(FieldSpec(attr, domain, name, _FIELD_DIMS[name], kind))
+    return specs
+
+
+# Order follows the FileMap schema; it defines the array order inside each domain layout.
+# Positions (kind="coord") are stored float32; everything else float16 by default.
+FIELD_SPECS: list[FieldSpec] = _build_field_specs()
+
+CANONICAL_TO_SPEC: dict[str, FieldSpec] = {spec.canonical: spec for spec in FIELD_SPECS}
+
+
+def present_specs(filemap: FileMap) -> list[FieldSpec]:
+    """Return the :data:`FIELD_SPECS` whose ``filemap_attr`` is set on *filemap*."""
+    return [spec for spec in FIELD_SPECS if getattr(filemap, spec.filemap_attr, None) is not None]
+
+
+def build_domain_layouts(
+    filemap: FileMap,
+    coords_dtype: str = "float32",
+    values_dtype: str = "float16",
+    field_dtypes: dict[str, str] | None = None,
+) -> dict[str, DomainLayout]:
+    """Build the per-domain :class:`DomainLayout` (one array per field) present in *filemap*.
+
+    Args:
+        filemap: Field-to-filename mapping for the dataset being converted.
+        coords_dtype: Dtype string for position arrays.
+        values_dtype: Dtype string for physical field arrays.
+        field_dtypes: Per-field dtype overrides keyed by canonical name, e.g.
+            ``{"volume_vorticity": "float32"}`` for fields whose dynamic range exceeds
+            ``values_dtype`` (float16 caps at ~6.6e4).
+
+    Returns:
+        Mapping ``domain -> DomainLayout``.
+
+    Raises:
+        ValueError: If a domain has no (or more than one) coordinate field.
+    """
+    specs = present_specs(filemap)
+    domains = sorted({spec.domain for spec in specs})
+    overrides = field_dtypes or {}
+
+    layouts: dict[str, DomainLayout] = {}
+    for domain in domains:
+        domain_specs = [s for s in specs if s.domain == domain]
+        coord_specs = [s for s in domain_specs if s.kind == "coord"]
+        if len(coord_specs) != 1:
+            raise ValueError(f"Domain '{domain}' must have exactly one coordinate field, found {len(coord_specs)}.")
+        arrays = {
+            spec.canonical: ArrayLayout(
+                array_name=f"{domain}/{spec.name}",
+                field=spec.canonical,
+                dtype=overrides.get(spec.canonical, coords_dtype if spec.kind == "coord" else values_dtype),
+                dim=spec.dim,
+            )
+            for spec in domain_specs
+        }
+        layouts[domain] = DomainLayout(position=coord_specs[0].canonical, arrays=arrays)
+    return layouts
+
+
+def filename_to_canonical(filemap: FileMap) -> dict[str, str]:
+    """Reverse map ``stored_filename -> canonical_field`` for the present fields.
+
+    Lets a Zarr-backed dataset translate the ``.pt`` filename referenced by an
+    ``AeroDataset.getitem_*`` method back to the canonical field key used in the
+    Zarr store.
+    """
+    mapping: dict[str, str] = {}
+    for spec in present_specs(filemap):
+        filename = getattr(filemap, spec.filemap_attr)
+        mapping[filename] = spec.canonical
+    return mapping

--- a/src/noether/data/zarr_store/manifest.py
+++ b/src/noether/data/zarr_store/manifest.py
@@ -1,0 +1,111 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Manifest schema for the chunked/sharded Zarr CFD store.
+
+The manifest is a small JSON sidecar written next to the per-sample Zarr groups.
+It records the *global* column layout (which field lives in which array and at
+which column offset) once, plus the *per-sample* chunk grid (point count, chunk
+size, shard size, number of chunks) for every domain.
+
+The dataloader uses the manifest to:
+
+* pick random chunk indices per (sample, domain) without opening every array's
+  metadata first, and
+* map the fused value array columns back onto individual named fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+import fsspec
+from pydantic import BaseModel, Field
+
+
+class ArrayLayout(BaseModel):
+    """Layout of a single per-field Zarr array.
+
+    Every field is its own array (``<domain>/<name>``) so fields can be read
+    independently. The channel axis is never chunked, and each array is packed into a
+    single whole-array shard, so the per-sample object count stays at one object per
+    field while chunks remain individually range-readable.
+    """
+
+    array_name: str
+    """Zarr path of the array within the per-sample group, e.g. ``"volume/velocity"``."""
+    field: str
+    """Canonical field name served by this array, e.g. ``"volume_velocity"``."""
+    dtype: str
+    """On-disk dtype of the array, e.g. ``"float32"`` or ``"float16"``."""
+    dim: int
+    """Channel width (1 for scalars, 3 for vectors)."""
+
+
+class DomainLayout(BaseModel):
+    """Per-field arrays of one domain.
+
+    All arrays of a domain share the point axis, the shuffle permutation and the chunk
+    grid, so chunk ``c`` addresses the same physical points in every field.
+    """
+
+    position: str
+    """Canonical name of the domain's coordinate field (e.g. ``"volume_position"``)."""
+    arrays: dict[str, ArrayLayout]
+    """Mapping ``canonical_field -> array layout`` (includes the position array)."""
+
+
+class DomainSample(BaseModel):
+    """Per-sample chunk grid for one domain."""
+
+    n_points: int
+    """Number of points (rows) for this sample/domain."""
+    chunk_points: int
+    """Chunk size along the point axis."""
+    shard_points: int
+    """Shard size along the point axis — a whole number of chunks; the full array
+    (``n_chunks * chunk_points``) unless the writer's ``shard_points`` cap split the
+    arrays into multiple shards."""
+    n_chunks: int
+    """Number of chunks along the point axis (``ceil(n_points / chunk_points)``)."""
+
+
+class SampleEntry(BaseModel):
+    """Manifest entry for a single sample."""
+
+    relpath: str
+    """Path of the sample's Zarr group relative to the store root."""
+    domains: dict[str, DomainSample]
+    """Per-domain chunk grids."""
+
+
+class StoreManifest(BaseModel):
+    """Top-level manifest for a converted Zarr store."""
+
+    dataset_name: str
+    format_version: int = 1
+    shuffle_seed: int
+    """Base seed used to derive the per-sample point shuffle permutations."""
+    coords_dtype: str = "float32"
+    values_dtype: str = "float16"
+    compressor: str = "blosc-zstd"
+    domains: dict[str, DomainLayout]
+    """Global column layout, shared by every sample."""
+    samples: dict[str, SampleEntry] = Field(default_factory=dict)
+    """Per-sample chunk grids keyed by sample id."""
+
+    MANIFEST_NAME: ClassVar[str] = "manifest.json"
+
+    def save(self, store_root: str | Path) -> str:
+        """Write the manifest to ``<store_root>/manifest.json`` (local path or fsspec URL)."""
+        path = f"{str(store_root).rstrip('/')}/{self.MANIFEST_NAME}"
+        with fsspec.open(path, "w") as f:
+            f.write(self.model_dump_json(indent=2))
+        return path
+
+    @classmethod
+    def load(cls, store_root: str | Path) -> StoreManifest:
+        """Load the manifest from ``<store_root>/manifest.json`` (local path or fsspec URL)."""
+        path = f"{str(store_root).rstrip('/')}/{cls.MANIFEST_NAME}"
+        with fsspec.open(path, "r") as f:
+            return cls.model_validate_json(f.read())

--- a/src/noether/data/zarr_store/reader.py
+++ b/src/noether/data/zarr_store/reader.py
@@ -1,0 +1,262 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Chunk-sampling reader for the Zarr CFD store.
+
+The reader turns "draw ``T`` random points from a sample" into "read a few random
+chunks". Because points were shuffled once at write time, any chunk is already a
+uniform-random subset, so the reader only fetches ``ceil(T / chunk_points)`` chunks
+per array instead of the whole sample. Reading a chunk from a sharded array is a
+byte-range request, so the bytes transferred scale with ``T`` and not with the
+sample size.
+
+The per-sample chunk reads are independent, so they can be issued concurrently. Set
+``read_concurrency > 1`` to fetch a sample's chunks (across both arrays and both
+domains) in a thread pool — this hides per-request latency on high-latency stores
+(e.g. S3) and is a no-op cost on fast local stores, where the default of ``1`` keeps
+reads serial.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import numpy as np
+import torch
+import zarr
+from zarr.abc.store import Store
+
+from noether.data.zarr_store import stores
+from noether.data.zarr_store.manifest import ArrayLayout, StoreManifest
+
+# One per-array read job: (array, chunk-aligned row slices or None for full, target points, layout).
+_ReadJob = tuple["zarr.Array", "list[tuple[int, int]] | None", "int | None", ArrayLayout]
+
+
+def _default_store_factory(path: str) -> Store:
+    """Open a read-only store for a sample group (LocalStore or FsspecStore by path)."""
+    return stores.make_store(path, read_only=True)
+
+
+class ZarrChunkReader:
+    """Reads chunk-subsampled (or full) per-field tensors from a converted store."""
+
+    def __init__(
+        self,
+        store_root: str | Path,
+        manifest: StoreManifest | None = None,
+        store_factory: Callable[[str], Store] = _default_store_factory,
+        read_concurrency: int = 1,
+    ) -> None:
+        """
+
+        Args:
+            store_root: Root of the converted Zarr store — a local path or an fsspec URL
+                (``s3://``, ``gs://``, ``memory://``, …) for object storage.
+            manifest: Pre-loaded manifest; loaded from ``store_root`` if omitted.
+            store_factory: Builds a Zarr store from a sample-group path/URL. Defaults to a
+                read-only LocalStore/FsspecStore by path; override to wrap the store (e.g.
+                for byte-accounting in benchmarks).
+            read_concurrency: Max threads used to fetch a sample's chunks in parallel.
+                ``1`` (default) reads serially — best for fast local stores. Use a value
+                around the number of chunks per sample to hide latency on S3.
+        """
+        self.store_root = str(store_root)
+        self.manifest = manifest if manifest is not None else StoreManifest.load(self.store_root)
+        self._store_factory = store_factory
+        self.read_concurrency = max(1, read_concurrency)
+        self._groups: dict[str, zarr.Group] = {}
+
+    def _group(self, relpath: str) -> zarr.Group:
+        """Return a cached read-only handle to a sample's Zarr group."""
+        group = self._groups.get(relpath)
+        if group is None:
+            group = zarr.open_group(store=self._store_factory(stores.join(self.store_root, relpath)), mode="r")
+            self._groups[relpath] = group
+        return group
+
+    @staticmethod
+    def _select_row_slices(
+        n_points: int,
+        chunk_points: int,
+        n_chunks: int,
+        num_points: int | None,
+        generator: torch.Generator | None,
+    ) -> list[tuple[int, int]] | None:
+        """Pick chunk-aligned ``(start, stop)`` row slices covering ``num_points`` rows.
+
+        Returns ``None`` to signal "read everything" (when ``num_points`` is ``None`` or
+        at least the sample size). Otherwise random chunk indices are accumulated until
+        their combined length reaches ``num_points``; the caller trims the surplus.
+        """
+        if num_points is None or num_points >= n_points:
+            return None
+        order = torch.randperm(n_chunks, generator=generator).tolist()
+        slices: list[tuple[int, int]] = []
+        gathered = 0
+        for chunk_idx in order:
+            start = chunk_idx * chunk_points
+            stop = min(start + chunk_points, n_points)
+            slices.append((start, stop))
+            gathered += stop - start
+            if gathered >= num_points:
+                break
+        return slices
+
+    @staticmethod
+    def _assemble(parts: list[np.ndarray], slices: list[tuple[int, int]] | None, num_points: int | None) -> np.ndarray:
+        """Concatenate a single array's chunk blocks (in order) and trim to ``num_points``."""
+        if slices is None:
+            return parts[0]
+        data = np.concatenate(parts, axis=0)
+        if num_points is not None:
+            data = data[:num_points]
+        return cast("np.ndarray", data)
+
+    @staticmethod
+    def _row_indices(slices: list[tuple[int, int]], num_points: int | None) -> np.ndarray:
+        """Flatten chunk-aligned slices into an ordered row-index array, trimmed to ``num_points``."""
+        rows = np.concatenate([np.arange(start, stop) for start, stop in slices])
+        return cast("np.ndarray", rows[:num_points] if num_points is not None else rows)
+
+    @staticmethod
+    def _to_field_tensor(layout: ArrayLayout, data: np.ndarray) -> torch.Tensor:
+        """Convert one per-field array block to its float32 tensor (scalars squeezed to 1-D)."""
+        tensor = torch.from_numpy(np.ascontiguousarray(data)).float()
+        return tensor.squeeze(1) if layout.dim == 1 else tensor
+
+    def _read_serial(self, jobs: list[_ReadJob]) -> dict[int, np.ndarray]:
+        """One read per array — a single orthogonal selection (or full read).
+
+        Lowest call overhead, so this is the fastest path on low-latency stores (local
+        disk / NFS). zarr fetches the chunks the selection touches.
+        """
+        blocks: dict[int, np.ndarray] = {}
+        for job_idx, (array, slices, target, _) in enumerate(jobs):
+            if slices is None:
+                blocks[job_idx] = np.asarray(array[:])
+            else:
+                blocks[job_idx] = np.asarray(array.oindex[self._row_indices(slices, target)])
+        return blocks
+
+    def _read_parallel(self, jobs: list[_ReadJob]) -> dict[int, np.ndarray]:
+        """Flatten every ``(array, chunk)`` read into one concurrent batch.
+
+        Maximises overlap across both arrays and chunks, which hides per-request latency
+        on high-latency stores (S3). Each chunk is a contiguous single-chunk slice read.
+        """
+        tasks: list[tuple[int, int, zarr.Array, int | None, int | None]] = []
+        for job_idx, (array, slices, _, _) in enumerate(jobs):
+            if slices is None:
+                tasks.append((job_idx, 0, array, None, None))
+            else:
+                for part_idx, (start, stop) in enumerate(slices):
+                    tasks.append((job_idx, part_idx, array, start, stop))
+
+        def _run(task: tuple[int, int, zarr.Array, int | None, int | None]) -> tuple[int, int, np.ndarray]:
+            job_idx, part_idx, array, start, stop = task
+            block = np.asarray(array[:] if start is None else array[start:stop])
+            return job_idx, part_idx, block
+
+        with ThreadPoolExecutor(max_workers=min(self.read_concurrency, len(tasks))) as executor:
+            results = list(executor.map(_run, tasks))
+
+        parts_by_job: dict[int, list[tuple[int, np.ndarray]]] = defaultdict(list)
+        for job_idx, part_idx, block in results:
+            parts_by_job[job_idx].append((part_idx, block))
+
+        blocks: dict[int, np.ndarray] = {}
+        for job_idx, (_, slices, target, _) in enumerate(jobs):
+            ordered = [block for _, block in sorted(parts_by_job[job_idx])]
+            blocks[job_idx] = self._assemble(ordered, slices, target)
+        return blocks
+
+    def read_sample(
+        self,
+        sample_id: str,
+        num_points: dict[str, int | None] | None = None,
+        generator: torch.Generator | None = None,
+        fields: set[str] | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Read (optionally chunk-subsampled) fields for one sample.
+
+        With ``read_concurrency == 1`` each array is read with a single orthogonal
+        selection (lowest overhead, best on local stores). With ``read_concurrency > 1``
+        all chunk reads of the sample are issued concurrently in a thread pool (best
+        latency hiding on S3). Both paths return identical results.
+
+        Args:
+            sample_id: Sample id present in the manifest.
+            num_points: Per-domain target counts, e.g. ``{"surface": 3586, "volume": 4096}``.
+                A ``None`` value (or missing domain) reads the full domain.
+            generator: Torch RNG for chunk selection. Pass a seeded generator for
+                deterministic evaluation; ``None`` draws a fresh subset each call.
+            fields: Optional subset of canonical fields to read. Because every field is
+                its own array, unrequested fields cost no I/O. ``None`` reads all fields.
+
+        Returns:
+            Mapping ``canonical_field -> tensor`` with scalar fields shaped ``(T,)`` and
+            vector fields shaped ``(T, dim)``, all float32 and point-aligned per domain.
+        """
+        num_points = num_points or {}
+        entry = self.manifest.samples[sample_id]
+        group = self._group(entry.relpath)
+
+        # Plan one read job per (requested) field array; all arrays of a domain share the
+        # same chunk selection so their rows stay point-aligned.
+        jobs: list[_ReadJob] = []
+        for domain, layout in self.manifest.domains.items():
+            if domain not in entry.domains:
+                continue
+            wanted = [al for field, al in layout.arrays.items() if fields is None or field in fields]
+            if not wanted:
+                continue
+            grid = entry.domains[domain]
+            target = num_points.get(domain)
+            slices = self._select_row_slices(grid.n_points, grid.chunk_points, grid.n_chunks, target, generator)
+            jobs.extend((cast("zarr.Array", group[al.array_name]), slices, target, al) for al in wanted)
+
+        blocks = self._read_parallel(jobs) if self.read_concurrency > 1 else self._read_serial(jobs)
+
+        out: dict[str, torch.Tensor] = {}
+        for job_idx, (_, _, _, array_layout) in enumerate(jobs):
+            out[array_layout.field] = self._to_field_tensor(array_layout, blocks[job_idx])
+        return out
+
+    def read_coords(
+        self,
+        sample_id: str,
+        domain: str,
+        num_points: int | None,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Read an independent chunk-subsample of a domain's point positions only.
+
+        This is a separate random draw from :meth:`read_sample` (it consumes the same
+        generator, so it is uncorrelated with the field draw), reading just the domain's
+        position array. It backs the AB-UPT ``geometry_position`` input — a random draw
+        of the surface points distinct from the surface anchor points.
+
+        Args:
+            sample_id: Sample id present in the manifest.
+            domain: Domain whose positions to read (e.g. ``"surface"``).
+            num_points: Number of points to sample (``None`` reads all positions).
+            generator: Torch RNG for chunk selection.
+
+        Returns:
+            ``(num_points, position_dim)`` float32 positions tensor.
+        """
+        entry = self.manifest.samples[sample_id]
+        layout = self.manifest.domains[domain]
+        position_layout = layout.arrays[layout.position]
+        grid = entry.domains[domain]
+        group = self._group(entry.relpath)
+        slices = self._select_row_slices(grid.n_points, grid.chunk_points, grid.n_chunks, num_points, generator)
+        jobs: list[_ReadJob] = [
+            (cast("zarr.Array", group[position_layout.array_name]), slices, num_points, position_layout)
+        ]
+        blocks = self._read_parallel(jobs) if self.read_concurrency > 1 else self._read_serial(jobs)
+        return self._to_field_tensor(position_layout, blocks[0])

--- a/src/noether/data/zarr_store/statistics.py
+++ b/src/noether/data/zarr_store/statistics.py
@@ -1,0 +1,238 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Calculate per-field statistics of a converted Zarr store.
+
+The Zarr-store counterpart of :mod:`noether.data.tools.calculate_statistics`: instead of
+going through a dataset class, it streams every sample's fields straight from the store
+(local path or fsspec URL such as ``oci://bucket@namespace/zarr_store``) and accumulates
+running moments in a single pass. Linear and logscale moments are computed together via
+:class:`~noether.data.stats.RunningStats`, so one run yields everything a ``stats.yaml``
+needs (``{field}_mean/std/min/max`` plus ``{field}_logscale_mean/std`` and the global
+``raw_pos_min``/``raw_pos_max`` position bounds).
+
+Usage::
+
+    OCIFS_IAM_TYPE=api_key uv run python -m noether.data.zarr_store.statistics \\
+        --store oci://emmi-drivaernet@frwnorq7ern2/zarr_store \\
+        --split-file train_design_ids.txt \\
+        --workers 8 --read-concurrency 4 --output-json drivaernet_stats.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import fsspec
+import torch
+from tqdm import tqdm
+
+from noether.data.stats import RunningStats
+from noether.data.zarr_store import stores
+from noether.data.zarr_store.manifest import StoreManifest
+from noether.data.zarr_store.reader import ZarrChunkReader
+
+
+def _store_fields(manifest: StoreManifest) -> set[str]:
+    """All canonical field names physically present in the store."""
+    fields: set[str] = set()
+    for layout in manifest.domains.values():
+        fields.update(layout.arrays)
+    return fields
+
+
+def _resolve_fields(
+    manifest: StoreManifest,
+    fields: set[str] | None,
+    exclude_fields: set[str] | None,
+) -> list[str]:
+    """Validate the include/exclude selection against the store's fields."""
+    available = _store_fields(manifest)
+    selected = set(fields) if fields else set(available)
+    unknown = selected - available
+    if unknown:
+        raise ValueError(f"Unknown fields {sorted(unknown)}; store has {sorted(available)}.")
+    if exclude_fields:
+        unknown = exclude_fields - available
+        if unknown:
+            raise ValueError(f"Cannot exclude non-existent fields {sorted(unknown)}.")
+        selected -= exclude_fields
+    return sorted(selected)
+
+
+def read_split_ids(store_root: str | Path, split_file: str) -> list[str]:
+    """Read sample ids (one per line) from a split file.
+
+    ``split_file`` may be an absolute path/URL or a name relative to the store root
+    (e.g. ``train_design_ids.txt`` next to ``manifest.json``).
+    """
+    url = split_file if "://" in split_file or Path(split_file).is_absolute() else stores.join(store_root, split_file)
+    with fsspec.open(url, "r") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def calculate_store_statistics(
+    store_root: str | Path,
+    *,
+    fields: set[str] | None = None,
+    exclude_fields: set[str] | None = None,
+    sample_ids: list[str] | None = None,
+    limit: int | None = None,
+    max_workers: int = 1,
+    read_concurrency: int = 1,
+    progress: bool = False,
+) -> dict[str, RunningStats]:
+    """Stream all samples of a Zarr store and accumulate per-field running statistics.
+
+    Args:
+        store_root: Store root (local path or fsspec URL).
+        fields: Restrict to these canonical field names (default: every stored field).
+        exclude_fields: Field names to skip.
+        sample_ids: Restrict to these manifest sample ids (default: all samples).
+        limit: Process at most this many samples (after ``sample_ids`` filtering).
+        max_workers: Samples read concurrently (threads); accumulation stays single-threaded.
+        read_concurrency: Per-sample chunk-read threads (see :class:`ZarrChunkReader`).
+        progress: Show a tqdm progress bar.
+
+    Returns:
+        Mapping from canonical field name to its :class:`~noether.data.stats.RunningStats`
+        (per-component mean/std/min/max and logscale moments, accumulated in float64).
+
+    Raises:
+        ValueError: If a requested field is not present in the store, or no samples remain
+            to process. Sample ids missing from the store are skipped with a warning
+            (split files may list samples that were skipped at conversion).
+    """
+    manifest = StoreManifest.load(store_root)
+    reader = ZarrChunkReader(store_root, manifest, read_concurrency=read_concurrency)
+    selected = _resolve_fields(manifest, fields, exclude_fields)
+
+    ids = sample_ids if sample_ids is not None else sorted(manifest.samples)
+    missing = [sid for sid in ids if sid not in manifest.samples]
+    if missing:
+        # Split files may list samples that were skipped at conversion (e.g. blacklisted).
+        warnings.warn(f"Skipping {len(missing)} sample ids not in the store (e.g. {missing[0]}).", stacklevel=2)
+        ids = [sid for sid in ids if sid in manifest.samples]
+    ids = ids[:limit]
+    if not ids:
+        raise ValueError("No samples to process.")
+
+    running_stats = {field: RunningStats(name=field) for field in selected}
+
+    def _read(sid: str) -> dict[str, torch.Tensor]:
+        return reader.read_sample(sid, fields=set(selected))
+
+    # Threads fetch full samples; pushing stays in the main thread so the Welford
+    # accumulators need no locking (push order does not change the result materially).
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        results = pool.map(_read, ids)
+        for sample in tqdm(results, total=len(ids), desc="Processing store", disable=not progress):
+            for field, value in sample.items():
+                running_stats[field].push_tensor(value)
+
+    return running_stats
+
+
+def _to_list(x: torch.Tensor) -> list[float]:
+    return [float(v) for v in x.tolist()]
+
+
+def statistics_to_dict(running_stats: dict[str, RunningStats]) -> dict[str, list[float] | int]:
+    """Flatten running statistics into ``stats.yaml``-style keys.
+
+    Emits ``{field}_mean/std/min/max/count`` and ``{field}_logscale_mean/std`` per field,
+    plus global ``raw_pos_min``/``raw_pos_max`` scalars over all ``*_position`` fields
+    (the bounds used by position normalization).
+    """
+    out: dict[str, list[float] | int] = {}
+    pos_min: float | None = None
+    pos_max: float | None = None
+    for field, stats in sorted(running_stats.items()):
+        out[f"{field}_mean"] = _to_list(stats.mean)
+        out[f"{field}_std"] = _to_list(stats.std)
+        out[f"{field}_min"] = _to_list(stats.min)
+        out[f"{field}_max"] = _to_list(stats.max)
+        out[f"{field}_logscale_mean"] = _to_list(stats.logmean)
+        out[f"{field}_logscale_std"] = _to_list(stats.logstd)
+        out[f"{field}_count"] = stats.count
+        if field.endswith("_position"):
+            lo, hi = float(stats.min.min()), float(stats.max.max())
+            pos_min = lo if pos_min is None else min(pos_min, lo)
+            pos_max = hi if pos_max is None else max(pos_max, hi)
+    if pos_min is not None and pos_max is not None:
+        out["raw_pos_min"] = [pos_min]
+        out["raw_pos_max"] = [pos_max]
+    return out
+
+
+def print_statistics(running_stats: dict[str, RunningStats]) -> None:
+    """Print the accumulated statistics per field, plus the global position bounds."""
+    for _, stats in sorted(running_stats.items()):
+        print(stats)
+    flat = statistics_to_dict(running_stats)
+    if "raw_pos_min" in flat:
+        print(f"raw_pos_min: {flat['raw_pos_min']}")
+        print(f"raw_pos_max: {flat['raw_pos_max']}")
+
+
+def save_statistics_to_json(running_stats: dict[str, RunningStats], output_path: str | Path) -> None:
+    """Save the flattened statistics (see :func:`statistics_to_dict`) as JSON."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(statistics_to_dict(running_stats), f, indent=2)
+    print(f"\nStatistics saved to: {output_path}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser("Calculate per-field statistics of a converted Zarr store.")
+    parser.add_argument("--store", required=True, help="Store root (local path or fsspec URL, e.g. oci://...).")
+    parser.add_argument(
+        "--fields",
+        type=lambda s: set(s.split(",")) if s else None,
+        default=None,
+        help="Comma-separated canonical field names to include (default: all stored fields).",
+    )
+    parser.add_argument(
+        "--exclude-fields",
+        type=lambda s: set(s.split(",")) if s else None,
+        default=None,
+        help="Comma-separated canonical field names to exclude.",
+    )
+    parser.add_argument(
+        "--split-file",
+        default=None,
+        help="Optional file with one sample id per line; a bare name is resolved relative to "
+        "the store root (e.g. train_design_ids.txt). Default: all samples in the manifest.",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Process at most this many samples.")
+    parser.add_argument("--workers", type=int, default=1, help="Samples read concurrently.")
+    parser.add_argument("--read-concurrency", type=int, default=1, help="Chunk-read threads per sample.")
+    parser.add_argument("--output-json", default=None, help="Optional path to save the statistics as JSON.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entry point for calculating Zarr store statistics."""
+    args = _parse_args()
+    sample_ids = read_split_ids(args.store, args.split_file) if args.split_file else None
+    running_stats = calculate_store_statistics(
+        args.store,
+        fields=args.fields,
+        exclude_fields=args.exclude_fields,
+        sample_ids=sample_ids,
+        limit=args.limit,
+        max_workers=args.workers,
+        read_concurrency=args.read_concurrency,
+        progress=True,
+    )
+    print_statistics(running_stats)
+    if args.output_json:
+        save_statistics_to_json(running_stats, args.output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/noether/data/zarr_store/stores.py
+++ b/src/noether/data/zarr_store/stores.py
@@ -1,0 +1,38 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Storage helpers so the Zarr store can live locally or on object storage.
+
+A ``store_root`` may be a local path or an fsspec URL (``s3://``, ``gs://``, ``az://``,
+``memory://``, …). Local roots use the fast :class:`~zarr.storage.LocalStore`; URLs use
+:class:`~zarr.storage.FsspecStore`. Path joining is done as plain ``/``-joins so it works
+for both local paths and URLs (``pathlib`` would mangle ``s3://`` into ``s3:/``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from zarr.abc.store import Store
+from zarr.storage import FsspecStore, LocalStore
+
+_FILE_PREFIX = "file://"
+
+
+def is_remote(store_root: str | Path) -> bool:
+    """Return True if *store_root* is an fsspec URL backed by a non-local filesystem."""
+    text = str(store_root)
+    return "://" in text and not text.startswith(_FILE_PREFIX)
+
+
+def join(store_root: str | Path, relpath: str) -> str:
+    """Join *relpath* onto a local path or URL store root (URL-safe, unlike ``Path``)."""
+    return f"{str(store_root).rstrip('/')}/{relpath}"
+
+
+def make_store(path: str | Path, *, read_only: bool = False) -> Store:
+    """Build a Zarr store for *path*: :class:`FsspecStore` for URLs, else :class:`LocalStore`."""
+    text = str(path)
+    if is_remote(text):
+        return FsspecStore.from_url(text, read_only=read_only)
+    text = text.removeprefix(_FILE_PREFIX)
+    return LocalStore(text, read_only=read_only)

--- a/src/noether/data/zarr_store/stores.py
+++ b/src/noether/data/zarr_store/stores.py
@@ -6,16 +6,29 @@ A ``store_root`` may be a local path or an fsspec URL (``s3://``, ``gs://``, ``a
 ``memory://``, …). Local roots use the fast :class:`~zarr.storage.LocalStore`; URLs use
 :class:`~zarr.storage.FsspecStore`. Path joining is done as plain ``/``-joins so it works
 for both local paths and URLs (``pathlib`` would mangle ``s3://`` into ``s3:/``).
+
+For ``s3://`` URLs, if the optional `obstore <https://developmentseed.org/obstore/>`_
+package is installed, the faster Rust-backed :class:`~zarr.storage.ObjectStore` is used
+instead of :class:`~zarr.storage.FsspecStore` (it reads credentials/region/endpoint from
+the standard ``AWS_*`` environment variables). Without obstore, or for any non-S3 URL,
+the fsspec backend is used — so this is a transparent, opt-in speedup.
 """
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 from zarr.abc.store import Store
 from zarr.storage import FsspecStore, LocalStore
 
 _FILE_PREFIX = "file://"
+_S3_PREFIX = "s3://"
+
+
+def _obstore_available() -> bool:
+    """Return True if the optional ``obstore`` package can be imported."""
+    return importlib.util.find_spec("obstore") is not None
 
 
 def is_remote(store_root: str | Path) -> bool:
@@ -29,9 +42,29 @@ def join(store_root: str | Path, relpath: str) -> str:
     return f"{str(store_root).rstrip('/')}/{relpath}"
 
 
+def _make_obstore_s3(url: str, *, read_only: bool) -> Store:
+    """Build an obstore-backed :class:`ObjectStore` for an ``s3://`` URL.
+
+    Credentials, region and endpoint are read from the standard ``AWS_*`` environment
+    variables at request time (``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``,
+    ``AWS_REGION``/``AWS_DEFAULT_REGION``, ``AWS_ENDPOINT_URL``, …).
+    """
+    from obstore.store import S3Store
+    from zarr.storage import ObjectStore
+
+    return ObjectStore(S3Store.from_url(url), read_only=read_only)
+
+
 def make_store(path: str | Path, *, read_only: bool = False) -> Store:
-    """Build a Zarr store for *path*: :class:`FsspecStore` for URLs, else :class:`LocalStore`."""
+    """Build a Zarr store for *path*.
+
+    Uses the Rust-backed :class:`~zarr.storage.ObjectStore` for ``s3://`` URLs when the
+    optional ``obstore`` package is installed, :class:`FsspecStore` for any other URL (or
+    for S3 without obstore), and :class:`LocalStore` for local paths.
+    """
     text = str(path)
+    if text.startswith(_S3_PREFIX) and _obstore_available():
+        return _make_obstore_s3(text, read_only=read_only)
     if is_remote(text):
         return FsspecStore.from_url(text, read_only=read_only)
     text = text.removeprefix(_FILE_PREFIX)

--- a/src/noether/data/zarr_store/writer.py
+++ b/src/noether/data/zarr_store/writer.py
@@ -1,0 +1,242 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Writer that converts per-sample CFD tensors into a sharded, pre-shuffled Zarr store.
+
+Each sample becomes an independent Zarr *group* (``<store_root>/<sample_id>.zarr``)
+holding **one array per field** (``surface/position``, ``volume/velocity``, …), so
+fields can be read independently. Points are shuffled once at write time with a
+deterministic, per-sample seed so that any contiguous chunk is already a uniform-random
+subset of the sample — this lets the dataloader turn "sample N random points" into
+"read a random chunk". All arrays of a domain share the permutation and chunk grid, so
+chunk ``c`` is point-aligned across fields.
+
+Arrays are chunked along the point axis (``chunk_points``) with the channel axis left
+unchunked, and packed into a single whole-array shard compressed per-chunk with
+blosc+zstd — the per-sample object count therefore stays at one object per field.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import warnings
+from pathlib import Path
+
+import numpy as np
+import torch
+import zarr
+from zarr.codecs import BloscCodec
+
+from noether.data.schemas import FileMap
+from noether.data.zarr_store import stores
+from noether.data.zarr_store.layout import build_domain_layouts
+from noether.data.zarr_store.manifest import DomainSample, SampleEntry, StoreManifest
+
+_INT64_MAX = 2**63 - 1
+
+
+def _derive_seed(base_seed: int, sample_id: str, domain: str) -> int:
+    """Deterministically derive a per-sample, per-domain shuffle seed."""
+    digest = hashlib.sha256(f"{base_seed}:{sample_id}:{domain}".encode()).digest()
+    return int.from_bytes(digest[:8], "little") % _INT64_MAX
+
+
+def _shuffle_perm(n: int, seed: int) -> np.ndarray:
+    """Return a deterministic random permutation of ``range(n)``."""
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randperm(n, generator=generator).numpy()
+
+
+class ZarrStoreWriter:
+    """Convert CFD samples into the chunked/sharded Zarr format and track the manifest."""
+
+    def __init__(
+        self,
+        store_root: str | Path,
+        filemap: FileMap,
+        dataset_name: str,
+        shuffle_seed: int = 0,
+        chunk_points: int = 4096,
+        shard_points: int | None = None,
+        coords_dtype: str = "float32",
+        values_dtype: str = "float16",
+        field_dtypes: dict[str, str] | None = None,
+        compression_level: int = 5,
+    ) -> None:
+        """
+
+        Args:
+            store_root: Output location for the Zarr store. A local path or an fsspec URL
+                (``s3://``, ``gs://``, ``memory://``, …) for object storage.
+            filemap: Field-to-filename mapping describing which fields exist.
+            dataset_name: Human-readable dataset name recorded in the manifest.
+            shuffle_seed: Base seed for the per-sample point shuffle.
+            chunk_points: Chunk size along the point axis. Pick close to the training
+                subsample size to minimise read amplification.
+            shard_points: Cap on the shard size along the point axis (rounded down to a
+                whole number of chunks, minimum one chunk). ``None`` (default) packs each
+                array into a single whole-array shard. Set this when per-field arrays grow
+                large: shard bytes ≈ ``shard_points × dim × dtype_size``, so e.g. a
+                ~128 MB cap on a float32×3 position array is ``shard_points ≈ 11_000_000``.
+                Smaller shards bound the writer's per-shard RAM and the blast radius of a
+                corrupt object, at the cost of more objects per array.
+            coords_dtype: Dtype for the positions array (keep float32).
+            values_dtype: Dtype for the physical fields array (float16 halves bytes).
+            field_dtypes: Per-field dtype overrides keyed by canonical name, e.g.
+                ``{"volume_vorticity": "float32"}`` for fields whose values exceed the
+                ``values_dtype`` range (float16 caps at ~6.6e4); overflowing casts are
+                rejected at write time rather than silently stored as ``inf``.
+            compression_level: blosc/zstd compression level.
+        """
+        self.store_root = str(store_root)
+        if not stores.is_remote(self.store_root):
+            Path(self.store_root.removeprefix("file://")).mkdir(parents=True, exist_ok=True)
+        if shard_points is not None and shard_points < 1:
+            raise ValueError(f"shard_points must be positive, got {shard_points}.")
+        self.filemap = filemap
+        self.chunk_points = chunk_points
+        self.shard_points = shard_points
+        self.coords_dtype = coords_dtype
+        self.values_dtype = values_dtype
+        self.field_dtypes = field_dtypes
+        self.compression_level = compression_level
+        self._compressor = BloscCodec(cname="zstd", clevel=compression_level)
+
+        self.layouts = build_domain_layouts(filemap, coords_dtype, values_dtype, field_dtypes)
+        self.manifest = StoreManifest(
+            dataset_name=dataset_name,
+            shuffle_seed=shuffle_seed,
+            coords_dtype=coords_dtype,
+            values_dtype=values_dtype,
+            compressor=f"blosc-zstd-{compression_level}",
+            domains=self.layouts,
+        )
+
+    @staticmethod
+    def _check_cast_range(field: str, data: np.ndarray, target_dtype: str) -> None:
+        """Reject casts that would overflow *target_dtype* (silently storing ``inf``).
+
+        Raises:
+            ValueError: If finite values of *data* exceed the target float range.
+        """
+        target = np.dtype(target_dtype)
+        if not (np.issubdtype(target, np.floating) and np.issubdtype(data.dtype, np.floating)):
+            return
+        limit = float(np.finfo(target).max)
+        if float(np.finfo(data.dtype).max) <= limit:
+            return  # widening or same-width cast cannot overflow
+        peak = float(np.abs(data).max()) if data.size else 0.0
+        if peak > limit:
+            raise ValueError(
+                f"Field '{field}' exceeds the {target_dtype} range (max |value| {peak:.4g} > {limit:.4g}); "
+                f"store it at higher precision, e.g. field_dtypes={{'{field}': 'float32'}} "
+                f"(CLI: --field-dtype {field}=float32)."
+            )
+
+    def _domain_grid(self, n_points: int) -> tuple[int, int, int]:
+        """Compute a domain's ``(chunk, n_chunks, shard)`` along the point axis.
+
+        The shard is the whole array (``n_chunks * chunk``) unless ``shard_points`` caps
+        it, in which case it is the largest whole number of chunks that fits the cap
+        (minimum one chunk) — Zarr requires shard shapes to be chunk multiples.
+        """
+        chunk = min(self.chunk_points, n_points)
+        n_chunks = math.ceil(n_points / chunk)
+        shard = n_chunks * chunk
+        if self.shard_points is not None:
+            shard = min(shard, max(1, self.shard_points // chunk) * chunk)
+        return chunk, n_chunks, shard
+
+    def _create_array(
+        self, group: zarr.Group, name: str, n_points: int, width: int, dtype: str, chunk: int, shard: int
+    ):
+        """Create a sharded per-field array chunked along the point axis only."""
+        return group.create_array(
+            name=name,
+            shape=(n_points, width),
+            chunks=(chunk, width),
+            shards=(shard, width),
+            dtype=dtype,
+            compressors=[self._compressor],
+        )
+
+    def write_group(self, sample_id: str, field_arrays: dict[str, np.ndarray]) -> SampleEntry:
+        """Write one sample's Zarr group and return its manifest entry (no manifest mutation).
+
+        Independent per sample (its own store), so this is safe to call concurrently from
+        multiple threads; the caller records the returned entry in the manifest.
+
+        Args:
+            sample_id: Stable id used for the relative path and shuffle seed
+                (e.g. ``"param1/<hash>"``).
+            field_arrays: Mapping ``canonical_field -> numpy array``. Positions must be
+                ``(N, 3)``; scalar fields may be ``(N,)`` or ``(N, 1)``.
+
+        Returns:
+            The :class:`SampleEntry` describing the written group.
+
+        Raises:
+            ValueError: If a domain's fields disagree on point count.
+        """
+        relpath = f"{sample_id}.zarr"
+        store = stores.make_store(stores.join(self.store_root, relpath))
+        group = zarr.create_group(store=store, overwrite=True)
+
+        domain_samples: dict[str, DomainSample] = {}
+        for domain, layout in self.layouts.items():
+            if layout.position not in field_arrays:
+                continue
+            n_points = np.asarray(field_arrays[layout.position]).shape[0]
+            perm = _shuffle_perm(n_points, _derive_seed(self.manifest.shuffle_seed, sample_id, domain))
+            # One chunk/shard grid per domain so chunk c is point-aligned across all field arrays.
+            chunk, n_chunks, shard = self._domain_grid(n_points)
+
+            for field, array_layout in layout.arrays.items():
+                data = np.asarray(field_arrays[field])
+                if data.ndim == 1:
+                    data = data[:, None]
+                if data.shape[0] != n_points:
+                    raise ValueError(f"Field '{field}' has {data.shape[0]} points, expected {n_points} for '{domain}'.")
+                self._check_cast_range(field, data, array_layout.dtype)
+                shuffled = np.ascontiguousarray(data[:, : array_layout.dim][perm], dtype=array_layout.dtype)
+                array = self._create_array(
+                    group, array_layout.array_name, n_points, array_layout.dim, array_layout.dtype, chunk, shard
+                )
+                array[:] = shuffled
+
+            domain_samples[domain] = DomainSample(
+                n_points=n_points, chunk_points=chunk, shard_points=shard, n_chunks=n_chunks
+            )
+
+        # Consolidate the group's metadata into its root zarr.json: opening a sample then
+        # costs one metadata GET instead of one per group/array — a per-sample latency win
+        # on object storage. Safe here because the store is write-once (no staleness), and
+        # readers without consolidated-metadata support just fall back to per-node reads.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Consolidated metadata is currently not part")
+            zarr.consolidate_metadata(store)
+
+        return SampleEntry(relpath=relpath, domains=domain_samples)
+
+    def write_sample(self, sample_id: str, field_arrays: dict[str, np.ndarray]) -> None:
+        """Write one sample and record it in the manifest (sequential convenience)."""
+        self.manifest.samples[sample_id] = self.write_group(sample_id, field_arrays)
+
+    def to_init_kwargs(self) -> dict[str, object]:
+        """Constructor kwargs to rebuild an identical writer (e.g. in a worker process)."""
+        return {
+            "store_root": self.store_root,
+            "filemap": self.filemap,
+            "dataset_name": self.manifest.dataset_name,
+            "shuffle_seed": self.manifest.shuffle_seed,
+            "chunk_points": self.chunk_points,
+            "shard_points": self.shard_points,
+            "coords_dtype": self.coords_dtype,
+            "values_dtype": self.values_dtype,
+            "field_dtypes": self.field_dtypes,
+            "compression_level": self.compression_level,
+        }
+
+    def save_manifest(self) -> str:
+        """Persist the manifest to the store root (local path or fsspec URL)."""
+        return self.manifest.save(self.store_root)

--- a/tests/unit/noether/data/base/wrappers/test_property_subset.py
+++ b/tests/unit/noether/data/base/wrappers/test_property_subset.py
@@ -230,6 +230,7 @@ class PreGetItemDataset(Dataset):
         super().__init__(dataset_config=DatasetBaseConfig(kind="pre"))
         self._length = length
         self.pre_getitem_call_count = 0
+        self.post_getitem_call_count = 0
 
     def __len__(self) -> int:
         return self._length
@@ -238,6 +239,9 @@ class PreGetItemDataset(Dataset):
         self.pre_getitem_call_count += 1
         return {"shared": f"shared_{idx}"}
 
+    def post_getitem(self, idx: int, pre: dict | None) -> None:
+        self.post_getitem_call_count += 1
+
     def getitem_plain(self, idx: int) -> str:
         return f"plain_{idx}"
 
@@ -245,25 +249,27 @@ class PreGetItemDataset(Dataset):
         return f"fancy_{shared}"
 
 
-def test_property_subset_bypasses_pre_getitem():
-    """PropertySubsetWrapper calls getitem methods directly, skipping pre_getitem."""
+def test_property_subset_runs_pre_and_post_getitem():
+    """PropertySubsetWrapper runs pre_getitem/post_getitem once, like Dataset.__getitem__."""
     ds = PreGetItemDataset(length=5)
     wrapper = PropertySubsetWrapper(dataset=ds, properties={"plain"})
 
     sample = wrapper[2]
     assert sample == {"plain": "plain_2"}
-    assert ds.pre_getitem_call_count == 0
+    assert ds.pre_getitem_call_count == 1
+    assert ds.post_getitem_call_count == 1
 
 
-def test_property_subset_getitem_with_kwargs_uses_defaults():
-    """When PropertySubsetWrapper bypasses pre_getitem, getitem methods fall back to defaults."""
+def test_property_subset_forwards_pre_getitem_kwargs():
+    """getitem methods that accept the pre_getitem payload receive it through the wrapper."""
     ds = PreGetItemDataset(length=5)
     wrapper = PropertySubsetWrapper(dataset=ds, properties={"fancy"})
 
     sample = wrapper[3]
-    # fancy gets default shared="" because pre_getitem is not called
-    assert sample == {"fancy": "fancy_"}
-    assert ds.pre_getitem_call_count == 0
+    # fancy receives shared=... forwarded from pre_getitem
+    assert sample == {"fancy": "fancy_shared_3"}
+    assert ds.pre_getitem_call_count == 1
+    assert ds.post_getitem_call_count == 1
 
 
 def test_direct_dataset_calls_pre_getitem():

--- a/tests/unit/noether/data/pipeline/test_point_sampling.py
+++ b/tests/unit/noether/data/pipeline/test_point_sampling.py
@@ -80,6 +80,19 @@ def test_point_sampling_precollator_deterministic():
     assert torch.equal(processed1["pos"], processed2["pos"])
 
 
+def test_point_sampling_skips_when_num_points_at_least_total():
+    """num_points >= available points is a redundant reshuffle, so the sample is returned as-is."""
+    sample = {"pos": torch.rand(8, 3), "feat": torch.rand(8, 2)}
+    items = {"pos", "feat"}
+
+    for num_points in (8, 16):  # equal to and greater than the 8 available points
+        processed = PointSamplingSampleProcessor(items, num_points)(sample)
+        for item in items:
+            assert processed[item].shape[0] == 8
+            # No subsampling and no reshuffle: identical to the input.
+            assert torch.equal(processed[item], sample[item])
+
+
 def test_point_sampling_precollator_invalid_num_points(sample_data):
     items = {"input_position", "output_position"}
     num_points = 0

--- a/tests/unit/noether/data/zarr_store/test_zarr_store.py
+++ b/tests/unit/noether/data/zarr_store/test_zarr_store.py
@@ -552,3 +552,109 @@ def test_convert_aero_dataset_is_dataset_driven(tmp_path: Path) -> None:
         np.sort(samples[1]["volume_position"], axis=0),
     )
     assert out["surface_pressure"].shape == (NS,)
+
+
+def test_store_statistics_match_direct_computation(tmp_path: Path) -> None:
+    """Per-field running stats over the store equal a direct float64 computation."""
+    from noether.data.zarr_store.statistics import calculate_store_statistics, statistics_to_dict
+
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "stats", chunk_points=4096)
+    s0, s1 = _make_sample(0), _make_sample(1)
+    writer.write_sample("a", s0)
+    writer.write_sample("b", s1)
+    writer.save_manifest()
+
+    stats = calculate_store_statistics(tmp_path)
+    assert set(stats) == {
+        "surface_position",
+        "surface_pressure",
+        "surface_normals",
+        "volume_position",
+        "volume_velocity",
+        "volume_sdf",
+        "volume_normals",
+    }
+
+    for field, st in stats.items():
+        # Reference goes through the stored dtype (positions float32, values float16).
+        cast = np.float32 if field.endswith("_position") else np.float16
+        ref = np.concatenate([s[field].astype(cast).astype(np.float64) for s in (s0, s1)])
+        ref = ref.reshape(len(ref), -1)
+        np.testing.assert_allclose(st.mean.numpy(), ref.mean(axis=0), rtol=1e-9)
+        np.testing.assert_allclose(st.std.numpy(), ref.std(axis=0, ddof=1), rtol=1e-9)
+        np.testing.assert_allclose(st.min.numpy(), ref.min(axis=0), rtol=0)
+        np.testing.assert_allclose(st.max.numpy(), ref.max(axis=0), rtol=0)
+        logref = np.sign(ref) * np.log1p(np.abs(ref))
+        np.testing.assert_allclose(st.logmean.numpy(), logref.mean(axis=0), rtol=1e-9)
+        assert st.count == len(ref)
+
+    flat = statistics_to_dict(stats)
+    pos = np.concatenate([s[f].astype(np.float64) for s in (s0, s1) for f in ("surface_position", "volume_position")])
+    np.testing.assert_allclose(flat["raw_pos_min"], [pos.min()], rtol=1e-9)
+    np.testing.assert_allclose(flat["raw_pos_max"], [pos.max()], rtol=1e-9)
+
+
+def test_store_statistics_field_selection_and_workers(store: Path) -> None:
+    from noether.data.zarr_store.statistics import calculate_store_statistics
+
+    stats = calculate_store_statistics(store, fields={"surface_pressure", "volume_velocity"}, max_workers=4)
+    assert set(stats) == {"surface_pressure", "volume_velocity"}
+
+    stats = calculate_store_statistics(store, exclude_fields={"volume_normals", "surface_normals"})
+    assert "volume_normals" not in stats and "surface_normals" not in stats
+
+    with pytest.raises(ValueError, match="Unknown fields"):
+        calculate_store_statistics(store, fields={"nope"})
+    with pytest.raises(ValueError, match="non-existent"):
+        calculate_store_statistics(store, exclude_fields={"nope"})
+
+
+def test_store_statistics_skips_missing_sample_ids(store: Path) -> None:
+    from noether.data.zarr_store.statistics import calculate_store_statistics
+
+    with pytest.warns(UserWarning, match="not in the store"):
+        stats = calculate_store_statistics(store, sample_ids=["param0/sample", "missing"])
+    assert stats["surface_pressure"].count == NS
+
+    with pytest.raises(ValueError, match="No samples"):
+        calculate_store_statistics(store, sample_ids=["missing"])
+
+
+def test_make_store_selects_local_for_paths(tmp_path: Path) -> None:
+    from zarr.storage import LocalStore as _LocalStore
+
+    from noether.data.zarr_store import stores
+
+    assert isinstance(stores.make_store(tmp_path), _LocalStore)
+    assert isinstance(stores.make_store(f"file://{tmp_path}"), _LocalStore)
+
+
+def test_make_store_uses_fsspec_for_non_s3_urls() -> None:
+    from zarr.storage import FsspecStore
+
+    from noether.data.zarr_store import stores
+
+    assert isinstance(stores.make_store("memory://some/zarr"), FsspecStore)
+
+
+def test_make_store_uses_obstore_for_s3_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("obstore")
+    from zarr.storage import ObjectStore
+
+    from noether.data.zarr_store import stores
+
+    monkeypatch.setattr(stores, "_obstore_available", lambda: True)
+    store = stores.make_store("s3://bucket/prefix.zarr", read_only=True)
+    assert isinstance(store, ObjectStore)
+    assert store.read_only is True
+
+
+def test_make_store_falls_back_to_fsspec_for_s3_without_obstore(monkeypatch: pytest.MonkeyPatch) -> None:
+    from noether.data.zarr_store import stores
+
+    # Assert routing only: building a real FsspecStore for s3:// would require s3fs.
+    monkeypatch.setattr(stores, "_obstore_available", lambda: False)
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(stores.FsspecStore, "from_url", classmethod(lambda cls, url, **kw: seen.update(url=url, kw=kw)))
+    stores.make_store("s3://bucket/prefix.zarr", read_only=True)
+    assert seen == {"url": "s3://bucket/prefix.zarr", "kw": {"read_only": True}}

--- a/tests/unit/noether/data/zarr_store/test_zarr_store.py
+++ b/tests/unit/noether/data/zarr_store/test_zarr_store.py
@@ -1,0 +1,554 @@
+#  Copyright © 2026 Emmi AI GmbH. All rights reserved.
+
+"""Tests for the chunked/sharded Zarr CFD store (writer, reader, manifest, layout)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from zarr.storage import LocalStore
+
+from noether.data.schemas import FileMap
+from noether.data.zarr_store import (
+    StoreManifest,
+    ZarrChunkReader,
+    ZarrStoreWriter,
+    build_domain_layouts,
+    filename_to_canonical,
+)
+
+FILEMAP = FileMap(
+    surface_position="surface_points.pt",
+    surface_pressure="surface_pressure.pt",
+    surface_normals="surface_normals.pt",
+    volume_position="volume_points.pt",
+    volume_velocity="volume_velocity.pt",
+    volume_distance_to_surface="volume_sdf.pt",
+    volume_normals="volume_normals.pt",
+)
+
+NS, NV = 3586, 28504
+
+
+def _make_sample(seed: int = 0) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    return {
+        "surface_position": rng.standard_normal((NS, 3)).astype("float32"),
+        "surface_pressure": rng.standard_normal((NS,)).astype("float32"),
+        "surface_normals": rng.standard_normal((NS, 3)).astype("float32"),
+        "volume_position": rng.standard_normal((NV, 3)).astype("float32"),
+        "volume_velocity": rng.standard_normal((NV, 3)).astype("float32"),
+        "volume_sdf": rng.standard_normal((NV,)).astype("float32"),
+        "volume_normals": rng.standard_normal((NV, 3)).astype("float32"),
+    }
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "test", shuffle_seed=0, chunk_points=4096)
+    writer.write_sample("param0/sample", _make_sample())
+    writer.save_manifest()
+    return tmp_path
+
+
+def test_full_read_is_lossless_for_positions_and_bounded_for_fields(store: Path) -> None:
+    reader = ZarrChunkReader(store)
+    out = reader.read_sample("param0/sample", num_points=None)
+    original = _make_sample()
+
+    # Positions are stored float32 -> exact (compare sorted, order is shuffled).
+    got = np.sort(out["volume_position"].numpy(), axis=0)
+    exp = np.sort(original["volume_position"], axis=0)
+    np.testing.assert_array_equal(got, exp)
+
+    # float16 fields -> small bounded error.
+    got_v = np.sort(out["volume_velocity"].numpy(), axis=0)
+    exp_v = np.sort(original["volume_velocity"], axis=0)
+    assert np.abs(got_v - exp_v).max() < 1e-2
+
+    # Scalar fields come back 1-D.
+    assert out["surface_pressure"].ndim == 1
+    assert out["volume_sdf"].shape == (NV,)
+
+
+def test_subsampling_returns_exact_point_counts(store: Path) -> None:
+    reader = ZarrChunkReader(store)
+    out = reader.read_sample("param0/sample", num_points={"surface": 1000, "volume": 4096})
+    assert out["surface_position"].shape == (1000, 3)
+    assert out["surface_pressure"].shape == (1000,)
+    assert out["volume_velocity"].shape == (4096, 3)
+    assert out["volume_normals"].shape == (4096, 3)
+
+
+def test_coords_and_fields_stay_point_aligned(tmp_path: Path) -> None:
+    """A row read from coords must correspond to the same point in the fields array."""
+    n = 512
+    # Encode each point's original index in column 0 of both position and velocity.
+    # f16 represents integers < 2048 exactly, so the marker survives the float16 cast.
+    idx = np.arange(n, dtype="float32")
+    sample = {
+        "surface_position": np.stack([idx, np.zeros(n), np.zeros(n)], axis=1).astype("float32"),
+        "surface_pressure": idx.copy(),
+        "surface_normals": np.zeros((n, 3), "float32"),
+    }
+    fm = FileMap(surface_position="p.pt", surface_pressure="pr.pt", surface_normals="nm.pt")
+    writer = ZarrStoreWriter(tmp_path, fm, "align", chunk_points=16)
+    writer.write_sample("s", sample)
+    writer.save_manifest()
+
+    reader = ZarrChunkReader(tmp_path)
+    gen = torch.Generator().manual_seed(123)
+    out = reader.read_sample("s", num_points={"surface": 128}, generator=gen)
+    # position[:,0] is the point index; pressure carries the same index -> must match row-wise.
+    np.testing.assert_array_equal(out["surface_position"][:, 0].numpy(), out["surface_pressure"].numpy())
+
+
+def test_chunk_selection_is_deterministic_with_seed(store: Path) -> None:
+    reader = ZarrChunkReader(store)
+    a = reader.read_sample("param0/sample", num_points={"volume": 4096}, generator=torch.Generator().manual_seed(7))
+    b = reader.read_sample("param0/sample", num_points={"volume": 4096}, generator=torch.Generator().manual_seed(7))
+    c = reader.read_sample("param0/sample", num_points={"volume": 4096}, generator=torch.Generator().manual_seed(8))
+    np.testing.assert_array_equal(a["volume_velocity"].numpy(), b["volume_velocity"].numpy())
+    assert not np.array_equal(a["volume_velocity"].numpy(), c["volume_velocity"].numpy())
+
+
+def test_chunk_read_transfers_far_less_than_full_read(tmp_path: Path) -> None:
+    """Subsampling must read only a fraction of the full sample's bytes."""
+    # Small chunks so a small draw touches few of many chunks in *both* domains
+    # (surface -> 8 chunks, volume -> 56), avoiding the full-surface dilution.
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "bytes", chunk_points=512)
+    writer.write_sample("param0/sample", _make_sample())
+    writer.save_manifest()
+
+    class CountingLocalStore(LocalStore):
+        bytes_read = 0
+
+        async def get(self, key, prototype, byte_range=None):  # type: ignore[override]
+            res = await super().get(key, prototype, byte_range)
+            if res is not None and "/c/" in str(key):
+                type(self).bytes_read += len(res)
+            return res
+
+    reader = ZarrChunkReader(tmp_path, store_factory=lambda path: CountingLocalStore(path, read_only=True))
+
+    CountingLocalStore.bytes_read = 0
+    reader.read_sample("param0/sample", num_points={"surface": 512, "volume": 512})
+    sub_bytes = CountingLocalStore.bytes_read
+
+    reader._groups.clear()  # drop cached handles so the full read re-fetches
+    CountingLocalStore.bytes_read = 0
+    reader.read_sample("param0/sample", num_points=None)
+    full_bytes = CountingLocalStore.bytes_read
+
+    # A 512-point draw touches ~1 chunk per domain out of 64 total -> well under a fifth.
+    assert sub_bytes < full_bytes / 5
+
+
+def test_consolidated_metadata_makes_sample_open_one_metadata_get(store: Path) -> None:
+    """The writer consolidates each sample group, so a first read costs one zarr.json GET."""
+
+    class CountingLocalStore(LocalStore):
+        metadata_gets = 0
+
+        async def get(self, key, prototype, byte_range=None):  # type: ignore[override]
+            res = await super().get(key, prototype, byte_range)
+            if res is not None and str(key).endswith("zarr.json"):
+                type(self).metadata_gets += 1
+            return res
+
+    reader = ZarrChunkReader(store, store_factory=lambda path: CountingLocalStore(path, read_only=True))
+    CountingLocalStore.metadata_gets = 0
+    reader.read_sample("param0/sample", num_points={"surface": 1000, "volume": 4096})
+    assert CountingLocalStore.metadata_gets == 1  # root zarr.json carries all child metadata
+
+
+def test_parallel_reads_match_serial(store: Path) -> None:
+    """read_concurrency > 1 must return bit-identical results to serial reads."""
+    serial = ZarrChunkReader(store, read_concurrency=1)
+    parallel = ZarrChunkReader(store, read_concurrency=8)
+    points = {"surface": 1000, "volume": 4096}
+    a = serial.read_sample("param0/sample", num_points=points, generator=torch.Generator().manual_seed(5))
+    b = parallel.read_sample("param0/sample", num_points=points, generator=torch.Generator().manual_seed(5))
+    assert a.keys() == b.keys()
+    for field in a:
+        np.testing.assert_array_equal(a[field].numpy(), b[field].numpy())
+
+
+def test_read_coords_is_an_independent_position_subsample(tmp_path: Path) -> None:
+    """read_coords returns a deterministic, seed-sensitive subset of a domain's positions."""
+    # Small chunks so a 1000-point draw spans many chunks (genuine random selection).
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "geom", chunk_points=256)
+    writer.write_sample("param0/sample", _make_sample())
+    writer.save_manifest()
+    reader = ZarrChunkReader(tmp_path)
+
+    g1 = reader.read_coords("param0/sample", "surface", 1000, torch.Generator().manual_seed(0))
+    g2 = reader.read_coords("param0/sample", "surface", 1000, torch.Generator().manual_seed(0))
+    g3 = reader.read_coords("param0/sample", "surface", 1000, torch.Generator().manual_seed(1))
+    assert g1.shape == (1000, 3)
+    np.testing.assert_array_equal(g1.numpy(), g2.numpy())  # deterministic for a fixed seed
+    assert not np.array_equal(g1.numpy(), g3.numpy())  # a different seed draws different points
+
+    # Every drawn position belongs to the full surface cloud.
+    full = reader.read_sample("param0/sample", None)["surface_position"].numpy()
+    full_rows = {tuple(row) for row in full}
+    assert all(tuple(row) in full_rows for row in g1.numpy())
+
+
+def test_dataset_emits_independent_geometry_position(tmp_path: Path) -> None:
+    """num_geometry_points adds geometry_position as a separate surface draw."""
+    from noether.data.base.dataset import StandardDatasetConfig
+    from noether.data.datasets.cfd.zarr_aero_dataset import ZarrAeroDataset
+
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "geom", chunk_points=256)
+    writer.write_sample("param0/sample", _make_sample())
+    writer.save_manifest()
+
+    class _DS(ZarrAeroDataset):
+        def __len__(self) -> int:
+            return 1
+
+        def _sample_id(self, idx: int) -> str:
+            return "param0/sample"
+
+    cfg = StandardDatasetConfig(root=str(tmp_path), split="train")
+    ds = _DS(cfg, FILEMAP, num_points={"surface": 512, "volume": 4096}, num_geometry_points=2000, sampling_seed=0)
+    assert "getitem_geometry_position" in ds.get_all_getitem_names()
+
+    sample = ds[0]
+    assert sample["geometry_position"].shape == (2000, 3)
+    assert sample["surface_position"].shape == (512, 3)  # anchors: separate, smaller draw
+
+    # Disabled by default.
+    ds_off = _DS(cfg, FILEMAP, num_points={"surface": 512, "volume": 4096})
+    assert "getitem_geometry_position" not in ds_off.get_all_getitem_names()
+    assert "geometry_position" not in ds_off[0]
+
+
+def test_zarr_config_resolves_and_parses_from_kind() -> None:
+    """The dataset config is discoverable via its `kind` and parses the sampling fields."""
+    from noether.core.schemas.lib import resolve_config_class
+    from noether.data.base.dataset import DatasetBaseConfig
+    from noether.data.datasets.cfd import ZarrShapeNetCarDatasetConfig
+
+    kind = "noether.data.datasets.cfd.ZarrShapeNetCarDataset"
+    # The framework resolves the config class from the dataset `kind` (via __init__ hints).
+    assert resolve_config_class(kind, DatasetBaseConfig) is ZarrShapeNetCarDatasetConfig
+
+    cfg = ZarrShapeNetCarDatasetConfig.model_validate(
+        {"kind": kind, "root": "/store", "split": "train", "num_surface_points": 256, "num_geometry_points": 3586}
+    )
+    assert (cfg.root, cfg.split) == ("/store", "train")
+    assert cfg.num_surface_points == 256 and cfg.num_geometry_points == 3586
+    assert cfg.num_volume_points is None and cfg.read_concurrency == 1
+
+
+def test_zarr_dataset_reads_sampling_from_config(tmp_path: Path) -> None:
+    """Subsampling counts are driven entirely by the config object."""
+    from noether.data.datasets.cfd.zarr_aero_dataset import ZarrAeroDataset, ZarrAeroDatasetConfig
+
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "cfg", chunk_points=256)
+    writer.write_sample("s", _make_sample())
+    writer.save_manifest()
+
+    class _DS(ZarrAeroDataset):
+        def __init__(self, cfg: ZarrAeroDatasetConfig) -> None:
+            super().__init__(
+                cfg,
+                FILEMAP,
+                num_points={"surface": cfg.num_surface_points, "volume": cfg.num_volume_points},
+                sampling_seed=cfg.sampling_seed,
+                read_concurrency=cfg.read_concurrency,
+                num_geometry_points=cfg.num_geometry_points,
+            )
+
+        def __len__(self) -> int:
+            return 1
+
+        def _sample_id(self, idx: int) -> str:
+            return "s"
+
+    cfg = ZarrAeroDatasetConfig(
+        root=str(tmp_path), split="train", num_surface_points=512, num_volume_points=4096, num_geometry_points=2000
+    )
+    sample = _DS(cfg)[0]
+    assert sample["surface_position"].shape == (512, 3)
+    assert sample["volume_velocity"].shape == (4096, 3)
+    assert sample["geometry_position"].shape == (2000, 3)
+
+
+def test_shard_points_cap_splits_arrays_into_multiple_shards(tmp_path: Path) -> None:
+    """A shard_points cap packs each array into several chunk-aligned shard objects."""
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "capped", chunk_points=4096, shard_points=8192)
+    writer.write_sample("param0/sample", _make_sample())
+    writer.save_manifest()
+
+    grid = StoreManifest.load(tmp_path).samples["param0/sample"].domains["volume"]
+    assert grid.shard_points == 8192  # cap rounded to a whole number of chunks
+    # volume has 28504 points -> ceil(28504 / 8192) = 4 shard objects per array
+    shard_objects = sorted((tmp_path / "param0/sample.zarr/volume/velocity/c").rglob("*"))
+    assert len([p for p in shard_objects if p.is_file()]) == 4
+
+    # reads are unaffected: full round-trip stays exact, subsampling stays exact-count
+    reader = ZarrChunkReader(tmp_path)
+    full = reader.read_sample("param0/sample", num_points=None)
+    np.testing.assert_array_equal(
+        np.sort(full["volume_position"].numpy(), axis=0),
+        np.sort(_make_sample()["volume_position"], axis=0),
+    )
+    assert reader.read_sample("param0/sample", num_points={"volume": 4096})["volume_velocity"].shape == (4096, 3)
+
+
+def test_shard_points_below_chunk_clamps_to_one_chunk(tmp_path: Path) -> None:
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "tiny-shards", chunk_points=4096, shard_points=1000)
+    writer.write_sample("param0/sample", _make_sample())
+    grid = writer.manifest.samples["param0/sample"].domains["volume"]
+    assert grid.shard_points == 4096  # at least one chunk per shard
+
+
+def test_manifest_round_trips(tmp_path: Path) -> None:
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "test", chunk_points=4096)
+    writer.write_sample("param0/sample", _make_sample())
+    writer.save_manifest()
+    loaded = StoreManifest.load(tmp_path)
+    assert loaded.dataset_name == "test"
+    grid = loaded.samples["param0/sample"].domains["volume"]
+    assert grid.n_points == NV
+    assert grid.chunk_points == 4096
+    assert grid.n_chunks == 7
+
+
+def test_layout_builds_one_array_per_field() -> None:
+    layouts = build_domain_layouts(FILEMAP)
+    volume = layouts["volume"]
+    assert volume.position == "volume_position"
+    # One array per present field, in spec order.
+    assert list(volume.arrays) == ["volume_position", "volume_velocity", "volume_normals", "volume_sdf"]
+    # Positions float32; physical fields float16.
+    assert volume.arrays["volume_position"].dtype == "float32"
+    assert volume.arrays["volume_velocity"].dtype == "float16"
+    assert volume.arrays["volume_velocity"].array_name == "volume/velocity"
+    assert volume.arrays["volume_velocity"].dim == 3
+    assert volume.arrays["volume_sdf"].dim == 1
+
+
+def test_selective_field_read(store: Path) -> None:
+    """Per-field arrays allow reading a subset of fields without touching the rest."""
+    reader = ZarrChunkReader(store)
+    out = reader.read_sample(
+        "param0/sample", num_points={"volume": 4096}, fields={"volume_position", "volume_velocity"}
+    )
+    assert set(out) == {"volume_position", "volume_velocity"}
+    assert out["volume_position"].shape == (4096, 3)
+    assert out["volume_velocity"].shape == (4096, 3)
+
+
+def test_filename_to_canonical_maps_stored_filenames() -> None:
+    mapping = filename_to_canonical(FILEMAP)
+    assert mapping["volume_sdf.pt"] == "volume_sdf"
+    assert mapping["surface_points.pt"] == "surface_position"
+
+
+class _StubDataset:
+    """Minimal FileMap dataset serving in-memory samples via _load (module-level: picklable)."""
+
+    filemap = FILEMAP
+    split = "train"
+
+    def __init__(self, samples: list[dict[str, np.ndarray]]) -> None:
+        self._samples = samples
+        self._reverse = filename_to_canonical(FILEMAP)  # stored filename -> canonical
+
+    def __len__(self) -> int:
+        return len(self._samples)
+
+    def sample_info(self, idx: int) -> dict[str, str]:
+        return {"run_name": f"run_{idx}"}
+
+    def _load(self, idx: int, filename: str) -> torch.Tensor:
+        return torch.from_numpy(self._samples[idx][self._reverse[filename]])
+
+
+def _make_stub_dataset(samples: list[dict[str, np.ndarray]]) -> _StubDataset:
+    return _StubDataset(samples)
+
+
+def test_fsspec_source_conversion_streams_pt_files() -> None:
+    """convert_fsspec_source discovers and converts .pt samples straight from an fsspec source."""
+    import io
+
+    import fsspec
+
+    from noether.data.zarr_store.convert import convert_fsspec_source
+
+    fs = fsspec.filesystem("memory")
+    samples = [_make_sample(seed=i) for i in range(2)]
+    filenames = {canonical: filename for filename, canonical in filename_to_canonical(FILEMAP).items()}
+    for i, sample in enumerate(samples):
+        for canonical, filename in filenames.items():
+            buffer = io.BytesIO()
+            torch.save(torch.from_numpy(sample[canonical]), buffer)
+            fs.pipe_file(f"/pt-source-test/preprocessed/run_{i}/{filename}", buffer.getvalue())
+
+    writer = ZarrStoreWriter("memory://pt-source-test/store", FILEMAP, "stream", chunk_points=4096)
+    # memory:// is per-process, so stream sequentially (real object stores use max_workers > 1).
+    convert_fsspec_source("memory://pt-source-test/preprocessed", FILEMAP, writer, max_workers=1)
+    writer.save_manifest()
+
+    reader = ZarrChunkReader("memory://pt-source-test/store")
+    assert set(reader.manifest.samples) == {"run_0", "run_1"}
+    out = reader.read_sample("run_0", num_points=None)
+    np.testing.assert_array_equal(
+        np.sort(out["volume_position"].numpy(), axis=0),
+        np.sort(samples[0]["volume_position"], axis=0),
+    )
+
+
+def test_filemap_for_dataset_kind_resolves_known_datasets() -> None:
+    """The FileMap of any CFD dataset kind is resolvable without instantiating it."""
+    from noether.data.datasets.cfd.caeml.filemap import CAEML_FILEMAP
+    from noether.data.datasets.cfd.drivaernet.dataset import DrivAerNetDataset
+    from noether.data.datasets.cfd.shapenet_car.filemap import SHAPENET_CAR_FILEMAP
+    from noether.data.zarr_store.convert import filemap_for_dataset_kind
+
+    assert filemap_for_dataset_kind("noether.data.datasets.cfd.DrivAerNetDataset") is DrivAerNetDataset.FILEMAP
+    assert filemap_for_dataset_kind("noether.data.datasets.cfd.ShapeNetCarDataset") is SHAPENET_CAR_FILEMAP
+    assert filemap_for_dataset_kind("noether.data.datasets.cfd.DrivAerMLDataset") is CAEML_FILEMAP
+
+
+def test_float16_overflow_is_rejected_not_stored_as_inf(tmp_path: Path) -> None:
+    """Values beyond the target dtype's range must raise, pointing at field_dtypes."""
+    sample = _make_sample()
+    sample["volume_velocity"] = sample["volume_velocity"] * 1e6  # exceeds float16 max (~6.6e4)
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "overflow", chunk_points=4096)
+    with pytest.raises(ValueError, match="exceeds the float16 range.*volume_velocity.*float32"):
+        writer.write_group("s", sample)
+
+
+def test_field_dtype_override_stores_wide_range_fields_losslessly(tmp_path: Path) -> None:
+    """A per-field float32 override keeps wide-dynamic-range fields exact."""
+    sample = _make_sample()
+    sample["volume_velocity"] = sample["volume_velocity"] * 1e6  # vorticity-like magnitudes
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "wide", chunk_points=4096, field_dtypes={"volume_velocity": "float32"})
+    writer.write_sample("s", sample)
+    writer.save_manifest()
+
+    manifest = StoreManifest.load(tmp_path)
+    assert manifest.domains["volume"].arrays["volume_velocity"].dtype == "float32"
+    assert manifest.domains["volume"].arrays["volume_normals"].dtype == "float16"  # others unaffected
+    out = ZarrChunkReader(tmp_path).read_sample("s", num_points=None)
+    np.testing.assert_array_equal(  # float32 storage -> exact round-trip despite huge values
+        np.sort(out["volume_velocity"].numpy(), axis=0),
+        np.sort(sample["volume_velocity"], axis=0),
+    )
+
+
+def test_broken_sample_is_skipped_not_fatal(tmp_path: Path) -> None:
+    """A sample with misaligned fields is skipped with a warning; the rest convert."""
+    from noether.data.zarr_store.convert import convert_aero_dataset
+
+    samples = [_make_sample(seed=i) for i in range(3)]
+    # Corrupt sample 1: pressure no longer point-aligned with the surface positions.
+    samples[1]["surface_pressure"] = np.concatenate([samples[1]["surface_pressure"], np.zeros(100, "float32")])
+
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "broken", chunk_points=4096)
+    convert_aero_dataset(_make_stub_dataset(samples), writer, max_workers=1)
+    writer.save_manifest()
+    assert set(StoreManifest.load(tmp_path).samples) == {"run_0", "run_2"}
+
+
+def test_all_samples_failing_raises(tmp_path: Path) -> None:
+    from noether.data.zarr_store.convert import convert_aero_dataset
+
+    sample = _make_sample(seed=0)
+    sample["surface_pressure"] = sample["surface_pressure"][:100]  # misaligned
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "all-broken", chunk_points=4096)
+    with pytest.raises(RuntimeError, match="All 1 samples failed"):
+        convert_aero_dataset(_make_stub_dataset([sample]), writer, max_workers=1)
+
+
+def test_parallel_conversion_matches_sequential(tmp_path: Path) -> None:
+    """max_workers > 1 must produce a bit-identical store (per-sample shuffles are seeded)."""
+    from noether.data.zarr_store.convert import convert_aero_dataset
+
+    samples = [_make_sample(seed=i) for i in range(5)]
+    sequential_root, parallel_root = tmp_path / "seq", tmp_path / "par"
+
+    w_seq = ZarrStoreWriter(sequential_root, FILEMAP, "stub", chunk_points=4096)
+    convert_aero_dataset(_make_stub_dataset(samples), w_seq, max_workers=1)
+    w_seq.save_manifest()
+
+    w_par = ZarrStoreWriter(parallel_root, FILEMAP, "stub", chunk_points=4096)
+    convert_aero_dataset(_make_stub_dataset(samples), w_par, max_workers=4)
+    w_par.save_manifest()
+
+    r_seq, r_par = ZarrChunkReader(sequential_root), ZarrChunkReader(parallel_root)
+    assert set(r_seq.manifest.samples) == set(r_par.manifest.samples) == {f"run_{i}" for i in range(5)}
+    for sample_id in r_seq.manifest.samples:
+        a = r_seq.read_sample(sample_id, num_points=None)
+        b = r_par.read_sample(sample_id, num_points=None)
+        for field in a:
+            np.testing.assert_array_equal(a[field].numpy(), b[field].numpy())
+
+
+def test_store_round_trips_on_fsspec_object_storage() -> None:
+    """Writer, manifest and reader all work against an fsspec object store (memory://)."""
+    root = "memory://zarr-store-test/store"
+    writer = ZarrStoreWriter(root, FILEMAP, "mem", chunk_points=4096)
+    writer.write_sample("run_0", _make_sample())
+    manifest_path = writer.save_manifest()
+    assert manifest_path.startswith("memory://")
+
+    manifest = StoreManifest.load(root)
+    assert "run_0" in manifest.samples
+
+    reader = ZarrChunkReader(root)
+    sub = reader.read_sample("run_0", num_points={"surface": 1000, "volume": 4096})
+    assert sub["surface_position"].shape == (1000, 3)
+    assert sub["volume_velocity"].shape == (4096, 3)
+
+    # full read round-trips the float32 positions exactly
+    full = reader.read_sample("run_0", num_points=None)
+    np.testing.assert_array_equal(
+        np.sort(full["volume_position"].numpy(), axis=0),
+        np.sort(_make_sample()["volume_position"], axis=0),
+    )
+
+
+def test_convert_aero_dataset_is_dataset_driven(tmp_path: Path) -> None:
+    """convert_aero_dataset converts any FileMap dataset via its own filemap/_load/sample ids."""
+    from noether.data.zarr_store import filename_to_canonical
+    from noether.data.zarr_store.convert import convert_aero_dataset
+
+    reverse = filename_to_canonical(FILEMAP)  # stored filename -> canonical
+    samples = [_make_sample(seed=i) for i in range(3)]
+
+    class _StubDataset:
+        filemap = FILEMAP
+        split = "train"
+
+        def __len__(self) -> int:
+            return len(samples)
+
+        def sample_info(self, idx: int) -> dict[str, str]:
+            return {"run_name": f"run_{idx}"}
+
+        def _load(self, idx: int, filename: str) -> torch.Tensor:
+            return torch.from_numpy(samples[idx][reverse[filename]])
+
+    writer = ZarrStoreWriter(tmp_path, FILEMAP, "stub", chunk_points=4096)
+    convert_aero_dataset(_StubDataset(), writer)  # type: ignore[arg-type]
+    writer.save_manifest()
+
+    reader = ZarrChunkReader(tmp_path)
+    assert set(reader.manifest.samples) == {"run_0", "run_1", "run_2"}  # ids come from sample_info
+    out = reader.read_sample("run_1", num_points=None)
+    # positions are stored float32 -> exact round-trip (compare sorted; write order is shuffled)
+    np.testing.assert_array_equal(
+        np.sort(out["volume_position"].numpy(), axis=0),
+        np.sort(samples[1]["volume_position"], axis=0),
+    )
+    assert out["surface_pressure"].shape == (NS,)

--- a/uv.lock
+++ b/uv.lock
@@ -359,6 +359,15 @@ wheels = [
 ]
 
 [[package]]
+name = "circuitbreaker"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ac/de7a92c4ed39cba31fe5ad9203b76a25ca67c530797f6bb420fff5f65ccb/circuitbreaker-2.1.3.tar.gz", hash = "sha256:1a4baee510f7bea3c91b194dcce7c07805fe96c4423ed5594b75af438531d084", size = 10787, upload-time = "2025-03-31T08:12:08.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl", hash = "sha256:87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1", size = 7737, upload-time = "2025-03-31T08:12:07.802Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -548,6 +557,112 @@ wheels = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/66/7e97aa77af7cf6afbff26e3651b564fe41932599bc2d3dce0b2f73d4829a/crc32c-2.8.tar.gz", hash = "sha256:578728964e59c47c356aeeedee6220e021e124b9d3e8631d95d9a5e5f06e261c", size = 48179, upload-time = "2025-10-17T06:20:13.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/36/fd18ef23c42926b79c7003e16cb0f79043b5b179c633521343d3b499e996/crc32c-2.8-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:572ffb1b78cce3d88e8d4143e154d31044a44be42cb3f6fbbf77f1e7a941c5ab", size = 66379, upload-time = "2025-10-17T06:19:10.115Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b8/c584958e53f7798dd358f5bdb1bbfc97483134f053ee399d3eeb26cca075/crc32c-2.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cf827b3758ee0c4aacd21ceca0e2da83681f10295c38a10bfeb105f7d98f7a68", size = 63042, upload-time = "2025-10-17T06:19:10.946Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/6f2af0ec64a668a46c861e5bc778ea3ee42171fedfc5440f791f470fd783/crc32c-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:106fbd79013e06fa92bc3b51031694fcc1249811ed4364ef1554ee3dd2c7f5a2", size = 61528, upload-time = "2025-10-17T06:19:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/17/8b/4a04bd80a024f1a23978f19ae99407783e06549e361ab56e9c08bba3c1d3/crc32c-2.8-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6dde035f91ffbfe23163e68605ee5a4bb8ceebd71ed54bb1fb1d0526cdd125a2", size = 80028, upload-time = "2025-10-17T06:19:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8f/01c7afdc76ac2007d0e6a98e7300b4470b170480f8188475b597d1f4b4c6/crc32c-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e41ebe7c2f0fdcd9f3a3fd206989a36b460b4d3f24816d53e5be6c7dba72c5e1", size = 81531, upload-time = "2025-10-17T06:19:13.406Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2b/8f78c5a8cc66486be5f51b6f038fc347c3ba748d3ea68be17a014283c331/crc32c-2.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ecf66cf90266d9c15cea597d5cc86c01917cd1a238dc3c51420c7886fa750d7e", size = 80608, upload-time = "2025-10-17T06:19:14.223Z" },
+    { url = "https://files.pythonhosted.org/packages/db/86/fad1a94cdeeeb6b6e2323c87f970186e74bfd6fbfbc247bf5c88ad0873d5/crc32c-2.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:59eee5f3a69ad0793d5fa9cdc9b9d743b0cd50edf7fccc0a3988a821fef0208c", size = 79886, upload-time = "2025-10-17T06:19:15.345Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/db/1a7cb6757a1e32376fa2dfce00c815ea4ee614a94f9bff8228e37420c183/crc32c-2.8-cp312-cp312-win32.whl", hash = "sha256:a73d03ce3604aa5d7a2698e9057a0eef69f529c46497b27ee1c38158e90ceb76", size = 64896, upload-time = "2025-10-17T06:19:16.457Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/8e/2024de34399b2e401a37dcb54b224b56c747b0dc46de4966886827b4d370/crc32c-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:56b3b7d015247962cf58186e06d18c3d75a1a63d709d3233509e1c50a2d36aa2", size = 66645, upload-time = "2025-10-17T06:19:17.235Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d8/3ae227890b3be40955a7144106ef4dd97d6123a82c2a5310cdab58ca49d8/crc32c-2.8-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:36f1e03ee9e9c6938e67d3bcb60e36f260170aa5f37da1185e04ef37b56af395", size = 66380, upload-time = "2025-10-17T06:19:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8b/178d3f987cd0e049b484615512d3f91f3d2caeeb8ff336bb5896ae317438/crc32c-2.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b2f3226b94b85a8dd9b3533601d7a63e9e3e8edf03a8a169830ee8303a199aeb", size = 63048, upload-time = "2025-10-17T06:19:18.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a1/48145ae2545ebc0169d3283ebe882da580ea4606bfb67cf4ca922ac3cfc3/crc32c-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6e08628bc72d5b6bc8e0730e8f142194b610e780a98c58cb6698e665cb885a5b", size = 61530, upload-time = "2025-10-17T06:19:19.974Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4b/cf05ed9d934cc30e5ae22f97c8272face420a476090e736615d9a6b53de0/crc32c-2.8-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:086f64793c5ec856d1ab31a026d52ad2b895ac83d7a38fce557d74eb857f0a82", size = 80001, upload-time = "2025-10-17T06:19:20.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ab/4b04801739faf36345f6ba1920be5b1c70282fec52f8280afd3613fb13e2/crc32c-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcf72ee7e0135b3d941c34bb2c26c3fc6bc207106b49fd89aaafaeae223ae209", size = 81543, upload-time = "2025-10-17T06:19:21.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1b/6e38dde5bfd2ea69b7f2ab6ec229fcd972a53d39e2db4efe75c0ac0382ce/crc32c-2.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a717dd9c3fd777d9bc6603717eae172887d402c4ab589d124ebd0184a83f89e", size = 80644, upload-time = "2025-10-17T06:19:22.325Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/45/012176ffee90059ae8ec7131019c71724ea472aa63e72c0c8edbd1fad1d7/crc32c-2.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0450bb845b3c3c7b9bdc0b4e95620ec9a40824abdc8c86d6285c919a90743c1a", size = 79919, upload-time = "2025-10-17T06:19:23.101Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/f557629842f9dec2b3461cb3a0d854bb586ec45b814cea58b082c32f0dde/crc32c-2.8-cp313-cp313-win32.whl", hash = "sha256:765d220bfcbcffa6598ac11eb1e10af0ee4802b49fe126aa6bf79f8ddb9931d1", size = 64896, upload-time = "2025-10-17T06:19:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/db/fd0f698c15d1e21d47c64181a98290665a08fcbb3940cd559e9c15bda57e/crc32c-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:171ff0260d112c62abcce29332986950a57bddee514e0a2418bfde493ea06bb3", size = 66646, upload-time = "2025-10-17T06:19:24.702Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b9/8e5d7054fe8e7eecab10fd0c8e7ffb01439417bdb6de1d66a81c38fc4a20/crc32c-2.8-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b977a32a3708d6f51703c8557008f190aaa434d7347431efb0e86fcbe78c2a50", size = 66203, upload-time = "2025-10-17T06:19:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/55/5f/cc926c70057a63cc0c98a3c8a896eb15fc7e74d3034eadd53c94917c6cc3/crc32c-2.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7399b01db4adaf41da2fb36fe2408e75a8d82a179a9564ed7619412e427b26d6", size = 62956, upload-time = "2025-10-17T06:19:26.652Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/8a/0660c44a2dd2cb6ccbb529eb363b9280f5c766f1017bc8355ed8d695bd94/crc32c-2.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4379f73f9cdad31958a673d11a332ec725ca71572401ca865867229f5f15e853", size = 61442, upload-time = "2025-10-17T06:19:27.74Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5a/6108d2dfc0fe33522ce83ba07aed4b22014911b387afa228808a278e27cd/crc32c-2.8-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e68264555fab19bab08331550dab58573e351a63ed79c869d455edd3b0aa417", size = 79109, upload-time = "2025-10-17T06:19:28.535Z" },
+    { url = "https://files.pythonhosted.org/packages/84/1e/c054f9e390090c197abf3d2936f4f9effaf0c6ee14569ae03d6ddf86958a/crc32c-2.8-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b48f2486727b8d0e7ccbae4a34cb0300498433d2a9d6b49cb13cb57c2e3f19cb", size = 80987, upload-time = "2025-10-17T06:19:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ad/1650e5c3341e4a485f800ea83116d72965030c5d48ccc168fcc685756e4d/crc32c-2.8-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ecf123348934a086df8c8fde7f9f2d716d523ca0707c5a1367b8bb00d8134823", size = 79994, upload-time = "2025-10-17T06:19:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/3b/f2ed924b177729cbb2ab30ca2902abff653c31d48c95e7b66717a9ca9fcc/crc32c-2.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e636ac60f76de538f7a2c0d0f3abf43104ee83a8f5e516f6345dc283ed1a4df7", size = 79046, upload-time = "2025-10-17T06:19:30.894Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/80/413b05ee6ace613208b31b3670c3135ee1cf451f0e72a9c839b4946acc04/crc32c-2.8-cp313-cp313t-win32.whl", hash = "sha256:8dd4a19505e0253892e1b2f1425cc3bd47f79ae5a04cb8800315d00aad7197f2", size = 64837, upload-time = "2025-10-17T06:19:32.03Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/1b/85eddb6ac5b38496c4e35c20298aae627970c88c3c624a22ab33e84f16c7/crc32c-2.8-cp313-cp313t-win_amd64.whl", hash = "sha256:4bb18e4bd98fb266596523ffc6be9c5b2387b2fa4e505ec56ca36336f49cb639", size = 66574, upload-time = "2025-10-17T06:19:33.143Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/df/50e9079b532ff53dbfc0e66eed781374bd455af02ed5df8b56ad538de4ff/crc32c-2.8-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3a3b2e4bcf7b3ee333050e7d3ff38e2ba46ea205f1d73d8949b248aaffe937ac", size = 66399, upload-time = "2025-10-17T06:19:34.279Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2e/67e3b0bc3d30e46ea5d16365cc81203286387671e22f2307eb41f19abb9c/crc32c-2.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:445e559e66dff16be54f8a4ef95aa6b01db799a639956d995c5498ba513fccc2", size = 63044, upload-time = "2025-10-17T06:19:35.062Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/1723b17437e4344ed8d067456382ecb1f5b535d83fdc5aaebab676c6d273/crc32c-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bf3040919e17afa5782e01b1875d6a05f44b8f19c05f211d8b9f8a1deb8bbd9c", size = 61541, upload-time = "2025-10-17T06:19:36.204Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6a/cbec8a235c5b46a01f319939b538958662159aec0ed3a74944e3a6de21f1/crc32c-2.8-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5607ab8221e1ffd411f64aa40dbb6850cf06dd2908c9debd05d371e1acf62ff3", size = 80139, upload-time = "2025-10-17T06:19:37.351Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/d096722fe74b692d6e8206c27da1ea5f6b2a12ff92c54a62a6ba2f376254/crc32c-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f5db4f16816926986d3c94253314920689706ae13a9bf4888b47336c6735ce", size = 81736, upload-time = "2025-10-17T06:19:38.16Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a2/f75ef716ff7e3c22f385ba6ef30c5de80c19a21ebe699dc90824a1903275/crc32c-2.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:70b0153c4d418b673309d3529334d117e1074c4a3b2d7f676e430d72c14de67b", size = 80795, upload-time = "2025-10-17T06:19:38.948Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/94/6d647a12d96ab087d9b8eacee3da073f981987827d57c7072f89ffc7b6cd/crc32c-2.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c8933531442042438753755a5c8a9034e4d88b01da9eb796f7e151b31a7256c", size = 80042, upload-time = "2025-10-17T06:19:39.725Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/dc/32b8896b40a0afee7a3c040536d0da5a73e68df2be9fadd21770fd158e16/crc32c-2.8-cp314-cp314-win32.whl", hash = "sha256:cdc83a3fe6c4e5df9457294cfd643de7d95bd4e9382c1dd6ed1e0f0f9169172c", size = 64914, upload-time = "2025-10-17T06:19:40.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b4/4308b27d307e8ecaf8dd1dcc63bbb0e47ae1826d93faa3e62d1ee00ee2d5/crc32c-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:509e10035106df66770fe24b9eb8d9e32b6fb967df17744402fb67772d8b2bc7", size = 66723, upload-time = "2025-10-17T06:19:42.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d5/a19d2489fa997a143bfbbf971a5c9a43f8b1ba9e775b1fb362d8fb15260c/crc32c-2.8-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:864359a39777a07b09b28eb31337c0cc603d5c1bf0fc328c3af736a8da624ec0", size = 66201, upload-time = "2025-10-17T06:19:43.273Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c2/5f82f22d2c1242cb6f6fe92aa9a42991ebea86de994b8f9974d9c1d128e2/crc32c-2.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:14511d7cfc5d9f5e1a6c6b64caa6225c2bdc1ed00d725e9a374a3e84073ce180", size = 62956, upload-time = "2025-10-17T06:19:44.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/61/3d43d33489cf974fb78bfb3500845770e139ae6d1d83473b660bd8f79a6c/crc32c-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:918b7999b52b5dcbcea34081e9a02d46917d571921a3f209956a9a429b2e06e5", size = 61443, upload-time = "2025-10-17T06:19:44.89Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6d/f306ce64a352a3002f76b0fc88a1373f4541f9d34fad3668688610bab14b/crc32c-2.8-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cc445da03fc012a5a03b71da1df1b40139729e6a5571fd4215ab40bfb39689c7", size = 79106, upload-time = "2025-10-17T06:19:45.688Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b7/1f74965dd7ea762954a69d172dfb3a706049c84ffa45d31401d010a4a126/crc32c-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e3dde2ec59a8a830511d72a086ead95c0b0b7f0d418f93ea106244c5e77e350", size = 80983, upload-time = "2025-10-17T06:19:46.792Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/50/af93f0d91ccd61833ce77374ebfbd16f5805f5c17d18c6470976d9866d76/crc32c-2.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:61d51681a08b6a2a2e771b7f0cd1947fb87cb28f38ed55a01cb7c40b2ac4cdd8", size = 80009, upload-time = "2025-10-17T06:19:47.619Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fa/94f394beb68a88258af694dab2f1284f55a406b615d7900bdd6235283bc4/crc32c-2.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:67c0716c3b1a02d5235be649487b637eed21f2d070f2b3f63f709dcd2fefb4c7", size = 79066, upload-time = "2025-10-17T06:19:48.409Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c6/a6050e0c64fd73c67a97da96cb59f08b05111e00b958fb87ecdce99f17ac/crc32c-2.8-cp314-cp314t-win32.whl", hash = "sha256:2e8fe863fbbd8bdb6b414a2090f1b0f52106e76e9a9c96a413495dbe5ebe492a", size = 64869, upload-time = "2025-10-17T06:19:49.197Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1f/c7735034e401cb1ea14f996a224518e3a3fa9987cb13680e707328a7d779/crc32c-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:20a9cfb897693eb6da19e52e2a7be2026fd4d9fc8ae318f086c0d71d5dd2d8e0", size = 66633, upload-time = "2025-10-17T06:19:50.003Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -712,6 +827,18 @@ wheels = [
 ]
 
 [[package]]
+name = "donfig"
+version = "0.8.1.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/71/80cc718ff6d7abfbabacb1f57aaa42e9c1552bfdd01e64ddd704e4a03638/donfig-0.8.1.post1.tar.gz", hash = "sha256:3bef3413a4c1c601b585e8d297256d0c1470ea012afa6e8461dc28bfb7c23f52", size = 19506, upload-time = "2024-05-23T14:14:31.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl", hash = "sha256:2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d", size = 21592, upload-time = "2024-05-23T14:13:55.283Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -734,6 +861,7 @@ dependencies = [
     { name = "hydra-core" },
     { name = "loguru" },
     { name = "numpy" },
+    { name = "ocifs" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "psutil" },
@@ -747,6 +875,7 @@ dependencies = [
     { name = "trimesh" },
     { name = "typer" },
     { name = "wheel" },
+    { name = "zarr" },
 ]
 
 [package.dev-dependencies]
@@ -803,6 +932,7 @@ requires-dist = [
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "numpy", specifier = "==2.3.1" },
+    { name = "ocifs", specifier = ">=1.3.4" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyvista", specifier = ">=0.44.2" },
@@ -814,6 +944,7 @@ requires-dist = [
     { name = "trimesh", specifier = ">=4.6.6" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "wheel" },
+    { name = "zarr", specifier = ">=3.2.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -981,6 +1112,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
 ]
 
 [[package]]
@@ -1909,6 +2063,33 @@ wheels = [
 ]
 
 [[package]]
+name = "numcodecs"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/8a391e7c356366224734efd24da929cc4796fff468bfb179fe1af6548535/numcodecs-0.16.5.tar.gz", hash = "sha256:0d0fb60852f84c0bd9543cc4d2ab9eefd37fc8efcc410acd4777e62a1d300318", size = 6276387, upload-time = "2025-11-21T02:49:48.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/cc/55420f3641a67f78392dc0bc5d02cb9eb0a9dcebf2848d1ac77253ca61fa/numcodecs-0.16.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:24e675dc8d1550cd976a99479b87d872cb142632c75cc402fea04c08c4898523", size = 1656287, upload-time = "2025-11-21T02:49:25.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/86644987505dcb90ba6d627d6989c27bafb0699f9fd00187e06d05ea8594/numcodecs-0.16.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:94ddfa4341d1a3ab99989d13b01b5134abb687d3dab2ead54b450aefe4ad5bd6", size = 1148899, upload-time = "2025-11-21T02:49:26.87Z" },
+    { url = "https://files.pythonhosted.org/packages/97/1e/98aaddf272552d9fef1f0296a9939d1487914a239e98678f6b20f8b0a5c8/numcodecs-0.16.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b554ab9ecf69de7ca2b6b5e8bc696bd9747559cb4dd5127bd08d7a28bec59c3a", size = 8534814, upload-time = "2025-11-21T02:49:28.547Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6", size = 9173471, upload-time = "2025-11-21T02:49:30.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/20/2fdec87fc7f8cec950d2b0bea603c12dc9f05b4966dc5924ba5a36a61bf6/numcodecs-0.16.5-cp312-cp312-win_amd64.whl", hash = "sha256:845a9857886ffe4a3172ba1c537ae5bcc01e65068c31cf1fce1a844bd1da050f", size = 801412, upload-time = "2025-11-21T02:49:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/38/38/071ced5a5fd1c85ba0e14ba721b66b053823e5176298c2f707e50bed11d9/numcodecs-0.16.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25be3a516ab677dad890760d357cfe081a371d9c0a2e9a204562318ac5969de3", size = 1654359, upload-time = "2025-11-21T02:49:33.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/5f84ba7525577c1b9909fc2d06ef11314825fc4ad4378f61d0e4c9883b4a/numcodecs-0.16.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0107e839ef75b854e969cb577e140b1aadb9847893937636582d23a2a4c6ce50", size = 1144237, upload-time = "2025-11-21T02:49:35.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/00/787ea5f237b8ea7bc67140c99155f9c00b5baf11c49afc5f3bfefa298f95/numcodecs-0.16.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:015a7c859ecc2a06e2a548f64008c0ec3aaecabc26456c2c62f4278d8fc20597", size = 8483064, upload-time = "2025-11-21T02:49:36.454Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e6/d359fdd37498e74d26a167f7a51e54542e642ea47181eb4e643a69a066c3/numcodecs-0.16.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84230b4b9dad2392f2a84242bd6e3e659ac137b5a1ce3571d6965fca673e0903", size = 9126063, upload-time = "2025-11-21T02:49:38.018Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/6663cc0382ddbb866136c255c837bcb96cc7ce5e83562efec55e1b995941/numcodecs-0.16.5-cp313-cp313-win_amd64.whl", hash = "sha256:5088145502ad1ebf677ec47d00eb6f0fd600658217db3e0c070c321c85d6cf3d", size = 799275, upload-time = "2025-11-21T02:49:39.558Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/9e/38e7ca8184c958b51f45d56a4aeceb1134ecde2d8bd157efadc98502cc42/numcodecs-0.16.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:b05647b8b769e6bc8016e9fd4843c823ce5c9f2337c089fb5c9c4da05e5275de", size = 1654721, upload-time = "2025-11-21T02:49:40.602Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/260fa42e7b2b08e6e00ad632f8dd620961a60a459426c26cea390f8c68d0/numcodecs-0.16.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3832bd1b5af8bb3e413076b7d93318c8e7d7b68935006b9fa36ca057d1725a8f", size = 1146887, upload-time = "2025-11-21T02:49:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/15/e2e1151b5a8b14a15dfd4bb4abccce7fff7580f39bc34092780088835f3a/numcodecs-0.16.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49f7b7d24f103187f53135bed28bb9f0ed6b2e14c604664726487bb6d7c882e1", size = 8476987, upload-time = "2025-11-21T02:49:43.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/16a57fc4d9fb0ba06c600408bd6634f2f1753c54a7a351c99c5e09b51ee2/numcodecs-0.16.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aec9736d81b70f337d89c4070ee3ffeff113f386fd789492fa152d26a15043e4", size = 9102377, upload-time = "2025-11-21T02:49:45.508Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a5/a0425af36c20d55a3ea884db4b4efca25a43bea9214ba69ca7932dd997b4/numcodecs-0.16.5-cp314-cp314-win_amd64.whl", hash = "sha256:b16a14303800e9fb88abc39463ab4706c037647ac17e49e297faa5f7d7dbbf1d", size = 819022, upload-time = "2025-11-21T02:49:47.39Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2096,6 +2277,39 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+]
+
+[[package]]
+name = "oci"
+version = "2.177.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "circuitbreaker" },
+    { name = "crc32c" },
+    { name = "cryptography" },
+    { name = "pyopenssl" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/eb/f4e9a840c2c703bf78f1ca8506514bb1195792715dcf52fbb92cab4a6cec/oci-2.177.0.tar.gz", hash = "sha256:941c15283677ec5ca65d82a4bc71bae28692d73e79abbaf5eccb305a0ddb1251", size = 17454232, upload-time = "2026-06-02T01:55:16.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/a6/260b0e2ef9de7356030ea82dec56b61c40ac2907590f6aecaa9ce7b11059/oci-2.177.0-py3-none-any.whl", hash = "sha256:fd45a4a4d81764315123283f66cf33cc536ede3e3008dd37c871c89103012a81", size = 35629529, upload-time = "2026-06-02T01:55:07.57Z" },
+]
+
+[[package]]
+name = "ocifs"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "oci" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/e0/8d376b294173914b343daded4711cb6e660c8a91761477f096a82ca59b8b/ocifs-1.3.4.tar.gz", hash = "sha256:52658665366210924eca61716ad3fce3c3cdf772c0e95d47fd378db7f969c6f4", size = 57541, upload-time = "2025-11-06T17:07:28.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/dd/92c66262f9b6bda335bc9f970f5b13145e3702330be6af76638fb1d7ff9b/ocifs-1.3.4-py3-none-any.whl", hash = "sha256:b81bbe65405c1f1af3603af867e51c2f7534c4b72d799179a9215afa047c6e10", size = 67985, upload-time = "2025-11-06T17:07:26.862Z" },
 ]
 
 [[package]]
@@ -2597,6 +2811,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -3711,4 +3938,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
     { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
     { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+]
+
+[[package]]
+name = "zarr"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "donfig" },
+    { name = "google-crc32c" },
+    { name = "numcodecs" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -878,6 +878,14 @@ dependencies = [
     { name = "zarr" },
 ]
 
+[package.optional-dependencies]
+obstore = [
+    { name = "obstore" },
+]
+preprocessing = [
+    { name = "scipy" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "autodoc-pydantic" },
@@ -932,11 +940,13 @@ requires-dist = [
     { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "numpy", specifier = "==2.3.1" },
+    { name = "obstore", marker = "extra == 'obstore'", specifier = ">=0.10" },
     { name = "ocifs", specifier = ">=1.3.4" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyvista", specifier = ">=0.44.2" },
     { name = "rtree", specifier = ">=1.4.0" },
+    { name = "scipy", marker = "extra == 'preprocessing'", specifier = ">=1.13" },
     { name = "setuptools" },
     { name = "submitit", specifier = ">=1.5.2" },
     { name = "torch", marker = "sys_platform != 'darwin'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cu128" },
@@ -946,6 +956,7 @@ requires-dist = [
     { name = "wheel" },
     { name = "zarr", specifier = ">=3.2.1" },
 ]
+provides-extras = ["preprocessing", "obstore"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2280,6 +2291,56 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e3/34852e48d5acedc1dbfa8bfb1ddcee448c7bb1dee7cefca659dce5ee10b4/obstore-0.10.0.tar.gz", hash = "sha256:b581d2f78b521c7c72862721384c109b6764c57222b7bf06dc83626a7c4a6945", size = 126379, upload-time = "2026-06-01T20:56:59.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/47/46357284f39465aeaec6b49f7741a26aa6c0258be6d0f968a3c5c1a93401/obstore-0.10.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:03b4e07d97e5271da136942dae71febd5a42c455aeee42a40892a6977171e9fa", size = 4090761, upload-time = "2026-06-01T20:55:33.434Z" },
+    { url = "https://files.pythonhosted.org/packages/48/40/dc3d2acc664af08c4b1062cd677c36a1f3a7face6fa4e966562ba58d92cc/obstore-0.10.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e45deb76f3f1a54cf730c43e917af72d3f1a46e4c502190a9111d2dabec3d71e", size = 3871052, upload-time = "2026-06-01T20:55:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/2a4eec925df64b46839b37222fb46fa32faa6790173688b6bbc1a5fd303c/obstore-0.10.0-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d90894aafb8baf02d4d7d4e6debbbd43b26890bfbe0bcad7c6d75b41b019ed6b", size = 4024833, upload-time = "2026-06-01T20:55:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a4/638775f75c7df43596c44684f722db4f130d9a47bc95047c81dcffd8461d/obstore-0.10.0-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8a443c729dfb6324591664aa4cca5394d89924014d585ea4ac7e2d448ad3a8e", size = 4122218, upload-time = "2026-06-01T20:55:38.02Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/31/e7ad24144996cb1c84414f5dfca83ce149ccfca621399a4fafcabdf18635/obstore-0.10.0-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52ed02949c1ea3dd445c963b246e95801ccd54b5d0d24050ad7ae9570e2c1195", size = 4410778, upload-time = "2026-06-01T20:55:39.468Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/37/d5710ed7aa32082933c89d3864197e9b413dbabd954ebd5504b976b998a6/obstore-0.10.0-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e360ce37f4b5f7b6e3eaf6517b8bbb481379eb0773a16bb2971c02b4363ca787", size = 4291676, upload-time = "2026-06-01T20:55:41.184Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5a/11b2947870663c4d804a5467462dcfc66a13505cd360e97b2d6ccbc93686/obstore-0.10.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70accdf1fc624559c810bed68041f599a218f3dc4fb3afdeed50f7151e240ff8", size = 4210395, upload-time = "2026-06-01T20:55:42.923Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2d/363d7d7f89378753e5491e5d1189b0c728d68ea39d2a02baa6644fb8c4ca/obstore-0.10.0-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:4fc646ad2c2ceaa3dbe07536eb207e1e868e4c701c89f71dd35678e1ee957283", size = 4101733, upload-time = "2026-06-01T20:55:44.561Z" },
+    { url = "https://files.pythonhosted.org/packages/51/fd/7ceffe6b89feb6169f81d2b1b5d06eb53998422346c79365424dd06978b1/obstore-0.10.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:72610b6e7b3da608762b6a8a37989e0559c813ac115b9376a176810eb0173bd8", size = 4285774, upload-time = "2026-06-01T20:55:46.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d9/4c534074516645236157135127e3379184f6f8e2622ab93485946ce2df42/obstore-0.10.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:38a10746b540aab3f898422d87fa7112dab35a824dfa912b64480eb37b55c755", size = 4258354, upload-time = "2026-06-01T20:55:48.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/dc/3f40b59c19054d8dc0c2699cdc72348bfd56edec78008c5e6bebe8aed55e/obstore-0.10.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:e62afd200b2e5bc93cff75e6f930877f4203a6a2f0e13252c6ce7dba78d77c9c", size = 4247831, upload-time = "2026-06-01T20:55:50.005Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/08/28d6917d454ae587ef10b10b5d591c22ceb42bcb42c777463fe04ff3efb7/obstore-0.10.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25e1cad14a7723e48e358c5635dc199ec1d0ddb0f6724ff58d92057ed93ad81b", size = 4429790, upload-time = "2026-06-01T20:55:51.765Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/de/5c683e75a7504ee73d51e34ac4b98c1eb2ab7679d53d292009028e05338b/obstore-0.10.0-cp311-abi3-win_amd64.whl", hash = "sha256:7e14e1ef6bb63730d6aec78499b0aa48dde160d1ad8fdd1e5553c930e7664107", size = 4166690, upload-time = "2026-06-01T20:55:53.314Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c1/782617a10203916d193ab2bc6efe363f8f42b5bc6fbde0e0cc3bb51a58dc/obstore-0.10.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f343227c37c6f217aaf56e82f58335fa5f34b70a727f4e5e718becc9c613060a", size = 4073158, upload-time = "2026-06-01T20:55:54.886Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/31d0a6801a05fb032060bb38c94acb5348ac4ceb0a3a55d0b100439005b4/obstore-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5b071781d2ef95653f78aef588bd054480381d679ae57c4f5d2553b366de1a05", size = 3862303, upload-time = "2026-06-01T20:55:56.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0c/70c1ba253ab9a7dbdb73996381b73ff9a121b032e9d04125709378f44b67/obstore-0.10.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71657a256f938715f5a4d3fe84c5141b79572dbe2436b90d0020ecb9cfe6548b", size = 4021507, upload-time = "2026-06-01T20:55:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d5/5495cb6056fac0f9394518c8eb85340ba625245a14de4384385966efeaba/obstore-0.10.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a96beb5628f3303d8fdfd003b1957f4c2a38f0f224a47b6e488ab0b4eb23edb", size = 4113513, upload-time = "2026-06-01T20:55:59.991Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/80/90b292e9989ea387b60f66077cafcb6cc637f3a3ec109ba2c3fd7849b19d/obstore-0.10.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2509b29b89e5a00480f165d5351132da2efeeca6a57d29f018c4e0534a5a5dc0", size = 4400976, upload-time = "2026-06-01T20:56:01.512Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/7ae84485bccb672f4abab5a4362e2e1554d3df83f07f76e2d68bee2a0657/obstore-0.10.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6b53a9c3e3afe24ea53e554c1d5626fdd456b2e7960091fce4a77af5b7a0ffb7", size = 4298268, upload-time = "2026-06-01T20:56:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f1/9934e3ae0869085449d87c54e41cef137c8ea8527a87d60f9934f822bc08/obstore-0.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d07b04a16c6a586444de1997f2121a332db05aac7953fbcb3e8fb28140306a8", size = 4208768, upload-time = "2026-06-01T20:56:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/69/76/50cd42e12d8fecef6637a00a857b39c4aade6fa8a100634fe8a000fe56ca/obstore-0.10.0-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:012ebb24ba0c47e54840fa02bef780ce4f4d73a3c9685d9addd53222f1b375b2", size = 4100278, upload-time = "2026-06-01T20:56:07.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/be/378d4ea417771bfffd49222711f70b426f475475881aa6adddf67e62be18/obstore-0.10.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:defe889c3baf0781eb83e0335e89fb1331723bebd6a015dc4eecb99794c70210", size = 4285696, upload-time = "2026-06-01T20:56:08.898Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/26/40a9a419de6ccc9e828336fab4a89a5d90c1e01523cce781600dfa970b6b/obstore-0.10.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b4b1fcf083474384565c5fd06523894419280fca4aeb23a7f3f88add8db2d824", size = 4255725, upload-time = "2026-06-01T20:56:10.609Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/db/038ae746b5f8ca2677fa95418234edfa22ebdeff77a55fa349abcb6a6823/obstore-0.10.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:c2c4974845b1192ec50959ad8579e01699b6ae8c64adb6433addcfbf35263901", size = 4242564, upload-time = "2026-06-01T20:56:12.127Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/dad7562624b89ed8b8c06241eea9340812decb4bbf1e4f744e9fbf652461/obstore-0.10.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:315fe386cc631247175c2cc64dfa77f7ec4746248d0a03a7126d9b6a063a1a1d", size = 4429578, upload-time = "2026-06-01T20:56:13.887Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d2/b2a232c428b7848862da2b31428694237bd4fe71166ace65d48bbfea6eb4/obstore-0.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1fc3a232026f9b33affa4c6aa9d4a1765c08aa4e2d0aa8a6034801cf3f8a3cf6", size = 4160793, upload-time = "2026-06-01T20:56:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/13/54/f3ed3d770279f59d87f476d36715f96ee097a8ab42f08c660c1e29d2a56e/obstore-0.10.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:fedac1464b8835063a5661da8dd33519d0d24988d2b256c92b5841c26b18ce28", size = 4073290, upload-time = "2026-06-01T20:56:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3d/8a20aa21c615b25fc37b1396f4d643a3f0a951b5d73284b1822b443912b0/obstore-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2cccb3adef4e6e113fcd54a12c342c2a01fb8e470abfa1a5f9ce4ad2830514f1", size = 3862508, upload-time = "2026-06-01T20:56:19.011Z" },
+    { url = "https://files.pythonhosted.org/packages/63/73/e1b00867e462c168de19a518688463f26a3560149373ab9a5b00a62770b7/obstore-0.10.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d0396e857e403848a366ba38ee0289a5ea206cff1e184d2ce7f63eeb2a24da20", size = 4021738, upload-time = "2026-06-01T20:56:20.485Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d9/23438e668d7eeeb7f30de4bece9467bdf9c2df25a849c10aec03edca4fc6/obstore-0.10.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3911b95eac66328606cfa0c5545592ef18c04c242f5c5631c18ef4c3ce456009", size = 4113768, upload-time = "2026-06-01T20:56:22.116Z" },
+    { url = "https://files.pythonhosted.org/packages/00/9c/e501563733f212f83ea3f2661f67c25dfd5cfd46bc9a979237662910b424/obstore-0.10.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f86aa14f02e35db95b5331dda4387761366fefd52ec0856c9eed07bf92c681d", size = 4401455, upload-time = "2026-06-01T20:56:23.742Z" },
+    { url = "https://files.pythonhosted.org/packages/35/12/2d1b356fc58e0868590f402067bcfe58d8de7501109f50924a2d691ae6e3/obstore-0.10.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b29f2477551114f1d3e01d9729fc54f88b6d6cd83fdc6e40d36eb4781ad03cd4", size = 4297930, upload-time = "2026-06-01T20:56:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5b/4deaf8795054977204925234ad9504b1fb942125bfeea11f6d11c7c04889/obstore-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d2290638739df5c4c9e766e716fb536eb0e591350302ba492ff2dac7b03e913", size = 4209433, upload-time = "2026-06-01T20:56:27.151Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fc/b80e7aa1119b46d7f232499ffda8c6e7db676405b421d566f856bd8034a6/obstore-0.10.0-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:0d6b1cf7af217dd6091e097e240347a64709a11eb22a89adcc85dda7462d2b4b", size = 4101258, upload-time = "2026-06-01T20:56:28.616Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7b/1518ad6d7ad39904378395c47fee2726d9d4518053089e7bd23406c827c3/obstore-0.10.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c338a9fcbb18aebf5aab654fbb0731feaa27b80a0c1153aba0aa93188e89a6de", size = 4286477, upload-time = "2026-06-01T20:56:30.247Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/035ac9f52e84ca7cf17554e11d522d6c213f56e656aff934ac6f1d4e7122/obstore-0.10.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:089d64f61649ded2b4f997ec94a4b659f594e6632f65c1c88622ad21c73f6089", size = 4255950, upload-time = "2026-06-01T20:56:31.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2c/5d9a5b2d1674db851bb8c9b886cf6a4f0a1d65adef113bd469bd7bae955d/obstore-0.10.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d12bc7c84cb923c65055d83705870e4fd7a233aba9db91a26aebcf2327614429", size = 4243073, upload-time = "2026-06-01T20:56:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/27/38/2899c989997d8576c0a37160721fcc094155b01eca4eff0ef5faf3fdf434/obstore-0.10.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4e69ce8e579227f6416c4e547c485a9ff84425ec92fd95107f2ad0cfb02f1cc", size = 4430865, upload-time = "2026-06-01T20:56:35.242Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ed/ddf7aa9f6fbaef49764af51c0aead36770afcb1cb43e05e5658c5bba404a/obstore-0.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9a64ededa74677649358bb35a1f07d912c77c51f732b77c531383ef964e29cdd", size = 4161321, upload-time = "2026-06-01T20:56:36.801Z" },
+]
+
+[[package]]
 name = "oci"
 version = "2.177.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3166,6 +3227,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a preprocessing/conversion script for the **DrivAerStar** dataset — the DrivAerStar analogue of `caeml/preprocessing.py`, but writing directly into the chunked/sharded Zarr store (`ZarrStoreWriter`) introduced in #237 instead of per-field `.pt` files.

> Stacked on `feat/zarr-chunked-store` (#237): the script imports `noether.data.zarr_store` and the `preprocessing` (scipy) extra, both of which live on that branch. Please merge #237 first.

### What it does
- Reads raw **EnSight Gold** cases (`case_<T>/<id>/case/<T>_<id>.case` + `.geo` + per-cell `Pressure`/`Velocity`/`WallShearStress`) from a local path **or any fsspec URL** (`oci://emmi-drivaer-star`, …; `ocifs` needs `OCIFS_IAM_TYPE=api_key`).
- **Surface/volume split** matches `Emmi-AI/proprioceptive`'s `match_experiment_probes.py`: volume = the `domain` block; surface = `WallShearStress`-bearing blocks that are *not* the domain and *not* wind-tunnel walls (`Block.*`), combined + surface-extracted, fields sampled at cell centres.
- Stores `surface_position/pressure/friction/normals` and `volume_position/pressure/velocity`; **keeps all volume cells** (optional `--subsample-factor`).
- **Optional `volume_sdf`** (distance-to-surface via scipy `cKDTree`, the same method caeml uses) behind `--sdf`, **off by default** — when disabled the FileMap drops the field so the writer doesn't expect it.
- **Crash isolation:** each case is read/extracted in a child process, so a C-level crash in VTK's EnSight reader skips just that case (non-zero exit) instead of aborting the run. Cases convert concurrently (`--workers`); the manifest is saved at the end.

### Why a child process / KD-tree SDF
- Some DrivAerStar binaries crash `vtkEnSightGoldBinaryReader` at the C level (uncatchable from Python) — hence per-case subprocess extraction.
- The exact VTK point-to-mesh distance was **~1092 s/case** on ~10M points; scipy `cKDTree` gives the same nearest-surface distance in **~1.3 s**, so the SDF (when enabled) uses the KD-tree.

### Usage
```bash
OCIFS_IAM_TYPE=api_key uv run python -m noether.data.datasets.cfd.drivaerstar.preprocessing \
    --source oci://emmi-drivaer-star@frwnorq7ern2 \
    --output oci://emmi-drivaer-star@frwnorq7ern2/zarr_store \
    --case-types E --workers 16          # add --sdf to also store volume_sdf
```

## Test plan
- [x] End-to-end on local `case_E` samples: 5/5 converted, full + subsampled reads via `ZarrChunkReader`, all fields finite and point-aligned, surface normals unit length, float16 range OK.
- [x] Default (no `--sdf`) run: store correctly **omits** `volume_sdf` and the reader returns only the present fields.
- [x] `ruff` + `mypy` clean.
- [ ] OCI streaming smoke test (fsspec download path) — pending.
- [ ] Full-dataset conversion.